### PR TITLE
solves issue #145

### DIFF
--- a/admin/panels/entry/admin.entry.write.tpl
+++ b/admin/panels/entry/admin.entry.write.tpl
@@ -41,6 +41,7 @@
 			id="content" rows="20" cols="74">{$content|default:{$smarty.request.content|default:''}|htmlspecialchars}</textarea><br />
 			{*here will go a plugin hook*}
 			{action hook=simple_edit_form}
+			{action hook=simple_metatag_info}
 
 			</p>
 		</div>

--- a/admin/panels/static/admin.static.write.tpl
+++ b/admin/panels/static/admin.static.write.tpl
@@ -40,6 +40,7 @@
 			<textarea name="content" class="{$class}" id="content" 
 			rows="20" cols="74">{$content|default:{$smarty.request.content|default:''}|htmlspecialchars}</textarea><br />
 		{*here will go a plugin hook*}
+		{action hook=simple_metatag_info}
 			</p>
 		
 		<fieldset id="admin-static-filename"><legend>{$panelstrings.fieldset2}</legend>

--- a/fp-plugins/seometataginfo/doc_seometataginfo.txt
+++ b/fp-plugins/seometataginfo/doc_seometataginfo.txt
@@ -1,0 +1,5 @@
+SEO-Metatag Plugin
+==================
+
+This plugin helps to better present your FlatPress posts and static pages on social media and make them more readable for search engine queries.
+Enter a suitable description and keywords for your created static page or post.

--- a/fp-plugins/seometataginfo/inc/class.iniparser.php
+++ b/fp-plugins/seometataginfo/inc/class.iniparser.php
@@ -1,0 +1,126 @@
+<?php
+/*
+ * Author: Enrico Reinsdorf (enrico@.re-design.de)
+ * Author URI: www.re-design.de
+ * Changelog: 	*Fixed* PHP 7.4 Methods with the same name as their class will not be constructors in a future version of PHP
+ * Change-Date: 12.10.2022
+ */
+
+// error_reporting(E_ALL);
+// error_reporting(-1);
+// ini_set('error_reporting', E_ALL);
+
+class iniParser {
+	
+	var $_iniFilename = '';
+	var $_iniParsedArray = array();
+	
+	/** 
+	*  erstellt einen mehrdimensionalen Array aus der INI-Datei
+	**/
+	function __construct($filename)
+	{
+		$this->_iniFilename = $filename;
+
+                $file_content = file($this->_iniFilename);
+                $this->_iniParsedArray = array();
+                $cur_sec = false;
+                foreach ($file_content as $line) {
+                    $line = trim($line);
+                    if (preg_match("/^\[.+\]$/",$line)) {
+                        $sec_name = str_replace(array("[", "]"), "", $line);
+                        // If this section already exists, ignore the line.
+                        if (! isset($this->_iniParsedArray[$sec_name])) {
+                            $this->_iniParsedArray [$sec_name] = array();
+                            $cur_sec = $sec_name;
+                        }
+                    } else {
+                        $line_arr = explode('=', $line, 2);
+                        // If the line doesn't match the var=value pattern, or if it's a
+                        // comment then add it without a key.
+                        if (isset($line_arr [1]) &&
+                            !(substr(trim($line_arr [0]), 0, 1) == '//' ||
+                                 substr(trim($line_arr [0]), 0, 1) == ';')) {
+                         $this->_iniParsedArray [$cur_sec] [$line_arr [0]] = $line_arr [1];
+                     } else {
+                         $this->_iniParsedArray [] = $line_arr [0];
+                     }
+	         }
+             }
+	}
+
+	/**
+	* gibt die komplette Sektion zurück
+	**/
+	function getSection($key)
+	{
+		return $this->_iniParsedArray [$key];
+	}
+
+	/**
+	*  gibt einen Wert aus einer Sektion zurück
+	**/
+	function getValue($section, $key)
+	{
+		if (!isset($this->_iniParsedArray [$section])) return false;
+		return $this->_iniParsedArray [$section] [$key];
+	}
+	
+	/**
+	*  gibt den Wert einer Sektion  oder die ganze Section zurück
+	**/
+	function get($section, $key=NULL)
+	{
+		if (is_null($key)) return $this->getSection($section);
+		return $this->getValue($section, $key);
+	}
+	
+	/**
+	* Seta um valor de acordo com a chave especificada
+	**/
+	function setSection($section, $array)
+	{
+		if (!is_array($array)) return false;
+		return $this->_iniParsedArray [$section] = $array;
+	}
+	
+	/**
+	* setzt einen neuen Wert in einer Section
+	**/
+	function setValue($section, $key, $value)
+	{
+		if ($this->_iniParsedArray [$section] [$key] = $value) return true;
+	}
+	
+	/**
+	* setzt einen neuen Wert in einer Section oder eine gesamte, neue Section
+	**/
+	function set($section, $key, $value=NULL)
+	{
+		if (is_array($key) && is_null($value)) return $this->setSection($section, $key);
+		return $this->setValue($section, $key, $value);
+	}
+	
+	/**
+	* sichert den gesamten Array in die INI-Datei
+	**/
+	function save($filename = null)
+	{
+		if ($filename == null) $filename = $this->_iniFilename;
+		if (is_writeable($filename)) {
+			$SFfdescriptor = fopen($filename, "w");
+			foreach($this->_iniParsedArray as $section => $array){
+				fwrite($SFfdescriptor, "[" . $section . "]\n");
+				foreach($array as $key => $value) {
+					fwrite($SFfdescriptor, "$key = $value\n");
+				}
+				fwrite($SFfdescriptor, "\n");
+			}
+			fclose($SFfdescriptor);
+			return true;
+		} else {
+			return false;
+		}
+	}
+}
+?>

