### PR TITLE
Adding microdata to entry-default template

### DIFF
--- a/fp-interface/themes/leggero/entry-default.tpl
+++ b/fp-interface/themes/leggero/entry-default.tpl
@@ -1,26 +1,29 @@
-	<div id="{$id}" class="entry {$date|date_format:"y-%Y m-%m d-%d"}">
+	<div itemscope itemtype="http://schema.org/BlogPosting" id="{$id}" class="entry {$date|date_format:"y-%Y m-%m d-%d"}">
 				{* 	using the following way to print the date, if more 	*} 
 				{*	than one entry have been written the same day,		*} 
 				{*	 the date will be printed only once 				*}
 				
 		{$date|date_format_daily:"<h2 class=\"date\">`$fp_config.locale.dateformat`</h2>"}
 		
-				<h3>
+				<h3 itemprop="name">
 				<a href="{$id|link:post_link}">
 				{$subject|tag:the_title}
 				</a>
 				</h3>
 				{include file=shared:entryadminctrls.tpl}
 				
-				
+				<span itemprop="articleBody">
 				{$content|tag:the_content}
-			
+				</span>
 				
 				<ul class="entry-footer">
 			
-				<li class="entry-info">Posted by {$author} at
+				<li class="entry-info">Posted by <span itemprop="author">{$author}</span> at
 				{$date|date_format}
+
+				<span itemprop="articleSection">
 				{if ($categories)} in {$categories|@filed}{/if}
+				</span>
 				</li> 
 				
 				{if !(in_array('commslock', $categories) && !$comments)}


### PR DESCRIPTION
I integrated microdata in the entry-default template so that Google can create rich snippets for a blog entry. 

Reference and source: 
http://www.igorkromin.net/index.php/2013/02/27/adding-microdata-to-flatpress-themes-so-google-can-create-rich-snippets-for-a-blog-entry/
