### PR TITLE
Addition to #382  An active FlatPress Protect plugin hides the .htacc…

### DIFF
--- a/fp-defaults/plugins.conf.php
+++ b/fp-defaults/plugins.conf.php
@@ -33,6 +33,8 @@ $fp_plugins = array(
 	'emoticons', // Activates an emoticons toolbar for entries and static pages
 	'support', // Provides the FlatPress admin and the community with all relevant data in case of problems.
 	'gallerycaptions',
-	'photoswipe'
+	'photoswipe',
+	'fpprotect' // Hardens your blog with additional features in the HTTP response header.
+		// Removes the htaccess editor from the PrettyURLs plugin.
 );
 ?>

--- a/fp-plugins/fpprotect/doc_fpprotect.txt
+++ b/fp-plugins/fpprotect/doc_fpprotect.txt
@@ -3,7 +3,7 @@ FlatPress Protect
 
 Description
 -----------
-Protect the .htaccess file of the PrettyURLs plugin from unintentional changes.
+Removes the htaccess editor from the PrettyURLs plugin to protect the .htaccess file from unintentional changes.
 Protect your blog with additional fetures in the HTTP response header
 
  * Content Security Policy is an effective measure to protect your site from XSS attacks. By whitelisting sources for approved content, you can prevent the browser from loading malicious content.

--- a/fp-plugins/prettyurls/lang/lang.cs-cz.php
+++ b/fp-plugins/prettyurls/lang/lang.cs-cz.php
@@ -7,6 +7,10 @@ $lang ['admin'] ['plugin'] ['submenu'] ['prettyurls'] = 'PrettyURLs Config';
 $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'Nastavení PrettyURLs',
 	'description1' => 'Zde můžete přeměnit standardní adresy URL FlatPressu na krásné adresy URL vhodné pro SEO.',
+	'fpprotect_is_on' => 'Zásuvný modul PrettyURLs vyžaduje soubor .htaccess. ' . //
+		'Chcete-li tento soubor vytvořit nebo změnit, <a href="admin.php?p=plugin&action=default" title="Přejděte do administrace zásuvného modulu">deaktivujte</a> zásuvný modul FlatPress Protect. ',
+	'fpprotect_is_off' => 'Zásuvný modul FlatPress Protect chrání soubor .htaccess před nechtěnými změnami. ' . //
+		'Zásuvný modul můžete aktivovat <a href="admin.php?p=plugin&action=default" title="Přejděte do administrace zásuvného modulu">zde</a>!',
 	'nginx' => 'PrettyURLs se službou NGINX',
 	'wiki_nginx' => 'https://wiki.flatpress.org/res:plugins:prettyurls#nginx',
 	'htaccess' => '.htaccess',

--- a/fp-plugins/prettyurls/lang/lang.da-dk.php
+++ b/fp-plugins/prettyurls/lang/lang.da-dk.php
@@ -8,6 +8,10 @@ $lang ['admin'] ['plugin'] ['submenu'] ['prettyurls'] = 'PrettyURLs';
 $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'PrettyURLs Konfiguration',
 	'description1' => 'Her kan du forvandle FlatPress\' standard-URL\'er til smukke, SEO-venlige URL\'er.',
+	'fpprotect_is_on' => 'PrettyURLs-plugin\'et kræver en .htaccess-fil. ' . //
+		'For at oprette eller ændre denne fil skal du <a href="admin.php?p=plugin&action=default" title="Gå til plugin-administrationen">deaktivere</a> FlatPress Protect-plugin\'et. ',
+	'fpprotect_is_off' => 'FlatPress Protect-plugin\'et beskytter .htaccess-filen mod utilsigtede ændringer. ' . //
+		'Du kan aktivere pluginet <a href="admin.php?p=plugin&action=default" title="Gå til plugin-administrationen">her</a>!',
 	'nginx' => 'PrettyURLs med NGINX',
 	'wiki_nginx' => 'https://wiki.flatpress.org/res:plugins:prettyurls#nginx',
 	'htaccess' => '.htaccess',

