### PR TITLE
Revised static.write and entry.write panel in the administration area

### DIFF
--- a/admin/panels/entry/admin.entry.write.tpl
+++ b/admin/panels/entry/admin.entry.write.tpl
@@ -1,108 +1,102 @@
 <h2>{$panelstrings.head}</h2>
 
-	
-	{include file='shared:errorlist.tpl'}
+
+	{include file="shared:errorlist.tpl"}
 
 	{entry_block}
 	<div id="admin-post-preview">
 	{if isset($preview)}
-	<fieldset id="post-preview"><legend>{$panelstrings.preview}</legend>
-	{include file="preview.tpl"}
-	</fieldset>
+		<fieldset id="post-preview"><legend>{$panelstrings.preview}</legend>
+		{include file="preview.tpl"}
+		</fieldset>
 	{/if}
 	</div>
 
-		
 {html_form}
 	{if !isset($post)}
 		{assign var=post value=""}
 	{/if}
 		{entry content=$post alwaysshow=true}
-	
+
 		<div id="admin-editor">
-			<p><label for="subject">{$panelstrings.subject}</label><br />
+			<p><label for="subject">{$panelstrings.subject}</label><br>
 			{if isset($error) && isset($error.subject) && !empty($error.subject)}
 				{assign var=class value="field-error"}
 			{else}
 				{assign var=class value=""}
 			{/if}
-			<input type="text" class="{$class}" 
-				name="subject" id="subject" 
-				value="{$subject|default:{$smarty.request.subject|default:''}|wp_specialchars:1}" /><br />
-			<input type="hidden" name="timestamp" value="{$date}" />
-			<input type="hidden" name="entry" value="{$id}" />
+				<input type="text" name="subject" id="subject" class="{$class}" 
+					value="{$subject|default:{$smarty.request.subject|default:''}|wp_specialchars:1}"><br>
+				<input type="hidden" name="timestamp" value="{$date}">
+				<input type="hidden" name="entry" value="{$id}">
 			</p>
 			<p>
-			<label for="content">{$panelstrings.content}</label>
+				<label for="content">{$panelstrings.content}</label>
 			</p>
-			{toolbar}
+			{if function_exists('plugin_bbcode_init')}
+				{include file="plugin:bbcode/toolbar"}
+			{/if}
 			<p>
-			<textarea name="content" class="{$class}" 
-			id="content" rows="20" cols="74">{$content|default:{$smarty.request.content|default:''}|htmlspecialchars}</textarea><br />
-			{*here will go a plugin hook*}
-			{action hook=simple_edit_form}
-			{action hook=simple_metatag_info}
-
+			{if isset($error) && isset($error.content) && !empty($error.content)}
+				{assign var=class value="field-error"}
+			{else}
+				{assign var=class value=""}
+			{/if}
+				<textarea name="content" id="content" class="{$class}" 
+					rows="20" cols="74">{$content|default:{$smarty.request.content|default:''}|htmlspecialchars}</textarea><br>
 			</p>
+			{* here will go a plugin hook *}
+			<!-- BOF CommentCenter and Tag- Plugin -->{action hook=simple_edit_form}<!-- EOF CommentCenter and Tag- Plugin -->
+			<!-- BOF SEO-Metataginfo- Plugin -->{action hook=simple_metatag_info}<!-- EOF SEO-Metataginfo- Plugin -->
 		</div>
-		
+
 		<div id="admin-options">
