### PR TITLE
Fixes #349 | DateChanger plugin: use UTC+timeoffset

### DIFF
--- a/fp-defaults/plugins.conf.php
+++ b/fp-defaults/plugins.conf.php
@@ -27,9 +27,7 @@ $fp_plugins = array(
 	'postviews', // Counts and displays entry views
 	'commentcenter', // including Akismet interface
 	'mediamanager',
-	// 'datechanger', // Lets you change the publish date for (new) entries.
-			// DateChanger uses UTC. The time correction in the admin area is skipped
-			// Therefore deactivated by default
+	'datechanger', // Lets you change the publish date for (new) entries.
 	'feed', // Activates the RSS and Atom feed widget
 	'emoticons', // Activates an emoticons toolbar for entries and static pages
 	'support', // Provides the FlatPress admin and the community with all relevant data in case of problems.

--- a/fp-plugins/datechanger/doc_datechanger.txt
+++ b/fp-plugins/datechanger/doc_datechanger.txt
@@ -4,8 +4,6 @@ Lets you change the publish date for (new) entries. Therefore, it adds the edit 
 
 This plugin only works for NEW entries. Once published, the date cannot be changed again!
 
-Attention: The plugin skips a time correction, which can be set in the configuration menu.
- 
 About
 -----
 The DateChanger plugin was originally built by Edoardo Vacchi (NoWhereMan).

--- a/fp-plugins/datechanger/plugin.datechanger.php
+++ b/fp-plugins/datechanger/plugin.datechanger.php
@@ -5,7 +5,7 @@
  * Type: Block
  * Author: FlatPress
  * Description: Allows to change the date and time for <a href="./admin.php?p=entry&action=write" title="Write Entry">new entries</a> via a drop-down menu. Part of the standard distribution. <a href="./fp-plugins/datechanger/doc_datechanger.txt" title="Instructions" target="_blank">[Instructions]</a>
- * Version: 1.0.4
+ * Version: 1.0.5
  * Author URI: https://www.flatpress.org
  */
 if (!(basename($_SERVER ['PHP_SELF']) == 'admin.php' && // must be admin area
@@ -15,7 +15,9 @@ if (!(basename($_SERVER ['PHP_SELF']) == 'admin.php' && // must be admin area
 return;
 
 function plugin_datechanger_toolbar() {
-	$time = time();
+	// $time = time();
+	// use UTC + timeoffset, coe.date.php. line 64
+	$time = date_time();
 
 	$h = date('H', $time);
 	$m = date('i', $time);

--- a/fp-plugins/support/lang/lang.cs-cz.php
+++ b/fp-plugins/support/lang/lang.cs-cz.php
@@ -34,8 +34,6 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
-	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
-
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.da-dk.php
+++ b/fp-plugins/support/lang/lang.da-dk.php
@@ -34,8 +34,6 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
-	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
-
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.de-de.php
+++ b/fp-plugins/support/lang/lang.de-de.php
@@ -34,8 +34,6 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
-	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
-
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.el-gr.php
+++ b/fp-plugins/support/lang/lang.el-gr.php
@@ -34,8 +34,6 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
-	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
-
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.en-us.php
+++ b/fp-plugins/support/lang/lang.en-us.php
@@ -34,8 +34,6 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
-	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
-
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.es-es.php
+++ b/fp-plugins/support/lang/lang.es-es.php
@@ -34,8 +34,6 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
-	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
-
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.fr-fr.php
+++ b/fp-plugins/support/lang/lang.fr-fr.php
@@ -34,8 +34,6 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> </p>',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
-	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
-
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.it-it.php
+++ b/fp-plugins/support/lang/lang.it-it.php
@@ -34,8 +34,6 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
-	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
-
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.ja-jp.php
+++ b/fp-plugins/support/lang/lang.ja-jp.php
@@ -34,8 +34,6 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
-	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
-
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.nl-nl.php
+++ b/fp-plugins/support/lang/lang.nl-nl.php
@@ -34,8 +34,6 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
-	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
-
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.pt-br.php
+++ b/fp-plugins/support/lang/lang.pt-br.php
@@ -34,8 +34,6 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
-	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
-
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.ru-ru.php
+++ b/fp-plugins/support/lang/lang.ru-ru.php
@@ -34,8 +34,6 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
-	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
-
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/lang/lang.sl-si.php
+++ b/fp-plugins/support/lang/lang.sl-si.php
@@ -34,8 +34,6 @@ $lang ['admin'] ['maintain'] ['support'] = array(
 	'pos_plugins' => '<p class="output"><strong>Activated plugins:</strong> ',
 	'neg_plugins' => '<p class="output"><strong>Activated plugins:</strong> Could not be determined.</p>',
 
-	'output_datechanger' => '<p class="attention"><strong>&#8505;</strong> The active DateChanger plugin skips the corrected timezone in the configuration menu.</p>',
-
 	// output "Core files"
 	'h2_permissions' => 'File and directory permissions',
 	'h3_core_files' => 'Core',

--- a/fp-plugins/support/plugin.support.php
+++ b/fp-plugins/support/plugin.support.php
@@ -111,10 +111,6 @@ if (class_exists('AdminPanelAction')) {
 				$support ['plugins'] = $lang ['admin'] ['maintain'] ['support'] ['neg_plugins'];
 			}
 
-			if (function_exists("plugin_datechanger_toolbar")) {
-				$support ['output_datechanger'] = $lang ['admin'] ['maintain'] ['support'] ['output_datechanger'];
-			}
-
 			/**
 			 * prepare output "Core files"
 			 */

--- a/fp-plugins/support/tpls/admin.plugin.support.tpl
+++ b/fp-plugins/support/tpls/admin.plugin.support.tpl
@@ -39,9 +39,6 @@
 		<li>
 			{$support.plugins}{$support.output_plugins}
 		</li>
-		<li>
-			{$support.output_datechanger}
-		</li>
 	</ul>
 	<p class="codeblock">[/code]</p>
 


### PR DESCRIPTION
- Note removed from support plugin
- DateChanger plugin is activated again as default