### PR TITLE
Migrate from create_func to native anon func | #67

### DIFF
--- a/fp-includes/core/core.system.php
+++ b/fp-includes/core/core.system.php
@@ -216,8 +216,10 @@ function system_geterr($module = '') {
 /* delayed print */
 function system_dpr($action, $content) {
 	$p = print_r($content, 1);
-	$f = create_function('', "echo '<pre style=\'position:absolute\'>$p</pre>';");
-	add_action($action, $f);
+
+	add_action($action, function() use ($p) {
+		echo "<pre style='position:absolute'>$p</pre>";
+	});
 }
 
 ?>


### PR DESCRIPTION
Relating to issue #67, this just replaces a usage of `create_function()` with a native anonymous function.

`system_dpr()` doesn't seem to be called from anywhere _by default,_ but it may be useful when devs are debugging various things