### PR TITLE
for non-ASCII characters in the e-mail header

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -222,7 +222,8 @@ function commentform() {
 					$fp_config ['general'] ['title']
 				), $lang ['comments'] ['mail']);
 
-				@utils_mail($from_mail, "{$lang ['comments'] ['newcomment']} {$lang ['comments'] ['newcomment']} {$fp_config['general']['title']}", $mail);
+				// for non-ASCII characters in the e-mail header, use RFC 1342 — Encodes data with MIME base64
+				@utils_mail($from_mail, "=?utf-8?B?" . base64_encode($lang ['comments'] ['newcomment']) . "?= =?utf-8?B?" . base64_encode($fp_config ['general'] ['title']) . "?=", $mail);
 			}
 
 			// if comment is valid, this redirect will clean the postdata

--- a/comments.php
+++ b/comments.php
@@ -222,8 +222,8 @@ function commentform() {
 					$fp_config ['general'] ['title']
 				), $lang ['comments'] ['mail']);
 
-				// for non-ASCII characters in the e-mail header, use RFC 1342 — Encodes data with MIME base64
-				@utils_mail($from_mail, "=?utf-8?B?" . base64_encode($lang ['comments'] ['newcomment']) . "?= =?utf-8?B?" . base64_encode($fp_config ['general'] ['title']) . "?=", $mail);
+				// for non-ASCII characters in the e-mail header use RFC 1342 — Encodes data with MIME base64 and splits the encrypted subject
+				@utils_mail($from_mail, "=?utf-8?B?" . base64_encode($lang ['comments'] ['newcomment']) . "=?= =?utf-8?B?" . base64_encode($fp_config ['general'] ['title']) . "==?=", $mail);
 			}
 
 			// if comment is valid, this redirect will clean the postdata

--- a/comments.php
+++ b/comments.php
@@ -223,7 +223,7 @@ function commentform() {
 				), $lang ['comments'] ['mail']);
 
 				// for non-ASCII characters in the e-mail header use RFC 1342 — Encodes data with MIME base64 and splits the encrypted subject
-				@utils_mail($from_mail, "=?utf-8?B?" . base64_encode($lang ['comments'] ['newcomment']) . "=?= =?utf-8?B?" . base64_encode($fp_config ['general'] ['title']) . "==?=", $mail);
+				@utils_mail($from_mail, '=?utf-8?B?' . base64_encode($lang ['comments'] ['newcomment']) . '=?= =?utf-8?B?' . base64_encode($fp_config ['general'] ['title']) . '==?=', $mail);
 			}
 
 			// if comment is valid, this redirect will clean the postdata

--- a/fp-interface/lang/cs-cz/lang.comments.php
+++ b/fp-interface/lang/cs-cz/lang.comments.php
@@ -11,6 +11,6 @@ S pozdravem %blogtitle%
 
 ';
 
-$lang ['comments'] ['newcomment'] = 'Nový komentář k';
+$lang ['comments'] ['newcomment'] = 'Nový komentář k ';
 
 ?>

--- a/fp-interface/lang/de-de/lang.comments.php
+++ b/fp-interface/lang/de-de/lang.comments.php
@@ -16,6 +16,6 @@ Automatisch generiert von,
 
 ';
 
-$lang ['comments'] ['newcomment'] = 'Neuer Kommentar auf';
+$lang ['comments'] ['newcomment'] = 'Neuer Kommentar auf ';
 
 ?>

--- a/fp-interface/lang/el-gr/lang.comments.php
+++ b/fp-interface/lang/el-gr/lang.comments.php
@@ -16,6 +16,6 @@ $lang ['comments'] ['mail'] = 'Αγαπητέ/η %toname%,
 
 ';
 
-$lang ['comments'] ['newcomment'] = 'νέο σχόλιο στο';
+$lang ['comments'] ['newcomment'] = 'νέο σχόλιο στο ';
 
 ?>

--- a/fp-interface/lang/en-us/lang.comments.php
+++ b/fp-interface/lang/en-us/lang.comments.php
@@ -16,6 +16,6 @@ All the best,
 
 ';
 
-$lang ['comments'] ['newcomment'] = 'New comment on';
+$lang ['comments'] ['newcomment'] = 'New comment on ';
 
 ?>

--- a/fp-interface/lang/es-es/lang.comments.php
+++ b/fp-interface/lang/es-es/lang.comments.php
@@ -16,6 +16,6 @@ Todo lo mejor,
 
 ';
 
-$lang ['comments'] ['newcomment'] = 'Nuevo comentario sobre';
+$lang ['comments'] ['newcomment'] = 'Nuevo comentario sobre ';
 
 ?>

--- a/fp-interface/lang/fr-fr/lang.comments.php
+++ b/fp-interface/lang/fr-fr/lang.comments.php
@@ -16,6 +16,6 @@ Cordialement,
 
 ';
 
-$lang ['comments'] ['newcomment'] = 'Nouveau commentaire sur';
+$lang ['comments'] ['newcomment'] = 'Nouveau commentaire sur ';
 
 ?>

--- a/fp-interface/lang/it-it/lang.comments.php
+++ b/fp-interface/lang/it-it/lang.comments.php
@@ -16,6 +16,6 @@ Saluti,
 
 ';
 
-$lang ['comments'] ['newcomment'] = 'Nuovo commento su';
+$lang ['comments'] ['newcomment'] = 'Nuovo commento su ';
 
 ?>

--- a/fp-interface/lang/ja-jp/lang.comments.php
+++ b/fp-interface/lang/ja-jp/lang.comments.php
@@ -19,6 +19,6 @@ $lang ['comments'] ['mail'] = '%toname% さま,
 
 ';
 
-$lang ['comments'] ['newcomment'] = 'の新しいコメント';
+$lang ['comments'] ['newcomment'] = 'の新しいコメント ';
 
 ?>

--- a/fp-interface/lang/nl-nl/lang.comments.php
+++ b/fp-interface/lang/nl-nl/lang.comments.php
@@ -16,6 +16,6 @@ Groeten,
 
 ';
 
-$lang ['comments'] ['newcomment'] = 'Nieuw commentaar op';
+$lang ['comments'] ['newcomment'] = 'Nieuw commentaar op ';
 
 ?>

--- a/fp-interface/lang/pt-br/lang.comments.php
+++ b/fp-interface/lang/pt-br/lang.comments.php
@@ -17,6 +17,6 @@ Um abraço,
 
 ';
 
-$lang ['comments'] ['newcomment'] = 'Novo comentário em';
+$lang ['comments'] ['newcomment'] = 'Novo comentário em ';
 
 ?>


### PR DESCRIPTION
fixes #209 
Email notification is now sent when a new comment has been left and when the subject in the email header contains umlauts.