### PR TITLE
Character set in the template

### DIFF
--- a/fp-interface/themes/leggero/cpheader.tpl
+++ b/fp-interface/themes/leggero/cpheader.tpl
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="{$fp_config.locale.lang}">
 <head>
 	<title>{$flatpress.title}{$pagetitle}</title>
-	<meta http-equiv="Content-Type" content="text/html; charset={$flatpress.charset}">
+	<meta http-equiv="Content-Type" content="text/html; charset={$fp_config.locale.charset}">
 	{action hook=wp_head}
 	{action hook=admin_head}
 </head>

--- a/fp-interface/themes/leggero/header.tpl
+++ b/fp-interface/themes/leggero/header.tpl
@@ -2,8 +2,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="{$fp_config.locale.lang}">
 <head>
 	<title>{$flatpress.title|tag:wp_title:'&laquo;'}</title>
-	<meta http-equiv="Content-Type" content="text/html; charset={$flatpress.charset}" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<meta http-equiv="Content-Type" content="text/html; charset={$fp_config.locale.charset}">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	{action hook=wp_head}
 </head>
 


### PR DESCRIPTION
- The Leggero template now uses the array locale.charset and can be changed via the admin panel Options->International settings->Character set.

`/fp-content/config/settings.conf.php
`
- https://forum.flatpress.org/viewtopic.php?t=323
- #281 ?