### PR TITLE
Removes inline-unsave code | Solves #422

### DIFF
--- a/admin/panels/widgets/admin.widgets.default.php
+++ b/admin/panels/widgets/admin.widgets.default.php
@@ -1,9 +1,10 @@
 <?php
 
 function admin_widgets_head() {
-	global $lang;
+	global $fp_config, $lang;
+	$random_hex = $fp_config ['plugins'] ['fpprotect'] ['random_hex'];
 	echo '
-		<script>
+		<script nonce="' . $random_hex . '">
 			/**
 			 * FlatPress widget js admin
 			 */

--- a/fp-defaults/settings-defaults.php
+++ b/fp-defaults/settings-defaults.php
@@ -43,6 +43,9 @@ $fp_config = array(
 			'akismet_key' => '',
 			'akismet_url' => '',
 		),
+		'fpprotect' => array (
+			'random_hex' => bin2hex(random_bytes(18))
+		),
 	),
 );
 

--- a/fp-plugins/bbcode/res/editor.js
+++ b/fp-plugins/bbcode/res/editor.js
@@ -12,7 +12,7 @@ function insertAtCursor(element, start, end) {
 		}
 		element.focus(caretPos);    
 	} else if (element.selectionStart || element.selectionStart == '0') {
-	    // MOZILLA
+		// MOZILLA
 		element.focus();
 		var startPos = element.selectionStart;
 		var endPos = element.selectionEnd;
@@ -126,8 +126,8 @@ function checkTab(evt) {
 			t.selectionStart = ss + tab.length;
 			t.selectionEnd = se + tab.length;
 		}
-        // "Normal" case (no selection or selection on one line only)
-        else {
+		// "Normal" case (no selection or selection on one line only)
+		else {
 			t.value = t.value.slice(0, ss).concat(tab).concat(t.value.slice(ss, t.value.length));
 			if (ss == se) {
 				t.selectionStart = t.selectionEnd = ss + tab.length;
@@ -136,11 +136,276 @@ function checkTab(evt) {
 				t.selectionStart = ss + tab.length;
 				t.selectionEnd = se + tab.length;
 			}
-        }
-    }
+		}
+	}
 }
 
 if (typeof(Event.observe) == 'function') {
 	//prototype is loaded
 	Event.observe(window, 'load', tabKeyOverrider, false)
+}
+
+/**
+ * Replacement section for href onclick HTML method
+ */
+// url
+if (document.getElementById('bb_url')) {
+	bb_url();
+} else {
+	document.addEventListener('DOMContentLoaded', bb_url);
+}
+function bb_url() {
+	const bb = document.getElementById('bb_url');
+	if (bb) {
+		document.getElementById('bb_url').addEventListener('click', onClick_bb_url, false);
+	}
+}
+function onClick_bb_url() {
+	insBBCode('url');
+}
+
+// mail
+if (document.getElementById('bb_mail')) {
+	bb_mail();
+} else {
+	document.addEventListener('DOMContentLoaded', bb_mail);
+}
+function bb_mail() {
+	const bb = document.getElementById('bb_mail');
+	if (bb) {
+		document.getElementById('bb_mail').addEventListener('click', onClick_bb_mail, false);
+	}
+}
+function onClick_bb_mail() {
+	insBBCode('mail');
+}
+
+// h2
+if (document.getElementById('bb_h2')) {
+	bb_h2();
+} else {
+	document.addEventListener('DOMContentLoaded', bb_h2);
+}
+function bb_h2() {
+	const bb = document.getElementById('bb_h2');
+	if (bb) {
+		document.getElementById('bb_h2').addEventListener('click', onClick_bb_h2, false);
+	}
+}
+function onClick_bb_h2() {
+	insBBCode('h2');
+}
+
+// h3
+if (document.getElementById('bb_h3')) {
+	bb_h3();
+} else {
+	document.addEventListener('DOMContentLoaded', bb_h3);
+}
+function bb_h3() {
+	const bb = document.getElementById('bb_h3');
+	if (bb) {
+		document.getElementById('bb_h3').addEventListener('click', onClick_bb_h3, false);
+	}
+}
+function onClick_bb_h3() {
+	insBBCode('h3');
+}
+
+// h4
+if (document.getElementById('bb_h4')) {
+	bb_h4();
+} else {
+	document.addEventListener('DOMContentLoaded', bb_h4);
+}
+function bb_h4() {
+	const bb = document.getElementById('bb_h4');
+	if (bb) {
+		document.getElementById('bb_h4').addEventListener('click', onClick_bb_h4, false);
+	}
+}
+function onClick_bb_h4() {
+	insBBCode('h4');
+}
+
+// ul
+if (document.getElementById('bb_ul')) {
+	bb_ul();
+} else {
+	document.addEventListener('DOMContentLoaded', bb_ul);
+}
+function bb_ul() {
+	const bb = document.getElementById('bb_ul');
+	if (bb) {
+		document.getElementById('bb_ul').addEventListener('click', onClick_bb_ul, false);
+	}
+}
+function onClick_bb_ul() {
+	insBBCodeWithContent('list', '\n[*]\n[*]\n');
+}
+
+// ol
+if (document.getElementById('bb_ol')) {
+	bb_ol();
+} else {
+	document.addEventListener('DOMContentLoaded', bb_ol);
+}
+function bb_ol() {
+	const bb = document.getElementById('bb_ol');
+	if (bb) {
+		document.getElementById('bb_ol').addEventListener('click', onClick_bb_ol, false);
+	}
+}
+function onClick_bb_ol() {
+	insBBCodeWithParamsAndContent('list', '#', '\n[*]\n[*]\n');
+}
+
+// quote
+if (document.getElementById('bb_quote')) {
+	bb_quote();
+} else {
+	document.addEventListener('DOMContentLoaded', bb_quote);
+}
+function bb_quote() {
+	const bb = document.getElementById('bb_quote');
+	if (bb) {
+		document.getElementById('bb_quote').addEventListener('click', onClick_bb_quote, false);
+	}
+}
+function onClick_bb_quote() {
+	insBBCode('quote');
+}
+
+// code
+if (document.getElementById('bb_code')) {
+	bb_code();
+} else {
+	document.addEventListener('DOMContentLoaded', bb_code);
+}
+function bb_code() {
+	const bb = document.getElementById('bb_code');
+	if (bb) {
+		document.getElementById('bb_code').addEventListener('click', onClick_bb_code, false);
+	}
+}
+function onClick_bb_code() {
+	insBBCode('code');
+}
+
+// html
+if (document.getElementById('bb_html')) {
+	bb_html();
+} else {
+	document.addEventListener('DOMContentLoaded', bb_html);
+}
+function bb_html() {
+	const bb = document.getElementById('bb_html');
+	if (bb) {
+		document.getElementById('bb_html').addEventListener('click', onClick_bb_html, false);
+	}
+}
+function onClick_bb_html() {
+	insBBCode('html');
+}
+
+// b
+if (document.getElementById('bb_b')) {
+	bb_b();
+} else {
+	document.addEventListener('DOMContentLoaded', bb_b);
+}
+function bb_b() {
+	const bb = document.getElementById('bb_b');
+	if (bb) {
+		document.getElementById('bb_b').addEventListener('click', onClick_bb_b, false);
+	}
+}
+function onClick_bb_b() {
+	insBBCode('b');
+}
+
+// i
+if (document.getElementById('bb_i')) {
+	bb_i();
+} else {
+	document.addEventListener('DOMContentLoaded', bb_i);
+}
+function bb_i() {
+	const bb = document.getElementById('bb_i');
+	if (bb) {
+		document.getElementById('bb_i').addEventListener('click', onClick_bb_i, false);
+	}
+}
+function onClick_bb_i() {
+	insBBCode('i');
+}
+
+// u
+if (document.getElementById('bb_u')) {
+	bb_u();
+} else {
+	document.addEventListener('DOMContentLoaded', bb_u);
+}
+function bb_u() {
+	const bb = document.getElementById('bb_u');
+	if (bb) {
+		document.getElementById('bb_u').addEventListener('click', onClick_bb_u, false);
+	}
+}
+function onClick_bb_u() {
+	insBBCode('u');
+}
+
+// del
+if (document.getElementById('bb_del')) {
+	bb_del();
+} else {
+	document.addEventListener('DOMContentLoaded', bb_del);
+}
+function bb_del() {
+	const bb = document.getElementById('bb_del');
+	if (bb) {
+		document.getElementById('bb_del').addEventListener('click', onClick_bb_del, false);
+	}
+}
+function onClick_bb_del() {
+	insBBCode('del');
+}
+
+// contentfield expand-button
+if (document.getElementById('expand')) {
+	bb_expand();
+} else {
+	document.addEventListener('DOMContentLoaded', bb_expand);
+}
+function bb_expand() {
+	const bb = document.getElementById('expand');
+	if (bb) {
+		document.getElementById('expand').addEventListener('click', contentFieldExpand, false);
+	}
+}
+function contentFieldExpand() {
+	const bb = document.getElementById('content');
+	if (bb) {
+		document.getElementById('content').form.content.rows += 5;
+	}
+}
+
+// contentfield reduce-button
+if (document.getElementById('reduce')) {
+	bb_reduce();
+} else {
+	document.addEventListener('DOMContentLoaded', bb_reduce);
+}
+function bb_reduce() {
+	const bb = document.getElementById('reduce');
+	if (bb) {
+		document.getElementById('reduce').addEventListener('click', contentFieldReduce, false);
+	}
+}
+function contentFieldReduce() {
+	const bb = document.getElementById('content');
+	if (bb) {
+		document.getElementById('content').form.content.rows -= 5;
+	}
 }

