### PR TITLE
Fixes #322

### DIFF
--- a/fp-plugins/footnotes/doc_footnotes.txt
+++ b/fp-plugins/footnotes/doc_footnotes.txt
@@ -1,9 +1,8 @@
 The footnote plugin creates links between numbers in the content and the corresponding footnote below the text. It's quite straightforward - to try, just create a sample entry with the following content:
 
+Here is some text[^1] with a note. The text goes on and has another reference[^2] to a footnote.
 
-
-Here is some text[1] with a note. The text goes on and has another reference[2] to a footnote.
 
 [footnotes]
-[1] here is the note
-[2] and the second one :)
+[^1]: *here* is the note
+[^2]: and the _second_ one :)

--- a/fp-plugins/footnotes/lang/lang.cs-cz.php
+++ b/fp-plugins/footnotes/lang/lang.cs-cz.php
@@ -1,0 +1,7 @@
+<?php
+$lang ['plugin'] ['footnotes'] = array(
+	'footnote' => 'Poznámka pod čarou',
+	'footnotes' => 'Poznámky pod čarou',
+	'back' => 'Zpět na'
+);
+?>

--- a/fp-plugins/footnotes/lang/lang.da-dk.php
+++ b/fp-plugins/footnotes/lang/lang.da-dk.php
@@ -1,0 +1,7 @@
+<?php
+$lang ['plugin'] ['footnotes'] = array(
+	'footnote' => 'Fodnote',
+	'footnotes' => 'Fodnoter',
+	'back' => 'Tilbage til'
+);
+?>

--- a/fp-plugins/footnotes/lang/lang.de-de.php
+++ b/fp-plugins/footnotes/lang/lang.de-de.php
@@ -1,0 +1,7 @@
+<?php
+$lang ['plugin'] ['footnotes'] = array(
+	'footnote' => 'Fußnote',
+	'footnotes' => 'Fußnoten',
+	'back' => 'Zurück zu'
+);
+?>

--- a/fp-plugins/footnotes/lang/lang.el-gr.php
+++ b/fp-plugins/footnotes/lang/lang.el-gr.php
@@ -1,0 +1,7 @@
+<?php
+$lang ['plugin'] ['footnotes'] = array(
+	'footnote' => 'Υποσημείωση',
+	'footnotes' => 'Υποσημειώσεις',
+	'back' => 'Πίσω στο'
+);
+?>

--- a/fp-plugins/footnotes/lang/lang.en-us.php
+++ b/fp-plugins/footnotes/lang/lang.en-us.php
@@ -1,0 +1,7 @@
+<?php
+$lang ['plugin'] ['footnotes'] = array(
+	'footnote' => 'Footnote',
+	'footnotes' => 'Footnotes',
+	'back' => 'Back to'
+);
+?>

--- a/fp-plugins/footnotes/lang/lang.es-es.php
+++ b/fp-plugins/footnotes/lang/lang.es-es.php
@@ -1,0 +1,7 @@
+<?php
+$lang ['plugin'] ['footnotes'] = array(
+	'footnote' => 'Nota a pie de página',
+	'footnotes' => 'Notas a pie de página',
+	'back' => 'Volver a'
+);
+?>

--- a/fp-plugins/footnotes/lang/lang.fr-fr.php
+++ b/fp-plugins/footnotes/lang/lang.fr-fr.php
@@ -1,0 +1,7 @@
+<?php
+$lang ['plugin'] ['footnotes'] = array(
+	'footnote' => 'Note de bas de page',
+	'footnotes' => 'Notes de bas de page',
+	'back' => 'Retour &agrave;'
+);
+?>

--- a/fp-plugins/footnotes/lang/lang.it-it.php
+++ b/fp-plugins/footnotes/lang/lang.it-it.php
@@ -1,0 +1,7 @@
+<?php
+$lang ['plugin'] ['footnotes'] = array(
+	'footnote' => 'Nota a piè di pagina',
+	'footnotes' => 'Note a piè di pagina',
+	'back' => 'Torna a'
+);
+?>

--- a/fp-plugins/footnotes/lang/lang.ja-jp.php
+++ b/fp-plugins/footnotes/lang/lang.ja-jp.php
@@ -1,0 +1,7 @@
+<?php
+$lang ['plugin'] ['footnotes'] = array(
+	'footnote' => 'フットノート',
+	'footnotes' => '脚注',
+	'back' => 'へ戻る'
+);
+?>

--- a/fp-plugins/footnotes/lang/lang.nl-nl.php
+++ b/fp-plugins/footnotes/lang/lang.nl-nl.php
@@ -1,0 +1,7 @@
+<?php
+$lang ['plugin'] ['footnotes'] = array(
+	'footnote' => 'Voetnoot',
+	'footnotes' => 'Voetnoten',
+	'back' => 'Terug naar'
+);
+?>