--- a/fp-plugins/prettyurls/lang/lang.de-de.php
+++ b/fp-plugins/prettyurls/lang/lang.de-de.php
@@ -8,6 +8,10 @@ $lang ['admin'] ['plugin'] ['submenu'] ['prettyurls'] = 'PrettyURLs';
 $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'PrettyURLs Konfiguration',
 	'description1' => 'Hier kannst du die Standard-URL\'s von FlatPress in schöne, SEO-freundliche URL\'s verwandeln.',
+	'fpprotect_is_on' => 'Das Plugin PrettyURLs benötigt eine .htaccess-Datei. ' . //
+		'Um diese Datei zu erstellen oder zu verändern, <a href="admin.php?p=plugin&action=default" title="gehe zur Plugin Verwaltung">deaktiviere</a> dazu das FlatPress Protect Plugin. ',
+	'fpprotect_is_off' => 'Das FlatPress Protect Plugin schützt die .htaccess Datei vor unbeabsichtigten Änderungen. ' . //
+		'<a href="admin.php?p=plugin&action=default" title="gehe zur Plugin Verwaltung">Hier</a> kannst du das Plugin aktivieren!',
 	'nginx' => 'PrettyURLs mit NGINX',
 	'wiki_nginx' => 'https://wiki.flatpress.org/res:plugins:prettyurls#nginx',
 	'htaccess' => '.htaccess',

--- a/fp-plugins/prettyurls/lang/lang.el-gr.php
+++ b/fp-plugins/prettyurls/lang/lang.el-gr.php
@@ -9,6 +9,10 @@ $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'Διαμόρφωση της PrettyURL',
 	'description1' => 'Εδώ μπορείτε να μετατρέψετε τις τυπικές διευθύνσεις URL του FlatPress σε όμορφες, φιλικές προς το SEO διευθύνσεις URL.',
 	'nginx' => 'PrettyURLs με NGINX',
+	'fpprotect_is_on' => 'Το πρόσθετο PrettyURLs απαιτεί ένα αρχείο .htaccess. ' . //
+		'Για να δημιουργήσετε ή να αλλάξετε αυτό το αρχείο, <a href="admin.php?p=plugin&action=default" title="Μεταβείτε στη διαχείριση του πρόσθετου">απενεργοποιήστε</a> το πρόσθετο FlatPress Protect. ',
+	'fpprotect_is_off' => 'Το πρόσθετο FlatPress Protect προστατεύει το αρχείο .htaccess από ακούσιες αλλαγές. ' . //
+		'Μπορείτε να ενεργοποιήσετε το πρόσθετο <a href="admin.php?p=plugin&action=default" title="Μεταβείτε στη διαχείριση του πρόσθετου">εδώ</a>!',
 	'wiki_nginx' => 'https://wiki.flatpress.org/res:plugins:prettyurls#nginx',
 	'htaccess' => '.htaccess',
 	'description2' => 'Αυτός ο επεξεργαστής σας επιτρέπει να επεξεργαστείτε απευθείας το <code>.htaccess</code> που απαιτείται για το πρόσθετο PrettyUrls.<br>' . //

--- a/fp-plugins/prettyurls/lang/lang.en-us.php
+++ b/fp-plugins/prettyurls/lang/lang.en-us.php
@@ -8,6 +8,10 @@ $lang ['admin'] ['plugin'] ['submenu'] ['prettyurls'] = 'PrettyURLs Config';
 $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'PrettyURLs Configuration',
 	'description1' => 'Here you can turn the standard FlatPress URLs into beautiful, SEO-friendly URLs.',
