### PR TITLE
Closes #350

### DIFF
--- a/fp-plugins/support/lang/lang.cs-cz.php
+++ b/fp-plugins/support/lang/lang.cs-cz.php
@@ -34,6 +34,8 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
+	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
+
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.da-dk.php
+++ b/fp-plugins/support/lang/lang.da-dk.php
@@ -34,6 +34,8 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
+	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
+
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.de-de.php
+++ b/fp-plugins/support/lang/lang.de-de.php
@@ -34,6 +34,8 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
+	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
+
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.el-gr.php
+++ b/fp-plugins/support/lang/lang.el-gr.php
@@ -34,6 +34,8 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
+	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
+
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.en-us.php
+++ b/fp-plugins/support/lang/lang.en-us.php
@@ -34,6 +34,8 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
+	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
+
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.es-es.php
+++ b/fp-plugins/support/lang/lang.es-es.php
@@ -34,6 +34,8 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
+	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
+
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.fr-fr.php
+++ b/fp-plugins/support/lang/lang.fr-fr.php
@@ -34,6 +34,8 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> </p>',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
+	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
+
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.it-it.php
+++ b/fp-plugins/support/lang/lang.it-it.php
@@ -34,6 +34,8 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
+	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
+
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.ja-jp.php
+++ b/fp-plugins/support/lang/lang.ja-jp.php
@@ -34,6 +34,8 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
+	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
+
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.nl-nl.php
+++ b/fp-plugins/support/lang/lang.nl-nl.php
@@ -34,6 +34,8 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
+	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
+
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.pt-br.php
+++ b/fp-plugins/support/lang/lang.pt-br.php
@@ -34,6 +34,8 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
+	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
+
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.ru-ru.php
+++ b/fp-plugins/support/lang/lang.ru-ru.php
@@ -34,6 +34,8 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
+	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
+
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.sl-si.php
+++ b/fp-plugins/support/lang/lang.sl-si.php
@@ -34,6 +34,8 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
+	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
+
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/plugin.support.php
+++ b/fp-plugins/support/plugin.support.php
@@ -111,6 +111,10 @@ if (class_exists('AdminPanelAction')) {
 				$support ['plugins'] = $lang ['admin'] ['maintain'] ['support'] ['neg_plugins'];
 			}
 
+			if (function_exists("plugin_datechanger_toolbar")) {
+				$support ['output_datechanger'] = $lang ['admin'] ['maintain'] ['support'] ['output_datechanger'];
+			}
+
 			/**
 			 * prepare output "Core files"
 			 */

--- a/fp-plugins/support/tpls/admin.plugin.support.tpl
+++ b/fp-plugins/support/tpls/admin.plugin.support.tpl
@@ -39,6 +39,9 @@
 		<li>
 			{$support.plugins}{$support.output_plugins}
 		</li>
+		<li>
+			{$support.output_datechanger}
+		</li>
 	</ul>
 	<p class="codeblock">[/code]</p>
 


### PR DESCRIPTION
- Support-Plugin: Indicates that the time zone correction in the configuration menu is skipped when the DateChanger plug-in is active