-	
+
 		{* let's disable this for now... *}
-		
+
 		{*
-		
 		<fieldset id="admin-entry-uploader"><legend>{$panelstrings.uploader}</legend>
 			<iframe id="uploader-iframe" src="{$smarty.const.BLOG_BASEURL}admin.php?p=uploader&amp;mod=inline"></iframe>
 		</fieldset>	
 		*}
-		
+
 		{* end of inline form *}
-		
+
 		<fieldset id="admin-entry-categories"><legend>{$panelstrings.categories}</legend>
 			{list_categories type=form selected=$categories}
 		</fieldset>
-		
+
 		<fieldset id="admin-entry-saveopts"><legend>{$panelstrings.saveopts}</legend>
-			
 			<p>
 			{foreach from=$saved_flags item=flag}
-			<label><input name="flags[{$flag}]" {if $categories and (bool)array_intersect(array($flag),$categories) }checked="checked"{/if} type="checkbox" /> {$lang.entry.flags.long[$flag]} </label><br />
+			<label><input name="flags[{$flag}]"{if $categories and (bool)array_intersect(array($flag),$categories)}checked="checked"{/if} type="checkbox">{$lang.entry.flags.long[$flag]} </label><br>
 			{/foreach}
 			</p>
-			
 		</fieldset>
 		</div>
-		
-		
+
 		<div class="buttonbar">
 		{html_submit name="save" id="save" value=$panelstrings.submit accesskey=s}
 		{html_submit name="savecontinue" id="savecontinue" value=$panelstrings.savecontinue accesskey=c}
 		{html_submit name="preview" id="preview" value=$panelstrings.preview accesskey=p}
 		</div>
 
-	
 	{/entry}
 {/html_form}
 	{/entry_block}
 
-{if isset($smarty.get.entry) }
+{if isset($smarty.get.entry)}
 
-<div id="admin-otheroptions">	
-
-<h2>{$panelstrings.otheropts}</h2>
-	<ul>
+<div id="admin-otheroptions">
+	<h2>{$panelstrings.otheropts}</h2>
+		<ul>
 		{if !isset($draft)}
-		<li><a href="admin.php?p=entry&amp;entry={$smarty.get.entry}&amp;action=commentlist">
+			<li><a href="admin.php?p=entry&amp;entry={$smarty.get.entry}&amp;action=commentlist">
 			{$panelstrings.commmsg}</a></li>
 		{/if}
-		<li><a href="admin.php?p=entry&amp;entry={$smarty.get.entry}&amp;action=delete">
+			<li><a href="admin.php?p=entry&amp;entry={$smarty.get.entry}&amp;action=delete">
 			{$panelstrings.delmsg}</a></li>
-	</ul>
-
+		</ul>
 </div>
 
 {/if}
-
-
-

--- a/admin/panels/static/admin.static.write.tpl
+++ b/admin/panels/static/admin.static.write.tpl
@@ -1,36 +1,40 @@
 <h2>{$panelstrings.head}</h2>
 
-	{include file="shared:errorlist.tpl"}	
 
+	{include file="shared:errorlist.tpl"}
 
 	{static_block}
+	<div id="admin-post-preview">
 	{if isset($preview)}
 		<fieldset id="post-preview"><legend>{$panelstrings.preview}</legend>
 		{include file="previewstatic.tpl"}
 		</fieldset>
 	{/if}
+	</div>
 
-{html_form}		
-
+{html_form}
 	{if !isset($post)}
 		{assign var=post value=""}
 	{/if}
-	{static content=$post alwaysshow=true}
+		{static content=$post alwaysshow=true}
 	
-			<p><label for="subject">{$panelstrings.subject}</label><br />
+		<div id="admin-editor">
+			<p><label for="subject">{$panelstrings.subject}</label><br>
 			{if isset($error) && isset($error.subject) && !empty($error.subject)}
 				{assign var=class value="field-error"}
 			{else}
 				{assign var=class value=""}
 			{/if}
 			<input type="text" name="subject" id="subject" class="{$class}" 
-			value="{$subject|default:$smarty.request.subject|default:{$smarty.request.page|default:''}|wp_specialchars:1}" /><br />
-			<input type="hidden" name="timestamp" value="{$date}" />
+				value="{$subject|default:$smarty.request.subject|default:{$smarty.request.page|default:''}|wp_specialchars:1}"><br>
+			<input type="hidden" name="timestamp" value="{$date}">
 			</p>
 			<p>
-			<label for="content">{$panelstrings.content}</label>
+				<label for="content">{$panelstrings.content}</label>
 			</p>
-			{toolbar}
+			{if function_exists('plugin_bbcode_init')}
+				{include file="plugin:bbcode/toolbar"}
+			{/if}
 			<p>
 			{if isset($error) && isset($error.content) && !empty($error.content)}
 				{assign var=class value="field-error"}
@@ -38,35 +42,31 @@
 				{assign var=class value=""}
 			{/if}
 			<textarea name="content" class="{$class}" id="content" 
-			rows="20" cols="74">{$content|default:{$smarty.request.content|default:''}|htmlspecialchars}</textarea><br />
-		{*here will go a plugin hook*}
-		{action hook=simple_metatag_info}
+				rows="20" cols="74">{$content|default:{$smarty.request.content|default:''}|htmlspecialchars}</textarea><br>
 			</p>
-		
+			{* here will go a plugin hook *}
+			<!-- BOF SEO-Metataginfo- Plugin -->{action hook=simple_metatag_info}<!-- EOF SEO-Metataginfo- Plugin -->
+		</div>
+
 		<fieldset id="admin-static-filename"><legend>{$panelstrings.fieldset2}</legend>
-		<input type="hidden" name="oldid" id="oldid" value="{$id|default:$smarty.request.oldid}" />
-		<p><label for="id">{$panelstrings.pagename}</label><br />
+			<input type="hidden" name="oldid" id="oldid" value="{$id|default:$smarty.request.oldid}">
+				<p><label for="id">{$panelstrings.pagename}</label><br>
 		{if isset($error) && isset($error.id) && !empty($error.id)}
 			{assign var=class value="field-error"}
 		{else}
 			{assign var=class value=""}
 		{/if}
-		<input type="text" name="id" id="id" class="maxsize{$class}"
-		value="{$smarty.request.id|default:$smarty.request.page|default:$static_id}" /></p>
-		{html_submit name="save" id="save" value=$panelstrings.submit accesskey=s}
-		{html_submit name="preview" id="preview" value=$panelstrings.preview accesskey=p}
-		
+			<input type="text" name="id" id="id" class="maxsize{$class}"
+				value="{$smarty.request.id|default:$smarty.request.page|default:$static_id}"></p>
 		</fieldset>
 
-	
+		<div class="buttonbar">
+		{html_submit name="save" id="save" value=$panelstrings.submit accesskey=s}
+		{html_submit name="preview" id="preview" value=$panelstrings.preview accesskey=p}
+		</div>
+
 	{/static}
 
 
 {/html_form}
 	{/static_block}
-
-
-
-
-
-

--- a/fp-interface/themes/leggero/cpheader.tpl
+++ b/fp-interface/themes/leggero/cpheader.tpl
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="{$fp_config.locale.lang}">
 <head>
 	<title>{$flatpress.title}{$pagetitle}</title>
-	<meta http-equiv="Content-Type" content="text/html; charset={$flatpress.charset}" />
+	<meta http-equiv="Content-Type" content="text/html; charset={$flatpress.charset}">
 	{action hook=wp_head}
 	{action hook=admin_head}
 </head>

--- a/fp-plugins/bbcode/plugin.bbcode.php
+++ b/fp-plugins/bbcode/plugin.bbcode.php
@@ -46,7 +46,8 @@ function plugin_bbcode_startup() {
 	add_filter('the_content', 'plugin_bbcode_undoHtml', 30);
 	if (BBCODE_USE_EDITOR) {
 		// initialize the toolbar
-		add_filter('editor_toolbar', 'plugin_bbcode_init_toolbar');
+		add_filter('editor_toolbar', 'plugin_bbcode_toolbar');
+		plugin_bbcode_init_toolbar();
 	}
 	if (BBCODE_ENABLE_COMMENTS) {
 		add_filter('comment_text', 'plugin_bbcode_comment', 1);
@@ -807,8 +808,6 @@ function plugin_bbcode_init_toolbar() {
 	sort($attachslist);
 	array_unshift($attachslist, $selection);
 	$_FP_SMARTY->assign('attachs_list', $attachslist);
-
-	echo $_FP_SMARTY->fetch('plugin:bbcode/toolbar');
 }
 
 /**

--- a/fp-plugins/seometataginfo/lang/lang.cs-cz.php
+++ b/fp-plugins/seometataginfo/lang/lang.cs-cz.php
@@ -6,10 +6,10 @@ $lang ['admin'] ['plugin'] ['seometataginfo'] = array(
 	'sample_desc' => 'FlatPress související články, průvodci a pluginy',
 	'input_keywords' => 'Vložte klíčová slova:',
 	'sample_keywords' => 'flatpress, flatpress články, flatpress průvodci, flatpress pluginy',
-	'input_noindex' => 'Zakázat indexování (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noindex" target="_blank" title="Přečtěte si více o noindex">noindex</a>):',
-	'input_nofollow' => 'Zakázat sledování (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nofollow" target="_blank" title="Přečtěte si více o nofollow">nofollow</a>):',
-	'input_noarchive' => 'Zakázat archivaci (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noarchive" target="_blank" title="Přečtěte si více o noarchive">noarchive</a>):',
-	'input_nosnippet' => 'Zakázat úryvky (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nosnippet" target="_blank" title="Přečtěte si více o nosnippet">nosnippet</a>):'
+	'input_noindex' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noindex" target="_blank" title="Přečtěte si více o noindex">Zakázat indexování</a>:',
+	'input_nofollow' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nofollow" target="_blank" title="Přečtěte si více o nofollow">Zakázat sledování</a>:',
+	'input_noarchive' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noarchive" target="_blank" title="Přečtěte si více o noarchive">Zakázat archivaci</a>:',
+	'input_nosnippet' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nosnippet" target="_blank" title="Přečtěte si více o nosnippet">Zakázat úryvky</a>:'
 );
 
 $lang ['plugin'] ['seometataginfo'] = array(

--- a/fp-plugins/seometataginfo/lang/lang.da-dk.php
+++ b/fp-plugins/seometataginfo/lang/lang.da-dk.php
@@ -6,10 +6,10 @@ $lang ['admin'] ['plugin'] ['seometataginfo'] = array(
 	'sample_desc' => 'FlatPress-relaterede artikler, vejledninger og plugins',
 	'input_keywords' => 'Indsæt nøgleordene:',
 	'sample_keywords' => 'flatpress, flatpress-artikler, flatpress-guider, flatpress-plugins',
-	'input_noindex' => 'Forbyd indeksering (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noindex" target="_blank" title="Læs mere om noindex">noindex</a>):',
-	'input_nofollow' => 'Forbyd at følge links (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nofollow" target="_blank" title="Læs mere om nofollow">nofollow</a>):',
-	'input_noarchive' => 'Forbyd arkivering (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noarchive" target="_blank" title="Læs mere om noarchive">noarchive</a>):',
-	'input_nosnippet' => 'Forbyd udskæringer (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nosnippet" target="_blank" title="Læs mere om nosnippet">nosnippet</a>):'
+	'input_noindex' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noindex" target="_blank" title="Læs mere om noindex">Forbyd indeksering</a>:',
+	'input_nofollow' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nofollow" target="_blank" title="Læs mere om nofollow">Forbyd at følge links</a>:',
+	'input_noarchive' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noarchive" target="_blank" title="Læs mere om noarchive">Forbyd arkivering</a>:',
+	'input_nosnippet' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nosnippet" target="_blank" title="Læs mere om nosnippet">Forbyd udskæringer</a>:'
 );
 
 $lang ['plugin'] ['seometataginfo'] = array(

--- a/fp-plugins/seometataginfo/lang/lang.de-de.php
+++ b/fp-plugins/seometataginfo/lang/lang.de-de.php
@@ -6,10 +6,10 @@ $lang ['admin'] ['plugin'] ['seometataginfo'] = array(
 	'sample_desc' => 'FlatPress-bezogene Artikel, Anleitungen und Plugins',
 	'input_keywords' => 'Füge die Schlüsselwörter ein:',
 	'sample_keywords' => 'flatpress, flatpress artikel, flatpress anleitungen, flatpress plugins',
-	'input_noindex' => 'Indizieren verbieten (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=de#noindex" target="_blank" title="Lese mehr über noindex">noindex</a>):',
-	'input_nofollow' => 'Link-Following verbieten (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=de#nofollow" target="_blank" title="Lese mehr über nofollow">nofollow</a>):',
-	'input_noarchive' => 'Archivierung verbieten (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=de#noarchive" target="_blank" title="Lese mehr über noarchive">noarchive</a>):',
-	'input_nosnippet' => 'Ausschnitte verbieten (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=de#nosnippet" target="_blank" title="Lese mehr über nosnippet">nosnippet</a>):'
+	'input_noindex' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=de#noindex" target="_blank" title="Lese mehr über noindex">Indizieren verbieten</a>:',
+	'input_nofollow' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=de#nofollow" target="_blank" title="Lese mehr über nofollow">Link-Following verbieten</a>:',
+	'input_noarchive' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=de#noarchive" target="_blank" title="Lese mehr über noarchive">Archivierung verbieten</a>:',
+	'input_nosnippet' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=de#nosnippet" target="_blank" title="Lese mehr über nosnippet">Ausschnitte verbieten</a>:'
 );
 
 $lang ['plugin'] ['seometataginfo'] = array(

--- a/fp-plugins/seometataginfo/lang/lang.el-gr.php
+++ b/fp-plugins/seometataginfo/lang/lang.el-gr.php
@@ -6,10 +6,10 @@ $lang ['admin'] ['plugin'] ['seometataginfo'] = array(
 	'sample_desc' => 'FlatPress σχετικά άρθρα, οδηγοί και plugins',
 	'input_keywords' => 'Εισάγετε τις λέξεις-κλειδιά:',
 	'sample_keywords' => 'flatpress, flatpress άρθρα, flatpress οδηγοί, flatpress πρόσθετα',
-	'input_noindex' => 'Απαγόρευση ευρετηρίασης (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noindex" target="_blank" title="Διαβάστε περισσότερα για το noindex">noindex</a>):',
-	'input_nofollow' => 'Απαγόρευση της παρακολούθησης (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nofollow" target="_blank" title="Διαβάστε περισσότερα για το nofollow">nofollow</a>):',
-	'input_noarchive' => 'Απαγόρευση αρχειοθέτησης (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noarchive" target="_blank" title="Διαβάστε περισσότερα για το noarchive">noarchive</a>):',
-	'input_nosnippet' => 'Απαγόρευση αποσπασμάτων (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nosnippet" target="_blank" title="Διαβάστε περισσότερα για το nosnippet">nosnippet</a>):'
+	'input_noindex' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noindex" target="_blank" title="Διαβάστε περισσότερα για το noindex">Απαγόρευση ευρετηρίασης</a>:',
+	'input_nofollow' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nofollow" target="_blank" title="Διαβάστε περισσότερα για το nofollow">Απαγόρευση της παρακολούθησης</a>:',
+	'input_noarchive' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noarchive" target="_blank" title="Διαβάστε περισσότερα για το noarchive">Απαγόρευση αρχειοθέτησης</a>:',
+	'input_nosnippet' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nosnippet" target="_blank" title="Διαβάστε περισσότερα για το nosnippet">Απαγόρευση αποσπασμάτων</a>:'
 );
 
 $lang ['plugin'] ['seometataginfo'] = array(

--- a/fp-plugins/seometataginfo/lang/lang.en-us.php
+++ b/fp-plugins/seometataginfo/lang/lang.en-us.php
@@ -6,10 +6,10 @@ $lang ['admin'] ['plugin'] ['seometataginfo'] = array(
 	'sample_desc' => 'FlatPress related articles, guides and plugins',
 	'input_keywords' => 'Insert the keywords:',
 	'sample_keywords' => 'flatpress, flatpress articles, flatpress guides, flatpress plugins',
-	'input_noindex' => 'Disallow Indexing (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noindex" target="_blank" title="Read more about noindex">noindex</a>):',
-	'input_nofollow' => 'Disallow Following (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nofollow" target="_blank" title="Read more about nofollow">nofollow</a>):',
-	'input_noarchive' => 'Disallow Archiving (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noarchive" target="_blank" title="Read more about noarchive">noarchive</a>):',
-	'input_nosnippet' => 'Disallow snippets (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nosnippet" target="_blank" title="Read more about nosnippet">nosnippet</a>):'
+	'input_noindex' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noindex" target="_blank" title="Read more about noindex">Disallow Indexing</a>:',
+	'input_nofollow' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nofollow" target="_blank" title="Read more about nofollow">Disallow Following</a>:',
+	'input_noarchive' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noarchive" target="_blank" title="Read more about noarchive">Disallow Archiving</a>:',
+	'input_nosnippet' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nosnippet" target="_blank" title="Read more about nosnippet">Disallow snippets</a>:'
 );
 
 $lang ['plugin'] ['seometataginfo'] = array(

--- a/fp-plugins/seometataginfo/lang/lang.es-es.php
+++ b/fp-plugins/seometataginfo/lang/lang.es-es.php
@@ -6,10 +6,10 @@ $lang ['admin'] ['plugin'] ['seometataginfo'] = array(
 	'sample_desc' => 'FlatPress artículos relacionados, guías y plugins',
 	'input_keywords' => 'Introduzca las palabras clave:',
 	'sample_keywords' => 'flatpress, flatpress artículos, flatpress guías, flatpress plugins',
-	'input_noindex' => 'No permitir la indexación (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=es#noindex" target="_blank" title="Más información sobre noindex">noindex</a>):',
-	'input_nofollow' => 'No permitir lo siguiente (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=es#nofollow" target="_blank" title="Más información sobre nofollow">nofollow</a>):',
-	'input_noarchive' => 'No permitir el archivo (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=es#noarchive" target="_blank" title="Más información sobre noarchive">noarchive</a>):',
-	'input_nosnippet' => 'No permitir fragmentos (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=es#nosnippet" target="_blank" title="Más información sobre nosnippet">nosnippet</a>):'
+	'input_noindex' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=es#noindex" target="_blank" title="Más información sobre noindex">No permitir la indexación</a>:',
+	'input_nofollow' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=es#nofollow" target="_blank" title="Más información sobre nofollow">No permitir lo siguiente</a>:',
+	'input_noarchive' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=es#noarchive" target="_blank" title="Más información sobre noarchive">No permitir el archivo</a>:',
+	'input_nosnippet' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=es#nosnippet" target="_blank" title="Más información sobre nosnippet">No permitir fragmentos</a>:'
 );
 
 $lang ['plugin'] ['seometataginfo'] = array(

--- a/fp-plugins/seometataginfo/lang/lang.fr-fr.php
+++ b/fp-plugins/seometataginfo/lang/lang.fr-fr.php
@@ -6,10 +6,10 @@ $lang ['admin'] ['plugin'] ['seometataginfo'] = array(
 	'sample_desc' => 'Articles, guides et plugins relatifs à FlatPress',
 	'input_keywords' => 'Insérez les mots-clés :',
 	'sample_keywords' => 'flatpress, flatpress articles, flatpress guides, flatpress plugins',
-	'input_noindex' => 'Désactiver l\'indexation (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=fr#noindex" target="_blank" title="En savoir plus sur noindex">noindex</a>):',
-	'input_nofollow' => 'Désactiver suivant (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=fr#nofollow" target="_blank" title="En savoir plus sur nofollow">nofollow</a>):',
-	'input_noarchive' => 'Désactiver l\'archivage (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=fr#noarchive" target="_blank" title="En savoir plus sur noarchive">noarchive</a>):',
-	'input_nosnippet' => 'Désactiver les snippets (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=fr#nosnippet" target="_blank" title="En savoir plus sur nosnippet">nosnippet</a>):'
+	'input_noindex' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=fr#noindex" target="_blank" title="En savoir plus sur noindex">Désactiver l\'indexation</a>:',
+	'input_nofollow' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=fr#nofollow" target="_blank" title="En savoir plus sur nofollow">Désactiver suivant</a>:',
+	'input_noarchive' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=fr#noarchive" target="_blank" title="En savoir plus sur noarchive">Désactiver l\'archivage</a>:',
+	'input_nosnippet' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=fr#nosnippet" target="_blank" title="En savoir plus sur nosnippet">Désactiver les snippets</a>:'
 );
 
 $lang ['plugin'] ['seometataginfo'] = array(

--- a/fp-plugins/seometataginfo/lang/lang.it-it.php
+++ b/fp-plugins/seometataginfo/lang/lang.it-it.php
@@ -6,10 +6,10 @@ $lang ['admin'] ['plugin'] ['seometataginfo'] = array(
 	'sample_desc' => 'Articoli, guide e plugin correlati a FlatPress',
 	'input_keywords' => 'Inserire le parole chiave:',
 	'sample_keywords' => 'flatpress, articoli flatpress, guide flatpress, plugin flatpress',
-	'input_noindex' => 'Disconoscimento dell\'indicizzazione (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=it#noindex" target="_blank" title="Per saperne di più sul noindex">noindex</a>):',
-	'input_nofollow' => 'Disconoscimento di quanto segue (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=it#nofollow" target="_blank" title="Per saperne di più sul nofollow">nofollow</a>):',
-	'input_noarchive' => 'Disconoscimento dell\'archiviazione (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=it#noarchive" target="_blank" title="Per saperne di più sul noarchive">noarchive</a>):',
-	'input_nosnippet' => 'Disconoscimento degli snippet (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=it#nosnippet" target="_blank" title="Per saperne di più sul nosnippet">nosnippet</a>):'
+	'input_noindex' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=it#noindex" target="_blank" title="Per saperne di più sul noindex">Disconoscimento dell\'indicizzazione</a>:',
+	'input_nofollow' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=it#nofollow" target="_blank" title="Per saperne di più sul nofollow">Disconoscimento di quanto segue</a>:',
+	'input_noarchive' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=it#noarchive" target="_blank" title="Per saperne di più sul noarchive">Disconoscimento dell\'archiviazione</a>:',
+	'input_nosnippet' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=it#nosnippet" target="_blank" title="Per saperne di più sul nosnippet">Disconoscimento degli snippet</a>:'
 );
 
 $lang ['plugin'] ['seometataginfo'] = array(

--- a/fp-plugins/seometataginfo/lang/lang.ja-jp.php
+++ b/fp-plugins/seometataginfo/lang/lang.ja-jp.php
@@ -6,10 +6,10 @@ $lang ['admin'] ['plugin'] ['seometataginfo'] = array(
 	'sample_desc' => 'FlatPress 関連記事, ガイドとプラグイン',
 	'input_keywords' => 'キーワードを挿入します。',
 	'sample_keywords' => 'flatpress, flatpress 物品, flatpress ガイド, flatpress プラグイン',
-	'input_noindex' => 'インデックスを禁止する。(<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=ja#noindex" target="_blank" title="noindex についてもっと読む">noindex</a>)',
-	'input_nofollow' => 'フォローを拒否する。 (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=ja#nofollow" target="_blank" title="nofollow についてもっと読む">nofollow</a>)',
-	'input_noarchive' => 'アーカイブを禁止する。 (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=ja#noarchive" target="_blank" title="noarchive についてもっと読む">noarchive</a>)',
-	'input_nosnippet' => 'スニペットを禁止する。 (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=ja#nosnippet" target="_blank" title="nosnippet についてもっと読む">nosnippet</a>)'
+	'input_noindex' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=ja#noindex" target="_blank" title="noindex についてもっと読む">インデックスを禁止する。</a>',
+	'input_nofollow' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=ja#nofollow" target="_blank" title="nofollow についてもっと読む">フォローを拒否する。</a>',
+	'input_noarchive' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=ja#noarchive" target="_blank" title="noarchive についてもっと読む">アーカイブを禁止する。</a>',
+	'input_nosnippet' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=ja#nosnippet" target="_blank" title="nosnippet についてもっと読む">スニペットを禁止する。</a>'
 );
 
 $lang ['plugin'] ['seometataginfo'] = array(

--- a/fp-plugins/seometataginfo/lang/lang.nl-nl.php
+++ b/fp-plugins/seometataginfo/lang/lang.nl-nl.php
@@ -6,10 +6,10 @@ $lang ['admin'] ['plugin'] ['seometataginfo'] = array(
 	'sample_desc' => 'FlatPress-gerelateerde artikelen, gidsen en plugins',
 	'input_keywords' => 'Voeg de sleutelwoorden in:',
 	'sample_keywords' => 'flatpress, flatpress artikelen, flatpress gidsen, flatpress plugins',
-	'input_noindex' => 'Indexering weigeren (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noindex" target="_blank" title="Lees meer over noindex">noindex</a>):',
-	'input_nofollow' => 'Verbied volgen (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nofollow" target="_blank" title="Lees meer over nofollow">nofollow</a>):',
-	'input_noarchive' => 'Archivering niet toestaan (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noarchive" target="_blank" title="Lees meer over noarchive">noarchive</a>):',
-	'input_nosnippet' => 'Snippets niet toestaan (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nosnippet" target="_blank" title="Lees meer over nosnippet">nosnippet</a>):'
+	'input_noindex' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noindex" target="_blank" title="Lees meer over noindex">Indexering weigeren</a>:',
+	'input_nofollow' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nofollow" target="_blank" title="Lees meer over nofollow">Verbied volgen</a>:',
+	'input_noarchive' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noarchive" target="_blank" title="Lees meer over noarchive">Archivering niet toestaan</a>:',
+	'input_nosnippet' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nosnippet" target="_blank" title="Lees meer over nosnippet">Snippets niet toestaan</a>:'
 );
 
 $lang ['plugin'] ['seometataginfo'] = array(

--- a/fp-plugins/seometataginfo/lang/lang.pt-br.php
+++ b/fp-plugins/seometataginfo/lang/lang.pt-br.php
@@ -6,10 +6,10 @@ $lang ['admin'] ['plugin'] ['seometataginfo'] = array(
 	'sample_desc' => 'Artigos, guias e plug-ins relacionados ao FlatPress',
 	'input_keywords' => 'Insira as palavras-chave:',
 	'sample_keywords' => 'flatpress, artigos sobre flatpress, guias flatpress, flatpress plugins',
-	'input_noindex' => 'Não permitir a indexação (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=pt-br#noindex" target="_blank" title="Leia mais sobre o noindex">noindex</a>):',
-	'input_nofollow' => 'Não permitir o seguinte (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=pt-br#nofollow" target="_blank" title="Leia mais sobre o nofollow">nofollow</a>):',
-	'input_noarchive' => 'Não permitir o arquivamento (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=pt-br#noarchive" target="_blank" title="Leia mais sobre o noarchive">noarchive</a>):',
-	'input_nosnippet' => 'Não permitir snippets (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=pt-br#nosnippet" target="_blank" title="Leia mais sobre o nosnippet">nosnippet</a>):'
+	'input_noindex' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=pt-br#noindex" target="_blank" title="Leia mais sobre o noindex">Não permitir a indexação</a>:',
+	'input_nofollow' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=pt-br#nofollow" target="_blank" title="Leia mais sobre o nofollow">Não permitir o seguinte</a>:',
+	'input_noarchive' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=pt-br#noarchive" target="_blank" title="Leia mais sobre o noarchive">Não permitir o arquivamento</a>:',
+	'input_nosnippet' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=pt-br#nosnippet" target="_blank" title="Leia mais sobre o nosnippet">Não permitir snippets</a>:'
 );
 
 $lang ['plugin'] ['seometataginfo'] = array(

--- a/fp-plugins/seometataginfo/lang/lang.ru-ru.php
+++ b/fp-plugins/seometataginfo/lang/lang.ru-ru.php
@@ -6,10 +6,10 @@ $lang ['admin'] ['plugin'] ['seometataginfo'] = array(
 	'sample_desc' => 'FlatPress. Похожие статьи, руководства и плагины',
 	'input_keywords' => 'Добавьте ключевые слова:',
 	'sample_keywords' => 'flatpress, flatpress статьи, flatpress руководства, flatpress плагины',
-	'input_noindex' => 'Запретить индексацию (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=ru#noindex" target="_blank" title="Подробнее о noindex">noindex</a>):',
-	'input_nofollow' => 'Запретить сканирование (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=ru#nofollow" target="_blank" title="Подробнее о nofollow">nofollow</a>):',
-	'input_noarchive' => 'Запретить архивирование (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=ru#noarchive" target="_blank" title="Подробнее о noarchive">noarchive</a>):',
-	'input_nosnippet' => 'Запретить сниппеты (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=ru#nosnippet" target="_blank" title="Подробнее о nosnippet">nosnippet</a>):'
+	'input_noindex' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=ru#noindex" target="_blank" title="Подробнее о noindex">Запретить индексацию</a>:',
+	'input_nofollow' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=ru#nofollow" target="_blank" title="Подробнее о nofollow">Запретить сканирование</a>:',
+	'input_noarchive' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=ru#noarchive" target="_blank" title="Подробнее о noarchive">Запретить архивирование</a>:',
+	'input_nosnippet' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=ru#nosnippet" target="_blank" title="Подробнее о nosnippet">Запретить сниппеты</a>:'
 );
 
 $lang ['plugin'] ['seometataginfo'] = array(

--- a/fp-plugins/seometataginfo/lang/lang.sl-si.php
+++ b/fp-plugins/seometataginfo/lang/lang.sl-si.php
@@ -6,10 +6,10 @@ $lang ['admin'] ['plugin'] ['seometataginfo'] = array(
 	'sample_desc' => 'Povezane novice, vodniki in vtičniki FlatPress',
 	'input_keywords' => 'Vnesite ključne besede:',
 	'sample_keywords' => 'flatpress, flatpress novice, flatpress vodniki, flatpress vtičniki',
-	'input_noindex' => 'Zakleni indeksiranje (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noindex" target="_blank" title="Preberite več o noindex">noindex</a>):',
-	'input_nofollow' => 'Zakleni sledenje (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nofollow" target="_blank" title="Preberite več o nofollow">nofollow</a>):',
-	'input_noarchive' => 'Zakleni arhiviranje (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noarchive" target="_blank" title="Preberite več o noarchive">noarchive</a>):',
-	'input_nosnippet' => 'Prepovedano izrezovanje (<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nosnippet" target="_blank" title="Preberite več o nosnippet">nosnippet</a>):'
+	'input_noindex' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noindex" target="_blank" title="Preberite več o noindex">Zakleni indeksiranje</a>:',
+	'input_nofollow' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nofollow" target="_blank" title="Preberite več o nofollow">Zakleni sledenje</a>:',
+	'input_noarchive' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#noarchive" target="_blank" title="Preberite več o noarchive">Zakleni arhiviranje</a>:',
+	'input_nosnippet' => '<a class="hint" href="https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag?hl=en#nosnippet" target="_blank" title="Preberite več o nosnippet">Prepovedano izrezovanje</a>:'
 );
 
 $lang ['plugin'] ['seometataginfo'] = array(

--- a/fp-plugins/seometataginfo/plugin.seometataginfo.php
+++ b/fp-plugins/seometataginfo/plugin.seometataginfo.php
@@ -136,7 +136,7 @@ if (version_compare(SYSTEM_VER, '0.1010', '>=') == 1 && defined('MOD_ADMIN_PANEL
 			echo "\n<fieldset id=\"plugin_seometataginfo\">\n";
 			echo " <legend>{$string['legend_desc']}</legend>\n";
 			echo "  <p>{$string['description']}</p>\n";
-			echo "  <p>\n";
+			echo "  <div>\n";
 			echo '    <input id="pl_file_meta" type="hidden" name="pl_file_meta" value="' . $file_meta . '">' . "\n";
 			echo "    <p><label for=\"pl_description\">{$string['input_desc']}</label>\n";
 			echo '       <input placeholder="' . $lang ['admin'] ['plugin'] ['seometataginfo'] ['sample_desc'] . '" class="maxsize" id="pl_description" type="text" name="pl_description" value="' . $old_desc . '"></p>' . "\n";
@@ -156,7 +156,7 @@ if (version_compare(SYSTEM_VER, '0.1010', '>=') == 1 && defined('MOD_ADMIN_PANEL
 			echo "    <label for=\"pl_nosnippet\">{$string['input_nosnippet']}</label>\n";
 			echo '       <input style="vertical-align: middle; margin: 0px 10px 0px 0px; cursor: pointer;" id="pl_nosnippet" type="checkbox"' . $checked . ' name="pl_nosnippet" value="1"' . '>';
 			echo '    </p>' . "\n";
-			echo "  </p>\n";
+			echo "  </div>\n";
 			echo "</fieldset>\n";
 
 			return true;


### PR DESCRIPTION
- Fixes #184

- Fixes the problem when the SEOmetatagInfo plugin and/or [Tag plugin](https://wiki.flatpress.org/res:plugins:tag) were active that no new entries or static pages could be written. **Note:** Apparently the Smarty plugin [function.toolbar.php](https://github.com/flatpressblog/flatpress/blob/master/fp-includes/fp-smartyplugins/function.toolbar.php) does not work correctly with Smarty 4. Should be checked, as the [datechanger plugin](https://wiki.flatpress.org/res:plugins:datechanger) needs this.
- Fixes various HTML errors in the PHP code and in the templates. "Write static page" and "Write entry" are now largely valid for HTML5.
	- The HTML code of the administration area now contains a lang attribute in the html start tag to specify the language.
	- The "Save page" and "Preview" -buttons in the "Create static pages" -panel now match the style of the other panels

	- Fixed: in the SEOmetatagInfo plugin an opening ````<p>```` element followed an opening ````<p>```` element.