--- a/fp-plugins/seometataginfo/inc/hw-helpers.php
+++ b/fp-plugins/seometataginfo/inc/hw-helpers.php
@@ -1,0 +1,229 @@
+<?php
+
+if (!function_exists('is_single')){
+	function is_single(){
+		global $fp_params;
+		return (!empty($fp_params ['entry']));
+	}
+}
+
+if (!function_exists('is_comments')){
+	function is_comments(){
+		global $fp_params;
+		return (isset($fp_params ['comments']));
+	}
+}
+
+if (!function_exists('is_static')){
+	function is_static(){
+		global $fp_params, $fp_config;
+		return (!empty($fp_params ['page']) ||
+				(empty($fp_params) && !empty($fp_config ['general'] ['startpage']))
+				);
+	}
+}
+
+if (!function_exists('is_static_home')){
+	function is_static_home(){
+		global $fp_params, $fp_config;
+		return (
+				(empty($fp_params ['page']) && empty($fp_params) && !empty($fp_config ['general'] ['startpage'])) ||
+				(!empty($fp_params ['page']) && !empty($fp_config ['general'] ['startpage']) &&
+					$fp_params ['page'] === $fp_config ['general'] ['startpage'])
+				);
+	}
+}
+
+if (!function_exists('is_blog_home')){
+	function is_blog_home(){
+		global $fp_params, $fp_config;
+		return (
+				(count(array_filter($fp_params)) === 1 && !empty($fp_params ['paged']) && $fp_params ['paged'] == 1) ||
+				(empty($fp_params) && empty($fp_config ['general'] ['startpage']))
+				);
+	}
+}
+
+if (!function_exists('is_blog_page')){
+	function is_blog_page(){
+		global $fp_params, $fp_config;
+		return (
+				(count(array_filter($fp_params)) === 1 && !empty($fp_params ['paged']) && $fp_params ['paged'] >= 1) ||
+				(empty($fp_params) && empty($fp_config ['general'] ['startpage']))
+				);
+	}
+}
+
+if (!function_exists('is_paging')){
+	function is_paging(){
+		global $fp_params;
+		return (!empty($fp_params ['paged']) && $fp_params ['paged'] >= 2);
+	}
+}
+
+if (!function_exists('is_category')){
+	function is_category(){
+		global $fp_params;
+		return (!empty($fp_params ['cat']) && !is_tag());
+	}
+}
+
+if (!function_exists('is_tag')){
+	function is_tag(){
+		global $fp_params;
+		return (!empty($fp_params ['tag']));
+	}
+}
+
+if (!function_exists('is_feed')){
+	function is_feed(){
+		global $fp_params;
+		return (!empty($fp_params ['feed']));
+	}
+}
+
+if (!function_exists('is_search')){
+	function is_search(){
+		global $fp_params;
+		return (!empty($_GET ['q']));
+	}
+}
+
+if (!function_exists('is_contact')){
+	function is_contact(){
+		global $smarty;
+		return (
+				(!empty($smarty->_tpl_vars ['SCRIPT_NAME']) &&	// check if contact form
+					strpos($smarty->_tpl_vars ['SCRIPT_NAME'], 'contact.php'))
+				);
+	}
+}
+
+if (!function_exists('is_archive')){
+	function is_archive(){
+		global $fp_params;
+		return (!is_single() && !is_static() && !is_category() && !is_tag() &&
+			(!empty($fp_params ['y']) || !empty($fp_params ['m']) || !empty($fp_params ['d'])));
+	}
+}
+
+if (!function_exists('is_archive_year')){
+	function is_archive_year(){
+		global $fp_params;
+		return (is_archive() && 
+					(!empty($fp_params ['y']) && 
+						(empty($fp_params ['m']) && empty($fp_params ['d']))
+					)
+				);
+	}
+}
+if (!function_exists('is_archive_month')){
+	function is_archive_month(){
+		global $fp_params;
+		return (is_archive() && 
+					(
+						(!empty($fp_params ['y']) && !empty($fp_params ['m'])) &&
+							empty($fp_params ['d'])
+					)
+				);
+	}
+}
+if (!function_exists('is_archive_day')){
+	function is_archive_day(){
+		global $fp_params;
+		return (is_archive() && 
+			(!empty($fp_params ['y']) && !empty($fp_params ['m']) && !empty($fp_params ['d'])));
+	}
+}
+
+if (!function_exists('get_category_name')){
+	function get_category_name($catid){
+		$category_names = entry_categories_get('defs');
+		return (!empty($category_names [$catid]) ?$category_names [$catid]:"");
+	}
+}
+
+if (!function_exists('pathinfo_filename')){
+	function pathinfo_filename($file) { //file.name.ext, returns file.name
+		if (defined('PATHINFO_FILENAME')) return pathinfo($file,PATHINFO_FILENAME);
+		if (strstr($file, '.')) return substr($file,0,strrpos($file,'.'));
+	}
+}
+
+if (!function_exists('currentPageURL')){
+    function currentPageURL() {
+    $curpageURL = 'http';
+    if ($_SERVER ["HTTPS"] == "on") {$curpageURL.= "s";}
+        $curpageURL .= "://";
+        if ($_SERVER ["SERVER_PORT"] != "80") {
+            // $curpageURL.= $_SERVER["SERVER_NAME"].":".$_SERVER["SERVER_PORT"].$_SERVER["REQUEST_URI"];
+            $curpageURL .= $_SERVER ["SERVER_NAME"] . $_SERVER ["REQUEST_URI"];
+        } else {
+            $curpageURL .= $_SERVER ["SERVER_NAME"] . $_SERVER ["REQUEST_URI"];
+        }
+        return $curpageURL;
+    }
+}
+
+// removes files and non-empty directories
+if (!function_exists('rrmdir')){
+	function rrmdir($dir) {
+	  if (is_dir($dir)) {
+		$files = scandir($dir);
+		foreach ($files as $file)
+		if ($file != "." && $file != "..") rrmdir("$dir/$file");
+		rmdir($dir);
+	  }
+	  else if (file_exists($dir)) unlink($dir);
+	}
+}
+	// copies files and non-empty directories
+if (!function_exists('rcopy')){
+	function rcopy($src, $dst) {
+	  if (file_exists($dst)) rrmdir($dst);
+	  if (is_dir($src)) {
+		mkdir($dst);
+		$files = scandir($src);
+		foreach ($files as $file)
+		if ($file != "." && $file != "..")
+			rcopy("$src/$file", "$dst/$file");
+	  }
+	  else if (file_exists($src)) copy($src, $dst);
+	}
+}
+
+function is_empty_dir($dir){
+    if ($dh = @opendir($dir))
+    {
+        while ($file = readdir($dh))
+        {
+            if ($file != '.' && $file != '..') {
+                closedir($dh);
+                return false;
+            }
+        }
+        closedir($dh);
+        return true;
+    }
+    else return false; // whatever the reason is : no such dir, not a dir, not readable
+}
+
+// debug
+if (!function_exists('echoPre')){
+	function echoPre($value, $print=true){  
+			$output = '';
+			if ($value){
+					$output .= "<pre>";
+					$output .= print_r($value, true);
+					$output .= "</pre><br>";
+					if ($print)
+							echo $output;
+					else
+							return $output;
+			}
+			return false;
+	}
+}
+
+?>
+