+	'fpprotect_is_on' => 'The PrettyURLs plugin requires an .htaccess file. ' . //
+		'To create or change this file, <a href="admin.php?p=plugin&action=default" title="Go to the plugin administration">deactivate</a> the FlatPress Protect plugin. ',
+	'fpprotect_is_off' => 'The FlatPress Protect plugin protects the .htaccess file from unintentional changes. ' . //
+		'You can activate the plugin <a href="admin.php?p=plugin&action=default" title="Go to the plugin administration">here</a>!',
 	'nginx' => 'PrettyURLs with NGINX',
 	'wiki_nginx' => 'https://wiki.flatpress.org/res:plugins:prettyurls#nginx',
 	'htaccess' => '.htaccess',

--- a/fp-plugins/prettyurls/lang/lang.es-es.php
+++ b/fp-plugins/prettyurls/lang/lang.es-es.php
@@ -8,6 +8,10 @@ $lang ['admin'] ['plugin'] ['submenu'] ['prettyurls'] = 'Configuración de Prett
 $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'Configuración de PrettyURLs',
 	'description1' => 'Aquí puedes transformar las URLs estándar de FlatPress en URLs bonitas y SEO-friendly.',
+	'fpprotect_is_on' => 'El plugin PrettyURLs requiere un archivo .htaccess. ' . //
+		'Para crear o modificar este archivo, <a href="admin.php?p=plugin&action=default" title="Vaya a la administración del plugin">desactive</a> el plugin FlatPress Protect. ',
+	'fpprotect_is_off' => 'El plugin FlatPress Protect protege el archivo .htaccess de cambios involuntarios. ' . //
+		'Puede activar el plugin <a href="admin.php?p=plugin&action=default" title="Vaya a la administración del plugin">aquí</a>!',
 	'nginx' => 'PrettyURLs con NGINX',
 	'wiki_nginx' => 'https://wiki.flatpress.org/res:plugins:prettyurls#nginx',
 	'htaccess' => '.htaccess',

--- a/fp-plugins/prettyurls/lang/lang.fr-fr.php
+++ b/fp-plugins/prettyurls/lang/lang.fr-fr.php
@@ -8,6 +8,10 @@ $lang ['admin'] ['plugin'] ['submenu'] ['prettyurls'] = 'PrettyURLs Config';
 $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'Configuration de PrettyURLs',
 	'description1' => 'Ici, tu peux transformer les URL standard de FlatPress en de jolies URL adaptées au SEO.',
+	'fpprotect_is_on' => 'Le plugin PrettyURLs nécessite un fichier .htaccess. ' . //
+		'Pour créer ou modifier ce fichier, <a href="admin.php?p=plugin&action=default" title="Va dans la gestion des plugins">désactive</a> le plugin FlatPress Protect. ',
+	'fpprotect_is_off' => 'Le plugin FlatPress Protect protège le fichier .htaccess contre les modifications involontaires. ' . //
+		'Tu peux activer le plugin <a href="admin.php?p=plugin&action=default" title="Va dans la gestion des plugins">ici</a>!',
 	'nginx' => 'PrettyURLs avec NGINX',
 	'wiki_nginx' => 'https://wiki.flatpress.org/res:plugins:prettyurls#nginx',
 	'htaccess' => '.htaccess',

--- a/fp-plugins/prettyurls/lang/lang.it-it.php
+++ b/fp-plugins/prettyurls/lang/lang.it-it.php
@@ -8,6 +8,10 @@ $lang ['admin'] ['plugin'] ['submenu'] ['prettyurls'] = 'Configurazione di Prett
 $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'Configurazione di PrettyURLs',
 	'description1' => 'Qui è possibile trasformare gli URL standard di FlatPress in URL belli e SEO-friendly.',
+	'fpprotect_is_on' => 'Il plugin PrettyURLs richiede un file .htaccess. ' . //
+		'Per creare o modificare questo file, <a href="admin.php?p=plugin&action=default" title="Andate all\'amministrazione del plugin">disattivare</a> il plugin FlatPress Protect. ',
+	'fpprotect_is_off' => 'Il plugin FlatPress Protect protegge il file .htaccess da modifiche involontarie. ' . //
+		'Potete attivare il plugin <a href="admin.php?p=plugin&action=default" title="Andate all\'amministrazione del plugin">qui</a>!',
 	'nginx' => 'PrettyURL con NGINX',
 	'wiki_nginx' => 'https://wiki.flatpress.org/res:plugins:prettyurls#nginx',
 	'htaccess' => '.htaccess',

