### PR TITLE
robust character encoding via core utils

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -222,8 +222,8 @@ function commentform() {
 					$fp_config ['general'] ['title']
 				), $lang ['comments'] ['mail']);
 
-				// for non-ASCII characters in the e-mail header use RFC 1342 — Encodes data with MIME base64 and splits the encrypted subject
-				@utils_mail($from_mail, '=?utf-8?B?' . base64_encode($lang ['comments'] ['newcomment']) . '=?= =?utf-8?B?' . base64_encode($fp_config ['general'] ['title']) . '==?=', $mail);
+				// for non-ASCII characters in the e-mail header use RFC RFC 1342 — Encodes $subject with MIME base64 via core.utils.php
+				@utils_mail($from_mail, "{$lang['comments']['newcomment']} {$lang['comments']['newcomment']} {$fp_config['general']['title']}", $mail);
 			}
 
 			// if comment is valid, this redirect will clean the postdata

--- a/contact.php
+++ b/contact.php
@@ -111,8 +111,8 @@ function contact_form() {
 	$msg .= "{$lang['contact']['notification']['content']} \n{$validationResult['content']}\n";
 
 	// send notification mail to site admin
-	// for non-ASCII characters in the e-mail header use RFC 1342 — Encodes data with MIME base64 and splits the encrypted subject
-	$success = @utils_mail((isset($validationResult ['email']) ? $validationResult ['email'] : $fp_config ['general'] ['email']), '=?utf-8?B?' . base64_encode($lang ['contact'] ['notification'] ['subject']) . '=?= =?utf-8?B?' . base64_encode($fp_config ['general'] ['title']) . '==?=', $msg);
+	// for non-ASCII characters in the e-mail header use RFC RFC 1342 — Encodes $subject with MIME base64 via core.utils.php
+	$success = @utils_mail((isset($validationResult ['email']) ? $validationResult ['email'] : $fp_config ['general'] ['email']), "{$lang['contact']['notification']['subject']} {$fp_config['general']['title']}", $msg);
 	system_seterr('contact', $success ? 1 : -1);
 	utils_redirect(basename(__FILE__));
 }

--- a/fp-includes/core/core.utils.php
+++ b/fp-includes/core/core.utils.php
@@ -287,13 +287,28 @@ function utils_countdashes($string, &$rest) {
 	return $i;
 }
 
-function utils_mail($from, $subject, $message, $headers = '') {
+function utils_mail($from = '', $subject, $message, $headers = '') {
 	global $fp_config;
-	if ($headers == '') {
-		$headers = "MIME-Version: 1.0\n" . "From: " . $from . "\n" . "Content-Type: text/plain; charset=\"" . $fp_config ['general'] ['charset'] . "\"\n";
+	/*
+	 * Fraenkiman: Many e-mail providers only allow e-mail addresses from domains that are known to the mail server via their mail server (SMTP host).
+	 * As a rule, these are all e-mail addresses for domains that are registered with the provider.
+	 * In some cases, however, there may be further restrictions, which you should ask your mail provider about.
+	 * When using the PHP mail() function, clarify directly with your provider what restrictions and regulations there are for sending e-mails.
+	 * For this reason, you should have set a sender e-mail address that is permitted for sending by the mail system used (e.g. SMTP).
+	 */
+	if ($from == '') {
+		$from = $fp_config ['general'] ['email'];
 	}
-
-	return mail($fp_config ['general'] ['email'], $subject, $message, $headers);
+	if ($headers == '') {
+		$headers = "MIME-Version: 1.0\r\n" . //
+			"From: " . $from . "\r\n" . //
+			"Content-Type: text/plain; charset=\"" . $fp_config ['general'] ['charset'] . "\"\r\n";
+	}
+	/*
+	 * for non-ASCII characters in the e-mail header use RFC 1342 — Encodes $subject with MIME base64
+	 * https://ncona.com/2011/06/using-utf-8-characters-on-an-e-mail-subject/
+	 */	 
+	return mail($fp_config ['general'] ['email'], '=?' . $fp_config ['general'] ['charset'] . '?B?' . base64_encode($subject) . '?=', $message, $headers);
 }
 
 /*

--- a/fp-plugins/commentcenter/plugin.commentcenter.php
+++ b/fp-plugins/commentcenter/plugin.commentcenter.php
@@ -438,8 +438,8 @@ class plugin_commentcenter {
 			$fp_config ['general'] ['title']
 		), $text);
 
-		// for non-ASCII characters in the e-mail header use RFC 1342 — Encodes data with MIME base64
-		return @utils_mail($from_mail, '=?utf-8?B?' . base64_encode($subject) . '?=', $text);
+		// for non-ASCII characters in the e-mail header use RFC RFC 1342 — Encodes $subject with MIME base64 via core.utils.php
+		return @utils_mail($from_mail, $subject, $text);
 	}
 
 }


### PR DESCRIPTION
- Instead of providing the mail subject with MIME base64 in different places, this has now been centralized.