### PR TITLE
Changed 'Archive' to 'Categories' in entry editor

### DIFF
--- a/admin/panels/entry/admin.entry.write.tpl
+++ b/admin/panels/entry/admin.entry.write.tpl
@@ -51,7 +51,7 @@
 		
 		{* end of inline form *}
 		
-		<fieldset id="admin-entry-categories"><legend>{$panelstrings.archive}</legend>
+		<fieldset id="admin-entry-categories"><legend>{$panelstrings.categories}</legend>
 			{list_categories type=form selected=$categories}
 		</fieldset>
 		

--- a/fp-interface/lang/en-us/lang.admin.entry.php
+++ b/fp-interface/lang/en-us/lang.admin.entry.php
@@ -43,7 +43,7 @@
 		'submit'	=> 'Publish',
 		'preview'	=> 'Preview',
 		'savecontinue'	=> 'Save&amp;Continue',
-		'archive'	=> 'Archive',
+		'categories'	=> 'Categories',
 		'nocategories'	=> 'No categories set. <a href="admin.php?p=entry&amp;action=cats">Create your own '. 
 					'categories</a> from the main entry panel. '.
 					'<a href="#save">Save</a> your entry first.',


### PR DESCRIPTION
Noticed that when editing an entry, the categories checkbox container's
name was 'Archive'. I modified the template and the lang file so that
it's 'Categories' from now on.

Before: 
![cats](https://f.cloud.github.com/assets/6784705/2300272/ed709f9e-a0e7-11e3-87c2-20e47db29464.png)
After:
![cats2](https://f.cloud.github.com/assets/6784705/2300273/efa85554-a0e7-11e3-8ee7-b28f6c1c93b0.png)