--- a/fp-plugins/prettyurls/lang/lang.ja-jp.php
+++ b/fp-plugins/prettyurls/lang/lang.ja-jp.php
@@ -8,6 +8,10 @@ $lang ['admin'] ['plugin'] ['submenu'] ['prettyurls'] = 'PrettyURLsの設定';
 $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'PrettyURLsの設定',
 	'description1' => 'FlatPressの標準的なURLを、SEOに配慮した美しいURLに変換することができます。',
+	'fpprotect_is_on' => 'PrettyURLsプラグインには.htaccessファイルが必要です。 ' . //
+		'このファイルを作成または変更するには、FlatPress Protect プラグインを<a href="admin.php?p=plugin&action=default" title="プラグイン管理画面へ">無効にしてください</a>。 ',
+	'fpprotect_is_off' => 'FlatPress Protectプラグインは、.htaccessファイルを意図しない変更から保護します。 ' . //
+		'<a href="admin.php?p=plugin&action=default" title="プラグ</a>イン管理画面へ">プラグインの有効化はこちらから！',
 	'nginx' => 'NGINXによるPrettyURLs',
 	'wiki_nginx' => 'https://wiki.flatpress.org/res:plugins:prettyurls#nginx',
 	'htaccess' => '.htaccess',

--- a/fp-plugins/prettyurls/lang/lang.nl-nl.php
+++ b/fp-plugins/prettyurls/lang/lang.nl-nl.php
@@ -8,6 +8,10 @@ $lang ['admin'] ['plugin'] ['submenu'] ['prettyurls'] = 'PrettyURLs Configuratie
 $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'PrettyURLs Configuratie',
 	'description1' => 'Hier kun je de standaard FlatPress URL\'s omzetten in mooie, SEO-vriendelijke URL\'s.',
+	'fpprotect_is_on' => 'De PrettyURLs plugin heeft een .htaccess bestand nodig. ' . //
+		'Om dit bestand aan te maken of te wijzigen moet je de FlatPress Protect plugin <a href="admin.php?p=plugin&action=default" title="Ga naar de plugin administratie">deactiveren</a>. ',
+	'fpprotect_is_off' => 'De FlatPress Protect plugin beschermt het .htaccess bestand tegen onbedoelde wijzigingen. ' . //
+		'U kunt de plugin <a href="admin.php?p=plugin&action=default" title="Ga naar de plugin administratie">hier</a> activeren!',
 	'nginx' => 'PrettyURLs met NGINX',
 	'wiki_nginx' => 'https://wiki.flatpress.org/res:plugins:prettyurls#nginx',
 	'htaccess' => '.htaccess',

--- a/fp-plugins/prettyurls/lang/lang.pt-br.php
+++ b/fp-plugins/prettyurls/lang/lang.pt-br.php
@@ -8,6 +8,10 @@ $lang ['admin'] ['plugin'] ['submenu'] ['prettyurls'] = 'Configurar PrettyURLs';
 $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'Configurar PrettyURLs',
 	'description1' => 'Aqui, você pode transformar os URLs padrão do FlatPress em URLs bonitos e compatíveis com SEO.',
+	'fpprotect_is_on' => 'O plug-in PrettyURLs requer um arquivo .htaccess. ' . //
+		'Para criar ou alterar esse arquivo, <a href="admin.php?p=plugin&action=default" title="Vá para a administração do plug-in">desative</a> o plug-in FlatPress Protect. ',
+	'fpprotect_is_off' => 'O plug-in FlatPress Protect protege o arquivo .htaccess de alterações não intencionais. ' . //
+		'Você pode ativar o plug-in <a href="admin.php?p=plugin&action=default" title="Vá para a administração do plug-in">aqui</a>!',
 	'nginx' => 'PrettyURLs com NGINX',
 	'wiki_nginx' => 'https://wiki.flatpress.org/res:plugins:prettyurls#nginx',
 	'htaccess' => '.htaccess',

