### PR TITLE
small Bugfix: empty comment with backslash

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -68,11 +68,17 @@ add_filter('wp_title', 'comment_pagetitle', 10, 2);
 
 
 /**
- * @author Illevyard
+ * Fix for being able to comment an empty comment when typing a single backslash.</br>
+ * This function replaces every backslash '\' in the given string with an escaped backslash '\\'.</br>
+ * We need to escape the backslash here in PHP-Code aswell, so '\\' equals '\' and '\\\\' equals '\\'.</br>
+ * </br>
+ * If you want any previous backslash to be stripped from the string, just call this function with <code>$stripSlash = true</code>.</br>
  * 
  * @param string $string
  * @param boolean $escapeSlashes
  * @return string
+ * 
+ * @author Illevyard
  */
 function comment_backslashFix($string, $stripSlash) {
     if ($stripSlash == true) {

--- a/comments.php
+++ b/comments.php
@@ -100,7 +100,7 @@ function comment_validate() {
 	 */
 	
 	if (isset($_POST['content'])) {
-	    $content = comment_backslashFix($_POST['content'], true);
+	    $content = comment_backslashFix($_POST['content'], false);
 	}
 	
 	$errors = array();

--- a/comments.php
+++ b/comments.php
@@ -75,11 +75,10 @@ add_filter('wp_title', 'comment_pagetitle', 10, 2);
  * @return string
  */
 function comment_backslashFix($string, $stripSlash) {
-    $content = $string;
     if ($stripSlash == true) {
-       $content = stripslashes($content);
+        $string = stripslashes($string);
     }
-    $fixedContent = str_replace('\\', '\\\\', $content);
+    $fixedContent = str_replace('\\', '\\\\', $string);
     return $fixedContent;
 }
 

--- a/comments.php
+++ b/comments.php
@@ -74,9 +74,9 @@ add_filter('wp_title', 'comment_pagetitle', 10, 2);
  * @param boolean $escapeSlashes
  * @return string
  */
-function comment_backslashFix($string, $escapeSlashes) {
+function comment_backslashFix($string, $stripSlash) {
     $content = $string;
-    if ($escapeSlashes == true) {
+    if ($stripSlash == true) {
        $content = stripslashes($content);
     }
     $fixedContent = str_replace('\\', '\\\\', $content);


### PR DESCRIPTION
You are able to post empty comments by typing a single backslash into the formular.
That's not a big deal, but I think it shouldn't be like that.
I fixed this bug with an additional function `function comment_backslashFix($string, $stripSlash)`, which escapes every backslash in the given string `$string` so it can be displayed properly.

Here's an Example on how it works:

OLD:
`input: '\' → '\'`
`print-out: ' ' (empty string - something got escaped, but not what we wanted to)` 

FIXED
WITH "`$stripSlash= false`":
`input: '\' → '\\' `
`print-out: '\' (escaped backslash)`
`input: '\\' → '\\\\' `
`print-out: '\\' (two escaped backslashes)`

You can toggle `$stripSlash = true` if you want the backslashes to be stripped, but dont want to be able to post empty comments

FIXED  
WITH "`$stripSlash= true`":
`input: '\' → '' (Backslash got stripped)`
`print-out: "You must enter a comment"`
`input: '\\' → '\' `
`print-out: '\'`