### PR TITLE
Prevents oversizing in the post-preview, when applying the code tag.

### DIFF
--- a/fp-interface/themes/leggero/flatmaas-rev/res/admin.css
+++ b/fp-interface/themes/leggero/flatmaas-rev/res/admin.css
@@ -167,6 +167,9 @@ input.maxsize, select.maxsize {width:100%}
 
 
 /* preview settings */
+#post-preview {
+	min-width: 54.4em
+}
 
 #post-preview .entry {
         padding:2em

--- a/fp-interface/themes/leggero/leggero-v2/res/admin.css
+++ b/fp-interface/themes/leggero/leggero-v2/res/admin.css
@@ -284,6 +284,10 @@ input.maxsize, select.maxsize { width: 99% }
 
 
 /* ===== PREVIEW SETTINGS ===== */
+#post-preview {
+	min-width: 68em
+}
+
 #post-preview .entry { padding: 2em; max-height: 20em; overflow: auto  }
 
 #post-preview div.entry h2 {

--- a/fp-interface/themes/leggero/leggero/res/admin.css
+++ b/fp-interface/themes/leggero/leggero/res/admin.css
@@ -283,6 +283,10 @@ input.maxsize, select.maxsize { width: 100% }
 
 
 /* ===== PREVIEW SETTINGS ===== */
+#post-preview {
+	min-width: 39em;
+}
+
 #post-preview .entry { padding: 2em; max-height: 20em; overflow: auto  }
 
 #post-preview div.entry h2,


### PR DESCRIPTION
Fixes #248 

 * Prevents oversizing in the post-preview, when applying the code tag.

![post-preview_code-tag](https://github.com/flatpressblog/flatpress/assets/50171344/11a6e69a-dade-4c91-b9cc-de4735c003b0)