--- a/fp-plugins/cookiebanner/plugin.cookiebanner.php
+++ b/fp-plugins/cookiebanner/plugin.cookiebanner.php
@@ -20,7 +20,8 @@ add_action('wp_head', 'plugin_cookiebanner_head', 0);
 
 function plugin_cookiebanner_footer() {
 
-	global $lang;
+	global $fp_config, $lang;
+	$random_hex = $fp_config ['plugins'] ['fpprotect'] ['random_hex'];
 	lang_load('plugin:cookiebanner');
 
 	$bannertext = $lang ['plugin'] ['cookiebanner'] ['bannertext'];
@@ -37,7 +38,7 @@ function plugin_cookiebanner_footer() {
 		<!-- EOF Cookie-Banner HTML -->
 
 		<!-- BOF Cookie-Banner JS -->
-		<script>
+		<script nonce="' . $random_hex . '">
 			/**
 			 * Initializes the CookieBanner plugin.
 			 */

--- a/fp-plugins/emoticons/plugin.emoticons.php
+++ b/fp-plugins/emoticons/plugin.emoticons.php
@@ -1,7 +1,7 @@
 <?php
 /*
  * Plugin Name: Emoticons
- * Version: 1.1.0
+ * Version: 1.1.1
  * Plugin URI: https://flatpress.org
  * Description: Allows use of emoticons. Part of the standard distribution.
  * Author: FlatPress
@@ -36,17 +36,54 @@ $plugin_emoticons = array(
 
 // outputs the editor toolbar
 function plugin_emoticons() {
-	global $plugin_emoticons;
-	if (!count($plugin_emoticons))
+	global $fp_config, $plugin_emoticons;
+	$random_hex = $fp_config ['plugins'] ['fpprotect'] ['random_hex'];
+
+	if (!count($plugin_emoticons)) {
 		return true;
-	echo '<div class="emoticons">';
-	foreach ($plugin_emoticons as $text => $emoticon) {
-		echo '<a href="#content" title="' . htmlentities($text) . '" onclick="emoticons(unescape(\'' . urlencode($text) . '\')); return false;">';
-		echo $emoticon;
-		echo '</a> ';
 	}
-	echo '</div>';
+	echo '
+		<!-- BOF Emoticons -->
+		<div class="emoticons">';
+	foreach ($plugin_emoticons as $emoText => $emoticon) {
+
+		$elementById = randomChar(8);
+		echo '
+		<script nonce="' . $random_hex . '">
+			if (document.getElementById(\'' . $elementById . '\')) { // Button already available?
+				BTN_' . $elementById . '(); // Call the registration function
+			} else { // Register as EventHandler
+				document.addEventListener(\'DOMContentLoaded\', BTN_' . $elementById . ');
+			}
+			// Registration function
+			function BTN_' . $elementById . '() {
+				const em = document.getElementById(\'' . $elementById . '\');
+				if (em) {
+					document.getElementById(\'' . $elementById . '\').addEventListener(\'click\', onClick_' . $elementById . ', false);
+				}
+			}
+			// Replacement for href onclick HTML method
+			function onClick_' . $elementById . '() {
+				emoticons(unescape(\'' . urlencode($emoText) . '\')); return false;
+			}
+		</script>
+		<a href="#!" title="' . htmlentities($emoText) . '" id="' . $elementById . '">';
+		echo $emoticon;
+		echo '</a>
+		';
+
+	}
+	echo '
+		</div>
+		<!-- EOF Emoticons -->
+		';
 	return true;
+}
+
+
+// generates a random string for elementById with $length characters
+function randomChar($length = 10) {
+	return substr(str_shuffle(str_repeat(implode('', range('a','z')), $length)), 0, $length);
 }
 
 // replaces the text with an utf-8 emoticon
@@ -66,11 +103,13 @@ function plugin_emoticons_filter ($emostring) {
 
 // css file
 function plugin_emoticons_head() {
+	global $fp_config;
+	$random_hex = $fp_config ['plugins'] ['fpprotect'] ['random_hex'];
 	$pdir = plugin_geturl('emoticons');
 	echo '
 		<!-- BOF Emoticons -->
 		<link rel="stylesheet" type="text/css" href="' . $pdir . 'res/emoticons.css">
-		<script src="' . plugin_geturl('emoticons') . 'res/emoticons.js"></script>
+		<script nonce="' . $random_hex . '" src="' . plugin_geturl('emoticons') . 'res/emoticons.js"></script>
 		<!-- EOF Emoticons -->';
 }
 

--- a/fp-plugins/fpprotect/plugin.fpprotect.php
+++ b/fp-plugins/fpprotect/plugin.fpprotect.php
@@ -7,18 +7,50 @@
  * Version: 1.0
  * Author URI: https://www.flatpress.org
  */
+
 if (function_exists('is_https')) {
 
+	global $fp_config;
+	$random_hex = $fp_config ['plugins'] ['fpprotect'] ['random_hex'];
+
 	if (is_https()) {
-		// Content Security Policy rules for Youtube, Facebook and Vimeo embedded video / BBCode [video], embedded OSM
-		header('Content-Security-Policy: default-src https: data:; frame-src https: data:; base-uri \'self\'; font-src https: data:; script-src https: \'unsafe-inline\' \'unsafe-eval\' blob:; style-src https: \'unsafe-inline\'; img-src https: data: blob:; frame-ancestors \'self\'; manifest-src \'self\'; worker-src \'self\' blob:; connect-src https: blob:; media-src \'self\' blob:; child-src \'self\' blob:; form-action \'self\'; object-src \'self\'');
-		header('X-Content-Security-Policy: default-src https: data:; frame-src https: data:; base-uri \'self\'; font-src https: data:; script-src https: \'unsafe-inline\' \'unsafe-eval\' blob:; style-src https: \'unsafe-inline\'; img-src https: data: blob:; frame-ancestors \'self\'; manifest-src \'self\'; worker-src \'self\' blob:; connect-src https: blob:; media-src \'self\' blob:; child-src \'self\' blob:; form-action \'self\'; object-src \'self\'');
-		header('X-WebKit-CSP: default-src https: data:; frame-src https: data:; base-uri \'self\'; font-src https: data:; script-src https: \'unsafe-inline\' \'unsafe-eval\' blob:; style-src https: \'unsafe-inline\'; img-src https: data: blob:; frame-ancestors \'self\'; manifest-src \'self\'; worker-src \'self\' blob:; connect-src https: blob:; media-src \'self\' blob:; child-src \'self\' blob:; form-action \'self\'; object-src \'self\'');
+		/**
+		 * Content Security Policy rules for Youtube, Facebook and Vimeo embedded video / BBCode [video], embedded OSM '
+		 * https://scotthelme.co.uk/content-security-policy-an-introduction/
+		 */
+		header('Content-Security-Policy: upgrade-insecure-requests; ' . // Is migrating from HTTP to HTTPS, will ensure that all requests will be sent over HTTPS with no fallback to HTTP
+			'default-src \'self\'; ' . // The default-src directive is the default setting for all directives that load additional content such as JavaScript, images, CSS, fonts, AJAX requests, frames and HTML5 media.
+			'frame-src \'self\' https: data:; ' . // Allows iframes from other sources - only via https
+			'base-uri \'self\'; ' . //
+			'font-src \'self\' https: data:; ' . // Allows fonts from other sources (e.g. font awesome) - only via https
+
+			/**
+			 * To make XSS attacks more difficult, remove all inline code in your plugins and templates and remove the “script-src inline-unsave” directive.
+			 * https://content-security-policy.com/nonce/
+			 */
+			'script-src \'self\' \'unsafe-inline\' https:; ' . // Allows the use of inline code such as style attributes, event handler attributes such as onclick and JavaScript code noted in <script> elements
+			//'script-src \'self\' \'nonce-' . $random_hex . '\' https:; ' . // No inline code without nonce-123xyz, no onclick e.t.c, other sources only https
+
+			'style-src \'self\' \'unsafe-inline\' https:; ' . // Defines permitted sources for stylesheets e.g Youtube - only via https
+			'img-src \'self\' https: data:; ' . // Defines permitted sources for images - only via https (e.g. base64-encoded images)
+			'frame-ancestors \'self\' https:; ' . // Defines permitted sources that may have embedded content, such as <frame>, <iframe>, <object>, <embed> and <applet>. 
+			'manifest-src \'self\'; ' . // Specifies the URLs from which video, audio and text track resources can be loaded from
+			'worker-src \'self\' blob:; '. //
+			'connect-src \'self\' https:; ' . // Applies to XMLHttpRequests (AJAX), WebSockets or EventSource - only via https. Otherwise emulate 400 HTTP status code
+			'media-src \'self\' https:; ' . // Defines permitted sources for audio and video, e.g. HTML5 <audio>, <video> elements.
+			'child-src \'self\'; ' . // Defines permitted sources for web workers and nested browsing contexts for elements such as <frame> and <iframe> - only via https
+			'form-action \'self\'; ' . // Defines permitted targets for HTML forms
+			'object-src \'self\' https:'); // Defines permitted sources for plugins, e.g. <object>, <embed> or <applet> - only via https
 
 		// End of Content Security Policy rules
 		header('Permissions-Policy: interest-cohort=(), autoplay=(self), camera=(self), fullscreen=*, geolocation=(self), microphone=(self), payment=()');
 		header('Referrer-Policy: strict-origin-when-cross-origin');
 		header('Strict-Transport-Security: max-age=15552000; includeSubDomains');
+
+		header('Cross-Origin-Embedder-Policy: same-origin');
+		header('Cross-Origin-Opener-Policy: same-origin-allow-popups');
+		header('Cross-Origin-Resource-Policy: same-site');
+
 		header('X-Permitted-Cross-Domain-Policies: none');
 		header('X-Download-Options: noopen');
 	}

--- a/fp-plugins/jquery/plugin.jquery.php
+++ b/fp-plugins/jquery/plugin.jquery.php
@@ -10,11 +10,14 @@
 add_action('wp_head', 'plugin_jquery_head', 0);
 
 function plugin_jquery_head() {
+	global $fp_config;
+	$random_hex = $fp_config ['plugins'] ['fpprotect'] ['random_hex'];
+
 	$pdir = plugin_geturl('jquery');
 	echo '
 		<!-- start of jsUtils -->
-		<script src="' . $pdir . 'res/jquery/3.6.1/jquery-3.6.1.min.js"></script>
-		<script src="' . $pdir . 'res/jqueryui/1.13.2/jquery-ui.min.js"></script>
+		<script nonce="' . $random_hex . '" src="' . $pdir . 'res/jquery/3.6.1/jquery-3.6.1.min.js"></script>
+		<script nonce="' . $random_hex . '" src="' . $pdir . 'res/jqueryui/1.13.2/jquery-ui.min.js"></script>
 		<!-- end of jsUtils -->';
 }
 

--- a/fp-plugins/lightbox2/plugin.lightbox2.php
+++ b/fp-plugins/lightbox2/plugin.lightbox2.php
@@ -26,10 +26,13 @@ function plugin_lightbox2_head() {
 add_action('wp_head', 'plugin_lightbox2_head');
 
 function plugin_lightbox2_footer() {
+	global $fp_config;
+	$random_hex = $fp_config ['plugins'] ['fpprotect'] ['random_hex'];
+
 	$pdir = plugin_geturl('lightbox2');
 	echo '
 		<!-- start of lightbox -->
-		<script src="' . $pdir . 'res/slimbox2.js"></script>
+		<script nonce="' . $random_hex . '" src="' . $pdir . 'res/slimbox2.js"></script>
 		<!-- end of lightbox -->';
 }
 add_action('wp_footer', 'plugin_lightbox2_footer');

--- a/fp-plugins/photoswipe/photoswipefunctions.class.php
+++ b/fp-plugins/photoswipe/photoswipefunctions.class.php
@@ -219,17 +219,19 @@ class PhotoSwipeFunctions {
 	 * Echoes the <script> tags.
 	 */
 	static function echoScriptTags() {
+		global $fp_config;
+		$random_hex = $fp_config ['plugins'] ['fpprotect'] ['random_hex'];
 		$pdir = plugin_geturl('photoswipe');
 		echo '<!-- PhotoSwipe -->
 ';
 		if (!function_exists('plugin_jquery_head')) {
-			echo '<script src="' . $pdir . 'res/jquery-2.2.2/jquery-2.2.2.min.js"></script>
+			echo '<script nonce="' . $random_hex . '" src="' . $pdir . 'res/jquery-2.2.2/jquery-2.2.2.min.js"></script>
 ';
 		}
 		echo '
-	<script src="' . $pdir . 'res/photoswipe-4.1.3/photoswipe-ui-default.min.js"></script>
-	<script src="' . $pdir . 'res/photoswipe-4.1.3/photoswipe.min.js"></script>
-	<script>';
+	<script nonce="' . $random_hex . '" src="' . $pdir . 'res/photoswipe-4.1.3/photoswipe-ui-default.min.js"></script>
+	<script nonce="' . $random_hex . '" src="' . $pdir . 'res/photoswipe-4.1.3/photoswipe.min.js"></script>
+	<script nonce="' . $random_hex . '">';
 		include_once (dirname(__FILE__) . '/res/photoswipe.js.php');
 		echo '
 	</script>


### PR DESCRIPTION
- Emoticons and BBcode plugin no longer requires an inline-unsave source
- Replacement for href onclick HTML method in BBcode-toolbar and Emoticons-Toolbar
- This nonce attribute can be used in plugins, templates and in the admin area to ensure inline code even with stricter CSP version 3

**Description**
Scripts are integrated with a nonce (`<script nonce=“rAnd0m”....`). The hexadecimal value is changed each time the page is called. The variable is located in the array `$fp_config ['plugins'] ['fpprotect'] ['random_hex']` and can be included in templates with `{$fp_config.plugins.fpprotect.random_hex}`.

If required, this nonce can be pushed into the HTML response header as a directive via the FPProtect plugin. The client browser then checks whether a nonce value is stored in the script directive and waves all scripts with the same nonce through as safe.

**Note**
To enable the FlatPress admin to migrate their own plugins and templates, the `self inline-unsave https:` script directive is still active. I recommend completing the migration promptly and activating the default secure script directive to prevent XSS attacks on vulnerabilities in the scripts.