--- a/fp-plugins/footnotes/lang/lang.pt-br.php
+++ b/fp-plugins/footnotes/lang/lang.pt-br.php
@@ -1,0 +1,7 @@
+<?php
+$lang ['plugin'] ['footnotes'] = array(
+	'footnote' => 'Nota de rodapé',
+	'footnotes' => 'Notas de rodapé',
+	'back' => 'Voltar para'
+);
+?>

--- a/fp-plugins/footnotes/lang/lang.ru-ru.php
+++ b/fp-plugins/footnotes/lang/lang.ru-ru.php
@@ -1,0 +1,7 @@
+<?php
+$lang ['plugin'] ['footnotes'] = array(
+	'footnote' => 'Сноска',
+	'footnotes' => 'Сноски',
+	'back' => 'Назад к'
+);
+?>

--- a/fp-plugins/footnotes/lang/lang.sl-si.php
+++ b/fp-plugins/footnotes/lang/lang.sl-si.php
@@ -1,0 +1,7 @@
+<?php
+$lang ['plugin'] ['footnotes'] = array(
+	'footnote' => 'Opomba',
+	'footnotes' => 'Opombe pod črto',
+	'back' => 'Nazaj na'
+);
+?>

--- a/fp-plugins/footnotes/plugin.footnotes.php
+++ b/fp-plugins/footnotes/plugin.footnotes.php
@@ -1,11 +1,11 @@
 <?php
 /*
  * Plugin Name: FootNotes
- * Version: 1.0
+ * Version: 1.0.1
  * Plugin URI: https://www.flatpress.org
  * Author: FlatPress
  * Author URI: https://www.flatpress.org
- * Description: Enables footnotes in your entries. Part of the standard distribution.
+ * Description: Enables footnotes in your entries. Part of the standard distribution. <a href="./fp-plugins/footnotes/doc_footnotes.txt" title="Instructions" target="_blank">[Instructions]</a>
  */
 define('FOOTNOTES_START', '[footnotes]');
 
@@ -21,16 +21,22 @@ class footnotes_class {
 	}
 
 	function note($n, $s) {
+		$lang = lang_load('plugin:footnotes');
+		$back = $lang ['plugin'] ['footnotes'] ['back'];
+		
 		$id = $this->id;
 		$this->refs = true;
 
-		return '<li>' . trim($s) . " <a id=\"$id-fn-{$n}\" href=\"#$id-rel-{$n}\" " . "title=\"Back {$n}\">^top</a>" . '</li>';
+		return '<li>' . trim($s) . " <a id=\"$id-fn-{$n}\" href=\"#$id-rel-{$n}\" " . "title=\"{$back} {$n}\">&#8617;</a>" . '</li>';
 	}
 
 	function footnotes($matches) {
-		$str = '<div class="footnotes"><h4>Footnotes</h4><ol>';
+		$lang = lang_load('plugin:footnotes');
+		$footnotes = $lang ['plugin'] ['footnotes'] ['footnotes'];
 
-		$lines = preg_split('|\[([0-9]+)\]|', $matches [1], -1, PREG_SPLIT_DELIM_CAPTURE);
+		$str = '<div class="footnotes"><h4>' . $footnotes . '</h4><ol>';
+
+		$lines = preg_split('|\[\^([0-9]+)\]\:|', $matches [1], -1, PREG_SPLIT_DELIM_CAPTURE);
 
 		// first array element is always empty - remove
 		array_shift($lines);
@@ -46,6 +52,9 @@ class footnotes_class {
 	}
 
 	function references($matches) {
+		$lang = lang_load('plugin:footnotes');
+		$footnote = $lang ['plugin'] ['footnotes'] ['footnote'];
+
 		$n = $matches [1];
 
 		$id = $this->id;
@@ -53,7 +62,7 @@ class footnotes_class {
 		$href_rel = "{$id}-rel-{$n}";
 		$href_note = "{$id}-fn-{$n}";
 
-		return "<sup><a id=\"$href_rel\" href=\"#$href_note\" title=\"note {$n}\">{$n}</a></sup>";
+		return "<sup><a id=\"$href_rel\" href=\"#$href_note\" title=\"{$footnote} {$n}\">{$n}</a></sup>";
 	}
 
 	function headings($matches) {
@@ -92,7 +101,7 @@ function plugin_footnotes_filter($text) {
 	if (!$footnotes_obj->refs)
 		return $text;
 
-	$text = preg_replace_callback('|\[([0-9]+)\]|', array(
+	$text = preg_replace_callback('|\[\^([0-9]+)\]|', array(
 		&$footnotes_obj,
 		'references'
 	), $text);


### PR DESCRIPTION
- Compatibility with [Markdown](https://github.com/flatpressblog/flatpress-extras/tree/master/fp-plugins/markdown) established
- The help document is now linked in the plugin panel
- Hard-coded output now localized