--- a/fp-plugins/seometataginfo/inc/migrate_data.php
+++ b/fp-plugins/seometataginfo/inc/migrate_data.php
@@ -1,0 +1,117 @@
+<?php
+
+function migrate_old(){
+
+	function create_defaults(){
+		global $fp_config;
+		
+		if (!file_exists(SEOMETA_DEFAULT_DIR . 'metatags.ini')){
+			$metatags = "[meta]\n";
+			$metatags .= "description=\n";
+			$metatags .= "keywords=\n";
+			$metatags .= "noindex=0\n";
+			$metatags .= "nofollow=0\n";
+			$metatags .= "noarchive=0\n";
+			$metatags .= "nosnippet=0\n";
+			@io_write_file(SEOMETA_DEFAULT_DIR . 'metatags.ini',$metatags);
+		}
+
+		if (!file_exists(SEOMETA_STATIC_DIR.'blog_metatags.ini')){
+			$metatags = "[meta]\n";
+			$metatags .= "description=" . $fp_config ['general'] ['subtitle'] . "\n";
+			$metatags .= "keywords=blog\n";
+			$metatags .= "noindex=0\n";
+			$metatags .= "nofollow=0\n";
+			$metatags .= "noarchive=0\n";
+			$metatags .= "nosnippet=0\n";
+			@io_write_file(SEOMETA_STATIC_DIR . 'blog_metatags.ini',$metatags);
+		}
+		
+		if (!file_exists(SEOMETA_STATIC_DIR . 'contact_metatags.ini')){
+			$lang = lang_load('contact');
+			$metatags = "[meta]\n";
+			$metatags .= "description=" . $lang ['contact'] ['head'] . "\n";
+			$metatags .= "keywords="  .$lang ['contact'] ['head'] . "\n";
+			$metatags .= "noindex=0\n";
+			$metatags .= "nofollow=0\n";
+			$metatags .= "noarchive=0\n";
+			$metatags .= "nosnippet=0\n";
+			@io_write_file(SEOMETA_STATIC_DIR . 'contact_metatags.ini',$metatags);
+		}
+	}
+
+	function rmigrate_entries($cur){
+		if (is_dir($cur)){
+			$files = scandir($cur);
+			foreach ($files as $file){
+				if ($file != '.' && $file != '..' ){
+					if (is_dir("$cur/$file")){
+						rmigrate_entries("$cur/$file");
+					}
+					if ($file == 'metatags.ini'){
+						$pi = pathinfo_filename($cur);
+						$src = "$cur/$file";
+						$dst = SEOMETA_ENTRY_DIR . $pi . "_metatags.ini";
+						if (file_exists($src) && !file_exists($dst)){
+							echoPre($src . "\n" . $dst);
+							copy($src, $dst);
+							if (file_exists($dst))
+								unlink($src);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// entries
+	@io_write_file(SEOMETA_ENTRY_DIR.'dummy','');
+	for ($i = 05; $i < 20; $i++){
+		$cur = CONTENT_DIR.$i;
+		rmigrate_entries($cur);
+	}
+	$cur = CONTENT_DIR.'drafts';
+	rmigrate_entries($cur);
+
+	// statics
+	@io_write_file(SEOMETA_STATIC_DIR.'dummy','');
+	$cur = CONTENT_DIR . "static-meta";
+	if (is_dir($cur)){
+		$files = scandir($cur);
+		foreach ($files as $file){
+			if ($file != '.' && $file != '..' && is_file("$cur/$file")){
+				$src = "$cur/$file";
+				$dst = SEOMETA_STATIC_DIR . $file;
+				if (file_exists($src) && !file_exists($dst)){
+					$r = copy($src, $dst);
+					if (file_exists($dst))
+						unlink($src);
+				}
+			}
+		}
+		if (is_empty_dir($cur))
+			rrmdir($cur);
+	}
+	// categories
+	@io_write_file(SEOMETA_CATEGORY_DIR . 'dummy','');
+	$cur = CONTENT_DIR . "cat-meta";
+	if (is_dir($cur)){
+		$files = scandir($cur);
+		foreach ($files as $file){
+			if ($file != '.' && $file != '..' && is_file("$cur/$file")){
+				$src = "$cur/$file";
+				$dst = SEOMETA_CATEGORY_DIR.$file;
+				if (file_exists($src) && !file_exists($dst)){
+					copy($src, $dst);
+					if (file_exists($dst))
+						unlink($src);
+				}
+			}
+		}
+		if (is_empty_dir($cur))
+			rrmdir($cur);
+	}
+	
+	create_defaults();
+}
+?>

--- a/fp-plugins/seometataginfo/lang/lang.cs-cz.php
+++ b/fp-plugins/seometataginfo/lang/lang.cs-cz.php
@@ -1,0 +1,29 @@
+<?php
+
+$lang ['admin'] ['plugin'] ['seometataginfo'] = array (
+	'legend_desc'		=> 'Popis a klíčová slova',
+	'description'		=> 'Tyto údaje usnadňují jejich nalezení pomocí vyhledávačů a zveřejnění na sociálních sítích. <a href="https://en.wikipedia.org/wiki/Meta_element" title="Wikipedia" target="_blank">Wikipedia</a>',
+	'input_desc'		=> 'Vložte popis:',
+	'sample_desc'		=> 'FlatPress související články, průvodci a pluginy',
+	'input_keywords'	=> 'Vložte klíčová slova:',
+	'sample_keywords'	=> 'flatpress, flatpress články, flatpress průvodci, flatpress pluginy',
+	'input_noindex'		=> 'Zakázat indexování:',
+	'input_nofollow'	=> 'Zakázat sledování:',
+	'input_noarchive'	=> 'Zakázat archivaci:',
+	'input_nosnippet'	=> 'Zakázat úryvky:',
+);
+
+$lang ['plugin'] ['seometataginfo'] = array (
+	'sep'		=> ' - ',
+	'home'		=> 'Home',
+	'blog_home' => 'Blog Domů',
+	'blog_page' => 'Blog',
+	'archive'	=> 'Archiv',
+	'category'	=> 'Kategorie',
+	'tag'		=> 'Tag',
+	'contact'	=> 'Kontaktujte nás',
+	'comments'	=> 'Komentáře',
+	'pagenum'	=> 'Stránka #',
+);
+
+?>

--- a/fp-plugins/seometataginfo/lang/lang.de-de.php
+++ b/fp-plugins/seometataginfo/lang/lang.de-de.php
@@ -1,0 +1,29 @@
+<?php
+
+$lang ['admin'] ['plugin'] ['seometataginfo'] = array (
+	'legend_desc'		=> 'Beschreibung und Schlüsselwörter',
+	'description'		=> 'Diese Angaben erleichtern das Auffinden mit Suchmaschinen und das Einfügen in sozialen Medien. <a href="https://de.wikipedia.org/wiki/Meta-Element" title="Wikipedia" target="_blank">Wikipedia</a>',
+	'input_desc'		=> 'Gebe die Beschreibung ein:',
+	'sample_desc'		=> 'FlatPress-bezogene Artikel, Anleitungen und Plugins',
+	'input_keywords'	=> 'Füge die Schlüsselwörter ein:',
+	'sample_keywords'	=> 'flatpress, flatpress artikel, flatpress anleitungen, flatpress plugins',
+	'input_noindex'		=> 'Indizieren verbieten:',
+	'input_nofollow'	=> 'Link-Following verbieten:',
+	'input_noarchive'	=> 'Archivierung verbieten:',
+	'input_nosnippet'	=> 'Ausschnitte verbieten:',
+);
+
+$lang ['plugin'] ['seometataginfo'] = array (
+	'sep'		=> ' - ',
+	'home'		=> 'Startseite',
+	'blog_home' => 'Startseite des Blogs',
+	'blog_page' => 'Blog',
+	'archive'	=> 'Archiv',
+	'category'	=> 'Kategorie',
+	'tag'		=> 'Tag',
+	'contact'	=> 'Kontakt',
+	'comments'	=> 'Kommentare',
+	'pagenum'	=> 'Seite #',
+);
+
+?>

--- a/fp-plugins/seometataginfo/lang/lang.el-gr.php
+++ b/fp-plugins/seometataginfo/lang/lang.el-gr.php
@@ -1,0 +1,29 @@
+<?php
+
+$lang ['admin'] ['plugin'] ['seometataginfo'] = array (
+	'legend_desc'		=> 'Περιγραφή και λέξεις-κλειδιά',
+	'description'		=> 'Αυτά τα στοιχεία διευκολύνουν την εύρεσή τους από τις μηχανές αναζήτησης και την ανάρτησή τους στα μέσα κοινωνικής δικτύωσης. <a href="https://en.wikipedia.org/wiki/Meta_element" title="Wikipedia" target="_blank">Wikipedia</a>',
+	'input_desc'		=> 'Εισάγετε την περιγραφή:',
+	'sample_desc'		=> 'FlatPress σχετικά άρθρα, οδηγοί και plugins',
+	'input_keywords'	=> 'Εισάγετε τις λέξεις-κλειδιά:',
+	'sample_keywords'	=> 'flatpress, flatpress άρθρα, flatpress οδηγοί, flatpress πρόσθετα',
+	'input_noindex'		=> 'Απαγόρευση ευρετηρίασης:',
+	'input_nofollow'	=> 'Απαγόρευση της παρακολούθησης:',
+	'input_noarchive'	=> 'Απαγόρευση αρχειοθέτησης:',
+	'input_nosnippet'	=> 'Απαγόρευση αποσπασμάτων:',
+);
+
+$lang ['plugin'] ['seometataginfo'] = array (
+	'sep'		=> ' - ',
+	'home'		=> 'Αρχική σελίδα',
+	'blog_home' => 'Blog Αρχική σελίδα',
+	'blog_page' => 'Blog',
+	'archive'	=> 'Αρχείο',
+	'category'	=> 'Κατηγορία',
+	'tag'		=> 'Tag',
+	'contact'	=> 'Επικοινωνήστε μαζί μας',
+	'comments'	=> 'Σχόλια',
+	'pagenum'	=> 'Σελίδα #',
+);
+
+?>

--- a/fp-plugins/seometataginfo/lang/lang.en-us.php
+++ b/fp-plugins/seometataginfo/lang/lang.en-us.php
@@ -1,0 +1,29 @@
+<?php
+
+$lang ['admin'] ['plugin'] ['seometataginfo'] = array (
+	'legend_desc'		=> 'Description and keywords',
+	'description'		=> 'These details make it easier to find them with search engines and to post them on social media. <a href="https://en.wikipedia.org/wiki/Meta_element" title="Wikipedia" target="_blank">Wikipedia</a>',
+	'input_desc'		=> 'Insert the description:',
+	'sample_desc'		=> 'FlatPress related articles, guides and plugins',
+	'input_keywords'	=> 'Insert the keywords:',
+	'sample_keywords'	=> 'flatpress, flatpress articles, flatpress guides, flatpress plugins',
+	'input_noindex'		=> 'Disallow Indexing:',
+	'input_nofollow'	=> 'Disallow Following:',
+	'input_noarchive'	=> 'Disallow Archiving:',
+	'input_nosnippet'	=> 'Disallow snippets:',
+);
+
+$lang ['plugin'] ['seometataginfo'] = array (
+	'sep'		=> ' - ',
+	'home'		=> 'Home',
+	'blog_home' => 'Blog Home',
+	'blog_page' => 'Blog',
+	'archive'	=> 'Archive',
+	'category'	=> 'Category',
+	'tag'		=> 'Tag',
+	'contact'	=> 'Contact Us',
+	'comments'	=> 'Comments',
+	'pagenum'	=> 'Page #',
+);
+
+?>

--- a/fp-plugins/seometataginfo/lang/lang.es-es.php
+++ b/fp-plugins/seometataginfo/lang/lang.es-es.php
@@ -1,0 +1,29 @@
+<?php
+
+$lang ['admin'] ['plugin'] ['seometataginfo'] = array (
+	'legend_desc'		=> 'Descripción y palabras clave',
+	'description'		=> 'Estos datos facilitan su búsqueda en los motores de búsqueda y su publicación en las redes sociales. <a href="https://es.wikipedia.org/wiki/Etiqueta_meta" title="Wikipedia" target="_blank">Wikipedia</a>',
+	'input_desc'		=> 'Introduzca la descripción:',
+	'sample_desc'		=> 'FlatPress artículos relacionados, guías y plugins',
+	'input_keywords'	=> 'Introduzca las palabras clave:',
+	'sample_keywords'	=> 'flatpress, flatpress artículos, flatpress guías, flatpress plugins',
+	'input_noindex'		=> 'No permitir la indexación:',
+	'input_nofollow'	=> 'No permitir lo siguiente:',
+	'input_noarchive'	=> 'No permitir el archivo:',
+	'input_nosnippet'	=> 'No permitir fragmentos:',
+);
+
+$lang ['plugin'] ['seometataginfo'] = array (
+	'sep'		=> ' - ',
+	'home'		=> 'Inicio',
+	'blog_home' => 'Blog Inicio',
+	'blog_page' => 'Blog',
+	'archive'	=> 'Archivo',
+	'category'	=> 'Categoría',
+	'tag'		=> 'Tag',
+	'contact'	=> 'Contacte con nosotros',
+	'comments'	=> 'Comentarios',
+	'pagenum'	=> 'Página #',
+);
+
+?>

--- a/fp-plugins/seometataginfo/lang/lang.fr-fr.php
+++ b/fp-plugins/seometataginfo/lang/lang.fr-fr.php
@@ -1,0 +1,29 @@
+<?php
+
+$lang ['admin'] ['plugin'] ['seometataginfo'] = array (
+	'legend_desc'		=> 'Description et mots-clés Descripción y palabras clave',
+	'description'		=> 'Ces détails permettent de les retrouver plus facilement avec les moteurs de recherche et de les afficher sur les médias sociaux. <a href="https://fr.wikipedia.org/wiki/Élément_meta" title="Wikipedia" target="_blank">Wikipedia</a>',
+	'input_desc'		=> 'Insérez la description :',
+	'sample_desc'		=> 'Articles, guides et plugins relatifs à FlatPress',
+	'input_keywords'	=> 'Insérez les mots-clés :',
+	'sample_keywords'	=> 'flatpress, flatpress articles, flatpress guides, flatpress plugins',
+	'input_noindex'		=> 'Désactiver l\'indexation :',
+	'input_nofollow'	=> 'Désactiver suivant :',
+	'input_noarchive'	=> 'Désactiver l\'archivage :',
+	'input_nosnippet'	=> 'Désactiver les snippets :',
+);
+
+$lang ['plugin'] ['seometataginfo'] = array (
+	'sep'		=> ' - ',
+	'home'		=> 'Accueil',
+	'blog_home' => 'Accueil du blog',
+	'blog_page' => 'Blog',
+	'archive'	=> 'Archives',
+	'category'	=> 'Catégorie',
+	'tag'		=> 'Tag',
+	'contact'	=> 'Nous contacter',
+	'comments'	=> 'Commentaires',
+	'pagenum'	=> 'Page #',
+);
+
+?>

--- a/fp-plugins/seometataginfo/lang/lang.it-it.php
+++ b/fp-plugins/seometataginfo/lang/lang.it-it.php
@@ -1,0 +1,29 @@
+<?php
+
+$lang ['admin'] ['plugin'] ['seometataginfo'] = array (
+	'legend_desc'		=> 'Descrizione e parole chiave',
+	'description'		=> 'Questi dettagli rendono più facile trovarli con i motori di ricerca e pubblicarli sui social media. <a href="https://it.wikipedia.org/wiki/Meta_tag" title="Wikipedia" target="_blank">Wikipedia</a>',
+	'input_desc'		=> 'Inserire la descrizione:',
+	'sample_desc'		=> 'Articoli, guide e plugin correlati a FlatPress',
+	'input_keywords'	=> 'Inserire le parole chiave:',
+	'sample_keywords'	=> 'flatpress, articoli flatpress, guide flatpress, plugin flatpress',
+	'input_noindex'		=> 'Disconoscimento dell\'indicizzazione:',
+	'input_nofollow'	=> 'Disconoscimento di quanto segue:',
+	'input_noarchive'	=> 'Disconoscimento dell\'archiviazione:',
+	'input_nosnippet'	=> 'Disconoscimento degli snippet:',
+);
+
+$lang ['plugin'] ['seometataginfo'] = array (
+	'sep'		=> ' - ',
+	'home'		=> 'Casa',
+	'blog_home' => 'Casa del blog',
+	'blog_page' => 'Blog',
+	'archive'	=> 'Archivio',
+	'category'	=> 'Categoria',
+	'tag'		=> 'Tag',
+	'contact'	=> 'Contatto',
+	'comments'	=> 'Commenti',
+	'pagenum'	=> 'Pagina #',
+);
+
+?>

--- a/fp-plugins/seometataginfo/lang/lang.ja-jp.php
+++ b/fp-plugins/seometataginfo/lang/lang.ja-jp.php
@@ -1,0 +1,29 @@
+<?php
+
+$lang ['admin'] ['plugin'] ['seometataginfo'] = array (
+	'legend_desc'		=> '説明とキーワード',
+	'description'		=> 'これらの詳細な情報は、検索エンジンで見つけやすく、ソーシャルメディアに投稿しやすくなっています。 <a href="https://en.wikipedia.org/wiki/Meta_element" title="Wikipedia" target="_blank">Wikipedia</a>',
+	'input_desc'		=> '説明を挿入します。',
+	'sample_desc'		=> 'FlatPress 関連記事, ガイドとプラグイン',
+	'input_keywords'	=> 'キーワードを挿入します。',
+	'sample_keywords'	=> 'flatpress, flatpress 物品, flatpress ガイド, flatpress プラグイン',
+	'input_noindex'		=> 'インデックスを禁止する。',
+	'input_nofollow'	=> 'フォローを拒否する。',
+	'input_noarchive'	=> 'アーカイブを禁止する。',
+	'input_nosnippet'	=> 'スニペットを禁止する。',
+);
+
+$lang ['plugin'] ['seometataginfo'] = array (
+	'sep'		=> ' - ',
+	'home'		=> 'ホーム',
+	'blog_home' => 'ブログホーム',
+	'blog_page' => 'ブログ',
+	'archive'	=> 'アーカイブ',
+	'category'	=> 'カテゴリー',
+	'tag'		=> 'Tag',
+	'contact'	=> 'お問い合わせ',
+	'comments'	=> 'コメント',
+	'pagenum'	=> 'ページ #',
+);
+
+?>

--- a/fp-plugins/seometataginfo/lang/lang.nl-nl.php
+++ b/fp-plugins/seometataginfo/lang/lang.nl-nl.php
@@ -1,0 +1,29 @@
+<?php
+
+$lang ['admin'] ['plugin'] ['seometataginfo'] = array (
+	'legend_desc'		=> 'Beschrijving en trefwoorden',
+	'description'		=> 'Deze gegevens maken het gemakkelijker om ze te vinden met zoekmachines en om ze op sociale media te plaatsen. <a href="https://nl.wikipedia.org/wiki/Metatag" title="Wikipedia" target="_blank">Wikipedia</a>',
+	'input_desc'		=> 'Voeg de beschrijving in:',
+	'sample_desc'		=> 'FlatPress-gerelateerde artikelen, gidsen en plugins',
+	'input_keywords'	=> 'Voeg de sleutelwoorden in:',
+	'sample_keywords'	=> 'flatpress, flatpress artikelen, flatpress gidsen, flatpress plugins',
+	'input_noindex'		=> 'Indexering weigeren:',
+	'input_nofollow'	=> 'Verbied volgen:',
+	'input_noarchive'	=> 'Archivering niet toestaan:',
+	'input_nosnippet'	=> 'Snippets niet toestaan:',
+);
+
+$lang ['plugin'] ['seometataginfo'] = array (
+	'sep'		=> ' - ',
+	'home'		=> 'Home',
+	'blog_home' => 'Blog Home',
+	'blog_page' => 'Blog',
+	'archive'	=> 'Archief',
+	'category'	=> 'Categorie',
+	'tag'		=> 'Tag',
+	'contact'	=> 'Contacteer ons',
+	'comments'	=> 'Commentaar',
+	'pagenum'	=> 'Pagina #',
+);
+
+?>

--- a/fp-plugins/seometataginfo/plugin.seometataginfo.php
+++ b/fp-plugins/seometataginfo/plugin.seometataginfo.php
@@ -1,0 +1,522 @@
+<?php
+/*
+ * Plugin Name: SEO Meta Tag Info
+ * Version: 2.2.3
+ * Plugin URI: https://www.flatpress.org
+ * Description: This plugin allows editing of SEO meta tags description, keywords and robots for Entries, Statics and Categories. Part of the standard distribution. <a href="./fp-plugins/seometataginfo/doc_seometataginfo.txt" title="Anleitung" target="_blank">[Instructions]</a>
+ * Author: FlatPress
+ * Author URI: https://www.flatpress.org
+ */
+
+// SEE 'readme.txt' for information
+require ("inc/hw-helpers.php");
+require ("inc/class.iniparser.php");
+require ("inc/migrate_data.php");
+
+global $keep_char;
+global $seo_default;
+global $prepend_description;
+global $prepend_keywords;
+
+// IMPORTANT: For non LATIN-1 countries
+// ADD additional characters that you want to allow in your meta tags here
+$keep_char = "ășțîâÄäÜüÖößſ£¢ÆæëïŒœËÏÁáÉéÍíÓóÚúĲĳÅåØøÀàÂÈèÉéÊêÎïÔôÙùÛûÇçÿŸÌìÒò¡¿ªºÑñÃãÕõŠšŽžČčĎďĚěŇňŘřŤťŮůŐőŰűĞğİıŞş";
+
+$seo_default = array(
+	'description' => '', // the page description
+	'keywords' => '', // keywords comma seperated e.g. "a,c d,c"
+	'noindex' => '0', // "0" or "1"
+	'nofollow' => '0', // "0" or "1"
+	'noarchive' => '0', // "0" or "1"
+	'nosnippet' => '0' // "0" or "1"
+);
+
+// prepend the blog title to description and keywords
+global $fp_config;
+$prepend_description = $fp_config ['general'] ['title'] . ' - ';
+$prepend_keywords = $fp_config ['general'] ['title'] . ', ';
+
+// IMPORTANT: migrate data from previous version
+// Note: If a metatags.ini exists for both
+// an published entry and a draft entry
+// the published entry version will be kept.
+// set 'SEOMETA_MIGRATE_DATA' to 'true' then
+// create a new entry to force data migration.
+define('SEOMETA_MIGRATE_DATA', false);
+
+// generate pretty titles e.g.
+// 'Blog Title - Archive - 2011/06' or
+// 'Blog Title - Category - Something Cool'
+define('SEOMETA_GEN_TITLE', true);
+
+// generate <meta name='title'.. true/false
+define('SEOMETA_GEN_TITLE_META', true);
+
+// generate <link rel="canonical".. true/false
+define('SEOMETA_GEN_CANONICAL', true);
+
+// force comments to point at page (canonical)
+// e.g.
+// /yy/mm/dd/mypage/comments/ => /yy/mm/dd/mypage/
+// /yy/mm/dd/mypage/comments/#comments => /yy/mm/dd/mypage/
+define('SEOMETA_HIDECOMMENTS', true);
+
+// define storage
+define('SEOMETA_DIR', CONTENT_DIR . 'seometa/');
+define('SEOMETA_DEFAULT_DIR', SEOMETA_DIR . 'default/');
+define('SEOMETA_ENTRY_DIR', SEOMETA_DIR . 'entries/');
+define('SEOMETA_STATIC_DIR', SEOMETA_DIR . 'statics/');
+define('SEOMETA_CATEGORY_DIR', SEOMETA_DIR . 'categories/');
+define('SEOMETA_TAG_DIR', SEOMETA_DIR . 'tags/');
+define('SEOMETA_ARCHIVE_DIR', SEOMETA_DIR . 'archives/');
+
+/**
+ * This part of the plugin has to interface with
+ * the entry admin panel.
+ *
+ * It saves the meta data of entries/pages.
+ */
+if (version_compare(SYSTEM_VER, '0.1010', '>=') == 1 && defined('MOD_ADMIN_PANEL')) {
+
+	/**
+	 * plugin_description_entry class
+	 *
+	 * This class is used to interface the seo meta tag
+	 * with the entry editor.
+	 */
+	class plugin_seometatags_entry {
+
+		/**
+		 * "simple" function
+		 *
+		 * This function adds the Description field to editor
+		 */
+		function simple() {
+			if (!file_exists(SEOMETA_DEFAULT_DIR . 'metatags.ini')) {
+				$metatags = "[meta]\n";
+				$metatags .= "description=\n";
+				$metatags .= "keywords=\n";
+				$metatags .= "noindex=0\n";
+				$metatags .= "nofollow=0\n";
+				$metatags .= "noarchive=0\n";
+				$metatags .= "nosnippet=0\n";
+				@io_write_file(SEOMETA_DEFAULT_DIR . 'metatags.ini', $metatags);
+			}
+
+			if ((isset($_REQUEST ['entry']) && empty($_REQUEST ['entry'])) && (isset($_REQUEST ['timestamp']) && !empty($_REQUEST ['timestamp']))) {
+				$id = bdb_idfromtime(BDB_ENTRY, $_REQUEST ['timestamp']);
+				$file_meta = SEOMETA_ENTRY_DIR . $id . '_metatags.ini';
+			} elseif (!empty($_REQUEST ['entry'])) {
+				$id = $_REQUEST ['entry'];
+				$file_meta = SEOMETA_ENTRY_DIR . $id . '_metatags.ini';
+			} elseif (!empty($_REQUEST ['page'])) {
+				$id = $_REQUEST ['page'];
+				$file_meta = SEOMETA_STATIC_DIR . $id . '_metatags.ini';
+			} elseif (isset($_REQUEST ['p'])) {
+				// new blog entry or static page
+				$file_meta = SEOMETA_DEFAULT_DIR . 'metatags.ini';
+			} else {
+				$file_meta = SEOMETA_DEFAULT_DIR . 'metatags.ini';
+			}
+
+			if (!empty($file_meta) && !file_exists($file_meta))
+				@io_write_file($file_meta, '');
+
+			$cfg = new iniParser($file_meta);
+			$old_desc = $cfg->get("meta", "description") != false ? wp_specialchars(trim($cfg->get("meta", "description"))) : (!empty($_REQUEST ['pl_description']) ? $_REQUEST ['pl_description'] : '');
+			$old_keywords = $cfg->get("meta", "keywords") != false ? wp_specialchars(trim($cfg->get("meta", "keywords"))) : (!empty($_REQUEST ['pl_keywords']) ? $_REQUEST ['pl_keywords'] : '');
+			$old_noindex = $cfg->get("meta", "noindex") != false ? wp_specialchars(trim($cfg->get("meta", "noindex"))) : (!empty($_REQUEST ['pl_noindex']) ? $_REQUEST ['pl_noindex'] : '0');
+			$old_nofollow = $cfg->get("meta", "nofollow") != false ? wp_specialchars(trim($cfg->get("meta", "nofollow"))) : (!empty($_REQUEST ['pl_nofollow']) ? $_REQUEST ['pl_nofollow'] : '0');
+			$old_noarchive = $cfg->get("meta", "noarchive") != false ? wp_specialchars(trim($cfg->get("meta", "noarchive"))) : (!empty($_REQUEST ['pl_noarchive']) ? $_REQUEST ['pl_noarchive'] : '0');
+			$old_nosnippet = $cfg->get("meta", "nosnippet") != false ? wp_specialchars(trim($cfg->get("meta", "nosnippet"))) : (!empty($_REQUEST ['pl_nosnippet']) ? $_REQUEST ['pl_nosnippet'] : '0');
+
+			$lang = lang_load('plugin:seometataginfo');
+			$string = $lang ['admin'] ['plugin'] ['seometataginfo'];
+
+			echo "\n<fieldset id=\"plugin_seometataginfo\">\n";
+			echo " <legend>{$string['legend_desc']}</legend>\n";
+			echo "  <p>{$string['description']}</p>\n";
+			echo "  <p>\n";
+			echo '    <input id="pl_file_meta" type="hidden" name="pl_file_meta" value="' . $file_meta . '">' . "\n";
+			echo "    <p><label for=\"pl_description\">{$string['input_desc']}</label>\n";
+			echo '       <input placeholder="' . $lang ['admin'] ['plugin'] ['seometataginfo'] ['sample_desc'] . '" class="maxsize" id="pl_description" type="text" name="pl_description" value="' . $old_desc . '"></p>' . "\n";
+			echo "    <p><label for=\"pl_keywords\">{$string['input_keywords']}</label>\n";
+			echo '       <input placeholder="' . $lang ['admin'] ['plugin'] ['seometataginfo'] ['sample_keywords'] . '" class="maxsize" id="pl_keywords" type="text" name="pl_keywords" value="' . $old_keywords . '"></p>' . "\n";
+			echo "    <p><br>\n";
+			$checked = ($old_noindex === "1") ? ' checked="yes"' : '';
+			echo "    <label for=\"pl_noindex\">{$string['input_noindex']}</label>\n";
+			echo '       <input style="vertical-align: middle; margin: 0px 10px 0px 0px; cursor: pointer;" id="pl_noindex" type="checkbox"' . $checked . ' name="pl_noindex" value="1"' . '>';
+			$checked = ($old_nofollow === "1") ? ' checked="yes"' : '';
+			echo "    <label for=\"pl_nofollow\">{$string['input_nofollow']}</label>\n";
+			echo '       <input style="vertical-align: middle; margin: 0px 10px 0px 0px; cursor: pointer;" id="pl_nofollow" type="checkbox"' . $checked . ' name="pl_nofollow" value="1"' . '>';
+			$checked = ($old_noarchive === "1") ? ' checked="yes"' : '';
+			echo "    <label for=\"pl_noarchive\">{$string['input_noarchive']}</label>\n";
+			echo '       <input style="vertical-align: middle; margin: 0px 10px 0px 0px; cursor: pointer;" id="pl_noarchive" type="checkbox"' . $checked . ' name="pl_noarchive" value="1"' . '>';
+			$checked = ($old_nosnippet === "1") ? ' checked="yes"' : '';
+			echo "    <label for=\"pl_nosnippet\">{$string['input_nosnippet']}</label>\n";
+			echo '       <input style="vertical-align: middle; margin: 0px 10px 0px 0px; cursor: pointer;" id="pl_nosnippet" type="checkbox"' . $checked . ' name="pl_nosnippet" value="1"' . '>';
+			echo '    </p>' . "\n";
+			echo "  </p>\n";
+			echo "</fieldset>\n";
+
+			return true;
+		}
+
+		function do_save() {
+			if (empty($_POST ['pl_file_meta']))
+				return;
+			global $keep_char;
+			$metatags = "description=" . (isset($_POST ['pl_description']) ? trim($_POST ['pl_description']) : "") . "\n";
+			$metatags .= "keywords=" . (isset($_POST ['pl_keywords']) ? trim($_POST ['pl_keywords']) : "") . "\n";
+			$metatags .= "noindex=" . (isset($_POST ['pl_noindex']) ? trim($_POST ['pl_noindex']) : "0") . "\n";
+			$metatags .= "nofollow=" . (isset($_POST ['pl_nofollow']) ? trim($_POST ['pl_nofollow']) : "0") . "\n";
+			$metatags .= "noarchive=" . (isset($_POST ['pl_noarchive']) ? trim($_POST ['pl_noarchive']) : "0") . "\n";
+			$metatags .= "nosnippet=" . (isset($_POST ['pl_nosnippet']) ? trim($_POST ['pl_nosnippet']) : "0") . "\n";
+			$metatags = preg_replace("/[^0-9a-zA-Z- =,\r\n" . $keep_char . "]/", "", $metatags);
+
+			if (!empty($_POST ['pl_file_meta']) && $_POST ['pl_file_meta'] !== SEOMETA_DEFAULT_DIR . 'metatags.ini')
+				// existing blog entry or static page (got file name already)
+				@io_write_file($_POST ['pl_file_meta'], "[meta]\n" . $metatags);
+			elseif ($_REQUEST ['p'] === "entry") {
+				// this was a new blog entry
+				$new_id = bdb_idfromtime(BDB_ENTRY, $_POST ['timestamp']);
+				$file_meta = SEOMETA_ENTRY_DIR . $new_id . '_metatags.ini';
+				@io_write_file($file_meta, "[meta]\n" . $metatags);
+			} elseif ($_REQUEST ['p'] === "static") {
+				// this was a new static page
+				$new_id = $_REQUEST ['id'];
+				$file_meta = SEOMETA_STATIC_DIR . $new_id . '_metatags.ini';
+				@io_write_file($file_meta, "[meta]\n" . $metatags);
+			}
+			// @io_write_file(SEOMETA_DIR."log.txt", print_r($_REQUEST, true).print_r($_POST, true));
+		}
+
+		/**
+		 * "post" function
+		 *
+		 * This function is called by submit button hook.
+		 * It adds $this->save to publish_post hook.
+		 */
+		function post($data) {
+			add_filter('publish_post', array(
+				&$this,
+				'save'
+			), 10, 2);
+			return $data;
+		}
+
+		/**
+		 * "save" function
+		 *
+		 * This function save the description to a file.
+		 */
+		function save($id, $arr) {
+			$this->do_save();
+			return true;
+		}
+
+		/**
+		 * "save" function
+		 *
+		 * This function save the description to a file.
+		 */
+		function save_static($title) {
+			$this->do_save();
+			return ($title);
+		}
+
+		/**
+		 * plugin_description_entry function (constructor)
+		 *
+		 * This function adds some functions to filters system.
+		 */
+		function __construct() {
+			//add_filter('simple_edit_form', array( // is already used by the tag-plugin and is not intended for static pages
+			add_filter('simple_metatag_info', array(
+				&$this,
+				'simple'
+			));
+			add_filter('admin_entry_write_onsave', array(
+				&$this,
+				'post'
+			));
+			add_filter('admin_entry_write_onsavecontinue', array(
+				&$this,
+				'post'
+			));
+			add_filter('title_save_pre', array(
+				&$this,
+				'save_static'
+			));
+		}
+
+	}
+
+	# Init the class
+	if (SEOMETA_MIGRATE_DATA)
+		migrate_old(); // migrate old data from previous version of plugin
+	new plugin_seometatags_entry();
+}
+
+function output_metatags($seo_desc, $seo_keywords, $seo_noindex, $seo_nofollow, $seo_noarchive, $seo_nosnippet) {
+	global $prepend_description;
+	global $prepend_keywords;
+	global $fp_params, $fp_config;
+	$lang = lang_load('plugin:seometataginfo');
+	$string = $lang ['plugin'] ['seometataginfo'];
+
+	echo '
+	<!-- beginning of SEO Metatag Info -->'."\n";
+
+	if (SEOMETA_GEN_TITLE_META) {
+		$metatitle = apply_filters('wp_title', $fp_config ['general'] ['title'], trim($string ['sep']));
+		echo "\n" . '    <meta name="Title" content="' . $metatitle . '">' . "\n";
+	}
+
+	$count = 0;
+	$count += ($seo_noindex !== '0') ? 1 : 0;
+	$count += ($seo_nofollow !== '0') ? 1 : 0;
+	$count += ($seo_noarchive !== '0') ? 1 : 0;
+	$count += ($seo_nosnippet !== '0') ? 1 : 0;
+
+	// make description unique by adding a page# when paging
+	$pagenum = "";
+	if (is_paging()) {
+		$pagenum = $string ['sep'] . "(" . $string ['pagenum'] . $fp_params ['paged'] . ")";
+	}
+	// make description unique by adding a comments on comments page
+	$comment = "";
+	if (is_comments()) {
+		$comment = $string ['sep'] . "(" . $string ['comments'] . ")";
+	}
+
+	# Now write the tags
+	echo '    <meta name="description" content="' . $prepend_description . $seo_desc . $comment . $pagenum . '">' . "\n";
+	echo '    <meta name="keywords" content="' . $prepend_keywords . $seo_keywords . '">' . "\n";
+	echo '    <meta name="author" content="'.$fp_config['general']['author'].'">'."\n";
+
+	if ($count > 0) {
+		echo '    <meta name="robots" content="';
+		$data = ($seo_noindex !== '0') ? 'NOINDEX,' : '';
+		$data .= ($seo_nofollow !== '0' ? 'NOFOLLOW,' : '');
+		$data .= ($seo_noarchive !== '0' ? 'NOARCHIVE,' : '');
+		$data .= ($seo_nosnippet !== '0' ? 'NOSNIPPET,' : '');
+		$data = substr($data, 0, -1); // remove trailing comma
+		echo $data;
+		echo '">' . "\n";
+	}
+	if (SEOMETA_GEN_CANONICAL) {
+		$url = currentPageURL();
+		if (SEOMETA_HIDECOMMENTS === true) {
+			$url = preg_replace('/#comments/', '', $url);
+			$url = preg_replace('/comments\//', '', $url);
+		}
+		echo '    <link rel="canonical" href="' . $url . '">' . "\n";
+	}
+	echo '    <!-- end of SEO Metatag Info -->'."\n";
+}
+
+function process_meta($file_meta, $type, $id, $sep) {
+	global $fp_params;
+	global $seo_default;
+
+	if (empty($seo_default ['description']))
+		$seo_default ['description'] = $type . $sep . $id;
+	if (empty($seo_default ['keywords']))
+		$seo_default ['keywords'] = $type;
+	if (!isset($seo_default ['noindex']))
+		$seo_default ['noindex'] = '0';
+	if (!isset($seo_default ['nofollow']))
+		$seo_default ['nofollow'] = '0';
+	if (!isset($seo_default ['noarchive']))
+		$seo_default ['noarchive'] = '0';
+	if (!isset($seo_default ['nosnippet']))
+		$seo_default ['nosnippet'] = '0';
+
+	if (!file_exists($file_meta)) {
+		$metatags = "[meta]\n";
+		$metatags .= "description=" . $seo_default ['description'] . "\n";
+		$metatags .= "keywords=" . $seo_default ['keywords'] . "\n";
+		$metatags .= "noindex=" . $seo_default ['noindex'] . "\n";
+		$metatags .= "nofollow=" . $seo_default ['nofollow'] . "\n";
+		$metatags .= "noarchive=" . $seo_default ['noarchive'] . "\n";
+		$metatags .= "nosnippet=" . $seo_default ['nosnippet'] . "\n";
+		@io_write_file($file_meta, $metatags);
+	}
+
+	$cfg = new iniParser($file_meta);
+	$seo_desc = $cfg->get("meta", "description") != false ? wp_specialchars(trim($cfg->get("meta", "description"))) : $seo_default ['description'];
+	$seo_keywords = $cfg->get("meta", "keywords") != false ? wp_specialchars(trim($cfg->get("meta", "keywords"))) : $seo_default ['keywords'];
+	$seo_noindex = $cfg->get("meta", "noindex") != false ? wp_specialchars(trim($cfg->get("meta", "noindex"))) : $seo_default ['noindex'];
+	$seo_nofollow = $cfg->get("meta", "nofollow") != false ? wp_specialchars(trim($cfg->get("meta", "nofollow"))) : $seo_default ['nofollow'];
+	$seo_noarchive = $cfg->get("meta", "noarchive") != false ? wp_specialchars(trim($cfg->get("meta", "noarchive"))) : $seo_default ['noarchive'];
+	$seo_nosnippet = $cfg->get("meta", "nosnippet") != false ? wp_specialchars(trim($cfg->get("meta", "nosnippet"))) : $seo_default ['nosnippet'];
+	output_metatags($seo_desc, $seo_keywords, $seo_noindex, $seo_nofollow, $seo_noarchive, $seo_nosnippet);
+}
+
+function process_tag_meta() {
+	global $fp_params;
+	$lang = lang_load('plugin:seometataginfo');
+	$string = $lang ['plugin'] ['seometataginfo'];
+
+	$file_meta = SEOMETA_TAG_DIR . 'tag-' . $fp_params ['tag'] . '_metatags.ini';
+	$type = $string ['tag'];
+	$id = $fp_params ['tag'];
+	$sep = $string ['sep'];
+	process_meta($file_meta, $type, $id, $sep);
+}
+
+function process_archive_meta() {
+	global $fp_params;
+	$lang = lang_load('plugin:seometataginfo');
+	$string = $lang ['plugin'] ['seometataginfo'];
+
+	$file_meta = SEOMETA_ARCHIVE_DIR . 'archive-20' . (!empty($fp_params ['y']) ? $fp_params ['y'] : '') . (!empty($fp_params ['m']) ? '-' . $fp_params ['m'] : '') . (!empty($fp_params ['d']) ? '-' . $fp_params ['d'] : '') . '_metatags.ini';
+	$type = $string ['archive'];
+	$id = "20" . (!empty($fp_params ['y']) ? $fp_params ['y'] : '') . (!empty($fp_params ['m']) ? '/' . $fp_params ['m'] : '') . (!empty($fp_params ['d']) ? '/' . $fp_params ['d'] : '');
+	$sep = $string ['sep'];
+	process_meta($file_meta, $type, $id, $sep);
+}
+
+function process_category_meta() {
+	global $fp_params;
+	$lang = lang_load('plugin:seometataginfo');
+	$string = $lang ['plugin'] ['seometataginfo'];
+
+	// check if requested category exists
+	if (!seometa_category_id_exists($fp_params ['cat'])) {
+		return;
+	}
+
+	$file_meta = SEOMETA_CATEGORY_DIR . 'cat-' . $fp_params ['cat'] . '_metatags.ini';
+	$type = $string ['category'];
+	$id = get_category_name($fp_params ['cat']);
+	$sep = $string ['sep'];
+	process_meta($file_meta, $type, $id, $sep);
+}
+
+/**
+ * Checks if the category with the given ID exists
+ *
+ * @param int $cat_id
+ *        	the category ID
+ * @return boolean <code>true</code> if the category exists; <code>false</code> otherwise
+ */
+function seometa_category_id_exists($cat_id) {
+	// if we don't have a categories config, there's nothing to check!
+	if (!file_exists(CONTENT_DIR . 'categories.txt')) {
+		return false;
+	}
+
+	// get all categories from config file
+	$cats = trim(io_load_file(CONTENT_DIR . 'categories.txt'));
+	// check each known category
+	$catConfigLines = explode("\n", $cats);
+	foreach ($catConfigLines as $currentLine) {
+		$data = explode(':', $currentLine);
+		// category ID resides in index 1
+		if (array_key_exists(1, $data) && trim($data [1]) == $cat_id) {
+			return true;
+		}
+	}
+	// no matching category found!
+	return false;
+}
+
+function plugin_seometataginfo_head() {
+	global $fpdb, $fp_params, $fp_config, $smarty;
+
+	if (defined('ADMIN_PANEL'))
+		return;
+
+	if (is_tag()) { // Am I in a tag?
+		process_tag_meta();
+	} elseif (is_archive()) { // Am I in a archive?
+		process_archive_meta();
+	} elseif (is_category()) { // Am I in a category?
+		process_category_meta();
+	} else {
+		if (is_single()) {
+			# Search for the description
+			$id = $fp_params ['entry'];
+			$file_meta = SEOMETA_ENTRY_DIR . $id . '_metatags.ini';
+		} else {
+			if (is_blog_page()) {
+				$id = 'blog';
+				$file_meta = SEOMETA_STATIC_DIR . $id . '_metatags.ini';
+			} elseif (is_contact()) { // check if contact form
+				$file_meta = SEOMETA_STATIC_DIR . 'contact_metatags.ini';
+			} elseif (!empty($fp_params ['page'])) { // check if ordinary static page
+				$id = $fp_params ['page'];
+				$file_meta = SEOMETA_STATIC_DIR . $id . '_metatags.ini';
+			} elseif (is_static_home()) { // must be Home Page?
+				$id = $fp_config ['general'] ['startpage'];
+				$file_meta = SEOMETA_STATIC_DIR . $id . '_metatags.ini';
+			}
+		}
+
+		if (!file_exists($file_meta))
+			return;
+
+		$cfg = new iniParser($file_meta);
+		$seo_desc = $cfg->get("meta", "description") != false ? wp_specialchars(trim($cfg->get("meta", "description"))) : '';
+		$seo_keywords = $cfg->get("meta", "keywords") != false ? wp_specialchars(trim($cfg->get("meta", "keywords"))) : '';
+		$seo_noindex = $cfg->get("meta", "noindex") != false ? wp_specialchars(trim($cfg->get("meta", "noindex"))) : '0';
+		$seo_nofollow = $cfg->get("meta", "nofollow") != false ? wp_specialchars(trim($cfg->get("meta", "nofollow"))) : '0';
+		$seo_noarchive = $cfg->get("meta", "noarchive") != false ? wp_specialchars(trim($cfg->get("meta", "noarchive"))) : '0';
+		$seo_nosnippet = $cfg->get("meta", "nosnippet") != false ? wp_specialchars(trim($cfg->get("meta", "nosnippet"))) : '0';
+		output_metatags($seo_desc, $seo_keywords, $seo_noindex, $seo_nofollow, $seo_noarchive, $seo_nosnippet);
+	}
+}
+
+add_action('wp_head', 'plugin_seometataginfo_head', 1);
+
+function makePageTitle($title, $sep) {
+	global $fp_params;
+	$lang = lang_load('plugin:seometataginfo');
+	$string = $lang ['plugin'] ['seometataginfo'];
+
+	$page_title = "";
+
+	if (is_contact()) {
+		$page_title = $string ['contact'];
+	} elseif (is_static_home() && empty($fp_params ['page'])) {
+		$page_title = $string ['home'];
+	} elseif (is_blog_home()) {
+		$page_title = $string ['blog_home'];
+	} elseif (is_blog_page()) {
+		$page_title = $string ['blog_page'];
+	} elseif (is_tag()) {
+		$page_title = $string ['tag'] . $string ['sep'] . $fp_params ["tag"];
+	} elseif (is_archive()) {
+		if (is_archive_year()) {
+			$page_title = $string ['archive'] . $string ['sep'] . '20' . $fp_params ["y"];
+		} elseif (is_archive_month()) {
+			$page_title = $string ['archive'] . $string ['sep'] . '20' . $fp_params ["y"] . '/' . $fp_params ["m"];
+		} elseif (is_archive_day()) {
+			$page_title = $string ['archive'] . $string ['sep'] . '20' . $fp_params ["y"] . '/' . $fp_params ["m"] . '/' . $fp_params ["d"];
+		}
+	} elseif (is_category()) {
+		$page_title = $string ['category'] . $string ['sep'] . get_category_name($fp_params ['cat']);
+	} elseif (is_search()) {
+		$page_title = $fp_params ['q'];
+	}
+
+	if (is_paging()) {
+		$page_title .= $string ['sep'] . $string ['pagenum'] . $fp_params ['paged'];
+	}
+
+	return "$title" . (!empty($page_title) ? " $sep $page_title" : "");
+}
+
+function plugin_seometataginfo_init() {
+	if (defined('ADMIN_PANEL'))
+		return;
+
+	if (SEOMETA_GEN_TITLE)
+		add_filter('wp_title', 'makePageTitle', 10, 2);
+}
+
+add_action('init', 'plugin_seometataginfo_init');
+
+?>


### PR DESCRIPTION
*SEO Metatag Info Plugin in the standard distribution*
- includes all languages FlatPress currently supports as standard (translation via Deepl).
- Content customized texts incl. placeholder as example.
- With own hook in entry- and statictemplate, because otherwise the tag plugin is also shown when creating static pages; which is not supposed to be

With best regards
Frank