--- a/fp-plugins/prettyurls/lang/lang.ru-ru.php
+++ b/fp-plugins/prettyurls/lang/lang.ru-ru.php
@@ -8,6 +8,10 @@ $lang ['admin'] ['plugin'] ['submenu'] ['prettyurls'] = 'Конфигураци�
 $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'Конфигурация PrettyURLs',
 	'description1' => 'Здесь вы можете превратить стандартные URL из FlatPress в красивые, SEO-дружественные URL.',
+	'fpprotect_is_on' => 'Плагин PrettyURLs требует наличия файла .htaccess. ' . //
+		'Чтобы создать или изменить этот файл, <a href="admin.php?p=plugin&action=default" title="Перейдите в админку плагина">деактивируйте</a> плагин FlatPress Protect. ',
+	'fpprotect_is_off' => 'Плагин FlatPress Protect защищает файл .htaccess от непреднамеренных изменений. ' . //
+		'Вы можете активировать плагин <a href="admin.php?p=plugin&action=default" title="Перейдите в админку плагина">здесь</a>!',
 	'nginx' => 'PrettyURLs с NGINX',
 	'wiki_nginx' => 'https://wiki.flatpress.org/res:plugins:prettyurls#nginx',
 	'htaccess' => '.htaccess',

--- a/fp-plugins/prettyurls/lang/lang.sl-si.php
+++ b/fp-plugins/prettyurls/lang/lang.sl-si.php
@@ -8,6 +8,10 @@ $lang ['admin'] ['plugin'] ['submenu'] ['prettyurls'] = 'Nastavitve PrettyURLs';
 $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'Nastavitve PrettyURLs',
 	'description1' => 'Tu lahko standardne URL-je iz FlatPressa spremenite v čudovite, SEO prijazne URL-je.',
+	'fpprotect_is_on' => 'Vtičnik PrettyURLs zahteva datoteko .htaccess. ' . //
+		'Če želite ustvariti ali spremeniti to datoteko, <a href="admin.php?p=plugin&action=default" title="Pojdite v administracijo vtičnika">deaktivirajte</a> vtičnik FlatPress Protect. ',
+	'fpprotect_is_off' => 'Vtičnik FlatPress Protect ščiti datoteko .htaccess pred nenamernimi spremembami. ' . //
+		'Vtičnik lahko aktivirate <a href="admin.php?p=plugin&action=default" title="Pojdite v administracijo vtičnika">tukaj</a>!',
 	'nginx' => 'PrettyURLs med NGINX',
 	'wiki_nginx' => 'https://wiki.flatpress.org/res:plugins:prettyurls#nginx',
 	'htaccess' => '.htaccess',

--- a/fp-plugins/prettyurls/tpls/admin.plugin.prettyurls.tpl
+++ b/fp-plugins/prettyurls/tpls/admin.plugin.prettyurls.tpl
@@ -1,6 +1,14 @@
 <h2>{$plang.head}</h2>
 <p>{$plang.description1}</p>
 
+{if function_exists('fpprotect_harden_prettyurls_plugin')}
+<p>{$lang.admin.plugin.prettyurls.fpprotect_is_on}</p>
+{/if}
+
+{if not function_exists('fpprotect_harden_prettyurls_plugin')}
+<p>{$lang.admin.plugin.prettyurls.fpprotect_is_off}</p>
+{/if}
+
 {include file="shared:errorlist.tpl"}
 
 


### PR DESCRIPTION
…ess edit field

- The Flatpress Protect plugin is now activated by default
- The PrettyURLs menu now shows that the FlatPress Protect plugin must be deactivated to edit the .htaccess file