### PR TITLE
An active FlatPress Protect plugin hides the .htaccess edit field

### DIFF
--- a/fp-plugins/fpprotect/plugin.fpprotect.php
+++ b/fp-plugins/fpprotect/plugin.fpprotect.php
@@ -25,4 +25,8 @@ if (function_exists('is_https')) {
 	}
 
 }
+
+function hidde_input_field() {
+	// If active, the input field and the save button of the PrettyURLs plugin are hidden
+}
 ?>

--- a/fp-plugins/prettyurls/tpls/admin.plugin.prettyurls.tpl
+++ b/fp-plugins/prettyurls/tpls/admin.plugin.prettyurls.tpl
@@ -28,25 +28,26 @@
 	</div>
 
 
+	{if not function_exists('hidde_input_field')} {* If the FlatPress Protect plugin is deactivated, the .htaccess file can be edited and saved. *}
+		<p class="alignright">
+			<a class="hint externlink" href="{$lang.admin.plugin.prettyurls.wiki_nginx}" target="_blank">{$lang.admin.plugin.prettyurls.nginx}</a>
+		</p>
+		<h3>{$plang.htaccess}</h3>
 
-	<p class="alignright">
-		<a class="hint externlink" href="{$lang.admin.plugin.prettyurls.wiki_nginx}" target="_blank">{$lang.admin.plugin.prettyurls.nginx}</a>
-	</p>
-	<h3>{$plang.htaccess}</h3>
+		<p>{$plang.description2}</p>
+		<p>	
+		<textarea id="htaccess" name="htaccess" 
+		{if $cantsave}readonly="readonly" {/if}cols="70" rows="16">{$htaccess|escape:'html'}</textarea>
+		</p>
 
-	<p>{$plang.description2}</p>
-	<p>	
-	<textarea id="htaccess" name="htaccess" 
-	{if $cantsave}readonly="readonly" {/if}cols="70" rows="16">{$htaccess|escape:'html'}</textarea>
-	</p>
-	
-	<div class="buttonbar">
-	{if $cantsave}
-	<p><em>{$plang.cantsave}</em></p>
-	{else}
-	<p>{$lang.admin.plugin.prettyurls.location}</p>
-	<input type="submit" name="htaccess-submit" value="{$plang.submit}"/>
+		<div class="buttonbar">
+		{if $cantsave}
+		<p><em>{$plang.cantsave}</em></p>
+		{else}
+		<p>{$lang.admin.plugin.prettyurls.location}</p>
+		<input type="submit" name="htaccess-submit" value="{$plang.submit}"/>
+		{/if}
+		</div>
 	{/if}
-	</div>
-	
+
 {/html_form}


### PR DESCRIPTION
- An active FlatPress Protect plugin hides the .htaccess edit field