### PR TITLE
BBcode plugin v1.9.0

### DIFF
--- a/fp-plugins/bbcode/lang/lang.cs-cz.php
+++ b/fp-plugins/bbcode/lang/lang.cs-cz.php
@@ -13,12 +13,16 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 	'toolbar' => 'Lišta s nástroji',
 	'toolbar_long' => 'Zapnout upravování pomocí lišty nástrojů.',
 
-	'other'	=> 'Ostatní možnosti',
+	'other' => 'Ostatní možnosti',
 	'comments' => 'Komentáře',
 	'comments_long' => 'Povolit BBCode v komentářích',
 	'urlmaxlen' => 'Maximální délka URL',
 	'urlmaxlen_long_pre' => 'Zkrátit URL delší jako ',
 	'urlmaxlen_long_post' =>' znaků.',
+
+	'attachsdir' => 'Soubory ke stažení',
+	'attachsdir_long' => 'Skrýt adresář pro nahrávání (fp-content/attachs/)',
+
 	'submit' => 'Uložit nastavení',
 	'msgs' => array(
 		1 => 'BBCode configuration successful saved.',
@@ -53,6 +57,18 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 
 $lang ['plugin'] ['bbcode'] = array (
 	'go_to' => 'Přejít na',
-	'langtag' => 'cs_CZ' // language tag for Facebook Video
+
+	// Filewrapper getfille.php
+	'error_403' => 'Chyba 403',
+	'not_send' => 'Požadovaný soubor nelze odeslat.',
+	'error_404' => 'Chyba 404',
+	'not_found' => 'Požadovaný soubor se nepodařilo najít.',
+	'file' => 'Soubor',
+	'report_error_1' => '',
+	'report_error_2' => 'Nahlásit chybu',
+	'blog_search_1' => '',
+	'blog_search_2' => 'Vyhledávání v blogu',
+	'start_page_1' => 'nebo zpět na úvodní',
+	'start_page_2' => 'stránku'
 );
 ?>

--- a/fp-plugins/bbcode/lang/lang.da-dk.php
+++ b/fp-plugins/bbcode/lang/lang.da-dk.php
@@ -13,12 +13,16 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 	'toolbar' => 'Værktøjslinje',
 	'toolbar_long' => 'Aktivér Editor-værktøjslinjen.',
 
-	'other'	=> 'Flere muligheder',
+	'other' => 'Flere muligheder',
 	'comments' => 'Kommentarer',
 	'comments_long' => 'Tillad BBCode i kommentarerne',
 	'urlmaxlen' => 'Maksimal længde af URL-visningen',
 	'urlmaxlen_long_pre' => 'Korte URL\'er, der har mere end ',
 	'urlmaxlen_long_post' =>' tegn.',
+
+	'attachsdir' => 'Download af filer',
+	'attachsdir_long' => 'Skjul upload-bibliotek (fp-content/attachs/)',
+
 	'submit' => 'Gem konfiguration',
 	'msgs' => array(
 		1 => 'BBCode-konfiguration gemt med succes.',
@@ -53,6 +57,18 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 
 $lang ['plugin'] ['bbcode'] = array (
 	'go_to' => 'Gå til',
-	'langtag' => 'da_DK' // language tag for Facebook Video
+
+	// Filewrapper getfille.php
+	'error_403' => 'Fejl 403',
+	'not_send' => 'Den ønskede fil kan ikke sendes.',
+	'error_404' => 'Fejl 404',
+	'not_found' => 'Den ønskede fil kunne ikke findes.',
+	'file' => 'Fil',
+	'report_error_1' => '',
+	'report_error_2' => 'Rapporter fejl',
+	'blog_search_1' => '',
+	'blog_search_2' => 'Søg i bloggen',
+	'start_page_1' => 'eller tilbage til',
+	'start_page_2' => 'startsiden'
 );
 ?>

--- a/fp-plugins/bbcode/lang/lang.de-de.php
+++ b/fp-plugins/bbcode/lang/lang.de-de.php
@@ -13,12 +13,16 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 	'toolbar' => 'Toolbar',
 	'toolbar_long' => 'Editor Toolbar aktivieren.',
 
-	'other'	=> 'Weitere Optionen',
+	'other' => 'Weitere Optionen',
 	'comments' => 'Kommentare',
-	'comments_long' => 'erlaube BBCode in den Kommentaren',
+	'comments_long' => 'Erlaube BBCode in den Kommentaren',
 	'urlmaxlen' => 'Maximale Länge der URL Anzeige',
 	'urlmaxlen_long_pre' => 'Kürze URLs die mehr als ',
 	'urlmaxlen_long_post' =>' Zeichen haben.',
+
+	'attachsdir' => 'Datei-Downloads',
+	'attachsdir_long' => 'Uploadverzeichnis (fp-content/attachs/) verstecken',
+
 	'submit' => 'Konfiguration speichern',
 	'msgs' => array(
 		1 => 'BBCode Konfiguration erfolgreich gespeichert.',
@@ -53,6 +57,18 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 
 $lang ['plugin'] ['bbcode'] = array (
 	'go_to' => 'Gehe zu',
-	'langtag' => 'de_DE' // language tag for Facebook Video
+
+	// Filewrapper getfille.php
+	'error_403' => 'Fehler 403',
+	'not_send' => 'Die angeforderte Datei kann nicht gesendet werden.',
+	'error_404' => 'Fehler 404',
+	'not_found' => 'Die angeforderte Datei konnte nicht gefunden werden.',
+	'file' => 'Datei',
+	'report_error_1' => 'Fehler',
+	'report_error_2' => 'melden',
+	'blog_search_1' => 'im Blog',
+	'blog_search_2' => 'suchen',
+	'start_page_1' => 'oder zurück zur',
+	'start_page_2' => 'Startseite'
 );
 ?>

--- a/fp-plugins/bbcode/lang/lang.el-gr.php
+++ b/fp-plugins/bbcode/lang/lang.el-gr.php
@@ -13,12 +13,16 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 	'toolbar' => 'Μπάρα συντομεύσεων',
 	'toolbar_long' => 'Ενεργοποιείται η μπάρα συντομεύσεων κατά την καταχώρηση.',
 
-	'other'	=> 'Άλλες επιλογές',
+	'other' => 'Άλλες επιλογές',
 	'comments' => 'Σχόλια',
 	'comments_long' => 'Επιτρέπεται η χρήση BBCode στα σχόλια',
 	'urlmaxlen' => 'Μέγιστο μήκος συνδέσμων',
 	'urlmaxlen_long_pre' => 'Σμίκρυνση συνδέσμων μεγαλύτερων από ',
 	'urlmaxlen_long_post'=>' χαρακτήρες.',
+
+	'attachsdir' => 'Λήψεις αρχείων',
+	'attachsdir_long' => 'Απόκρυψη καταλόγου μεταφόρτωσης (fp-content/attachs/)',
+
 	'submit' => 'Αποθήκευση ρύθμισης',
 	'msgs' => array(
 		1 => 'Η ρύθμιση του BBCode αποθηκεύτηκε επιτυχώς.',
@@ -53,6 +57,18 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 
 $lang ['plugin'] ['bbcode'] = array (
 	'go_to' => 'Πηγαίνετε στον',
-	'langtag' => 'el_GR' // language tag for Facebook Video
+
+	// Filewrapper getfille.php
+	'error_403' => 'Σφάλμα 403', // neu
+	'not_send' => 'Το ζητούμενο αρχείο δεν μπορεί να αποσταλεί.', // neu
+	'error_404' => 'Σφάλμα 404', // neu
+	'not_found' => 'Το ζητούμενο αρχείο δεν βρέθηκε.', // neu
+	'file' => 'Αρχείο', // neu
+	'report_error_1' => '', // neu
+	'report_error_2' => 'Αναφορά σφάλματος', // neu
+	'blog_search_1' => '', // neu
+	'blog_search_2' => 'Αναζήτηση στο ιστολόγιο', // neu
+	'start_page_1' => '', // neu
+	'start_page_2' => 'ή πίσω στην αρχική σελίδα' // neu
 );
 ?>

--- a/fp-plugins/bbcode/lang/lang.en-us.php
+++ b/fp-plugins/bbcode/lang/lang.en-us.php
@@ -13,12 +13,16 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 	'toolbar' => 'Toolbar',
 	'toolbar_long' => 'Enable the editor toolbar.',
 
-	'other'	=> 'Other options',
+	'other' => 'Other options',
 	'comments' => 'Comments',
 	'comments_long' => 'Allow BBCode in comments',
 	'urlmaxlen' => 'URL max length',
 	'urlmaxlen_long_pre' => 'Shorten URLs longer than ',
 	'urlmaxlen_long_post' => ' characters.',
+
+	'attachsdir' => 'File downloads',
+	'attachsdir_long' => 'Hide upload directory (fp-content/attachs/)',
+
 	'submit' => 'Save configuration',
 	'msgs' => array(
 		1 => 'BBCode configuration successful saved.',
@@ -37,13 +41,13 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 		'boldtitle' => 'Bold',
 		'italictitle' => 'Italic',
 		'headlinetitle' => 'Headline',
-		'underlinetitle' => 'Unterstreichen',
+		'underlinetitle' => 'Underline',
 		'crossouttitle' => 'Crossed out',
 		'unorderedlisttitle' => 'Unsorted list',
 		'orderedlisttitle' => 'Sorted list',
 		'quotetitle' => 'Quote',
 		'codetitle' => 'Code',
-		'htmltitle' => 'Als HTML-Code einfügen',
+		'htmltitle' => 'Insert as HTML code',
 		'help' => 'BBCode Help',
 		'file' => 'File: ',
 		'image' => 'Image: ',
@@ -53,6 +57,18 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 
 $lang ['plugin'] ['bbcode'] = array (
 	'go_to' => 'Go to',
-	'langtag' => 'en_US' // language tag for Facebook Video
+
+	// Filewrapper getfille.php
+	'error_403' => 'Error 403',
+	'not_send' => 'The requested file cannot be sent.',
+	'error_404' => 'Error 404',
+	'not_found' => 'The requested file could not be found.',
+	'file' => 'File',
+	'report_error_1' => '',
+	'report_error_2' => 'Report error',
+	'blog_search_1' => 'search',
+	'blog_search_2' => 'in the blog',
+	'start_page_1' => 'or back to the',
+	'start_page_2' => 'start page'
 );
 ?>

--- a/fp-plugins/bbcode/lang/lang.es-es.php
+++ b/fp-plugins/bbcode/lang/lang.es-es.php
@@ -19,6 +19,10 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 	'urlmaxlen' => 'Largo máximo del URL',
 	'urlmaxlen_long_pre' => 'Acorte los URL más largos de ',
 	'urlmaxlen_long_post' => ' caracteres.',
+
+	'attachsdir' => 'Descargas de archivos',
+	'attachsdir_long' => 'Ocultar directorio de subida (fp-content/attachs/)',
+
 	'submit' => 'Save configuration',
 	'msgs' => array(
 			1 => 'BBCode configuration successful saved.',
@@ -53,6 +57,18 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 
 $lang ['plugin'] ['bbcode'] = array (
 	'go_to' => 'Ir a',
-	'langtag' => 'es_ES' // language tag for Facebook Video
+
+	// Filewrapper getfille.php
+	'error_403' => 'Error 403',
+	'not_send' => 'El archivo solicitado no puede ser enviado.',
+	'error_404' => 'Error 404',
+	'not_found' => 'No se ha podido encontrar el archivo solicitado.',
+	'file' => 'Archivo',
+	'report_error_1' => '',
+	'report_error_2' => 'Informar de un error', 
+	'blog_search_1' => '',
+	'blog_search_2' => 'buscar en el blog',
+	'start_page_1' => '',
+	'start_page_2' => 'o volver a la página de inicio'
 );
 ?>

--- a/fp-plugins/bbcode/lang/lang.fr-fr.php
+++ b/fp-plugins/bbcode/lang/lang.fr-fr.php
@@ -13,12 +13,16 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 	'toolbar' => 'Barre d\'outils',
 	'toolbar_long' => 'Activer la Barre d\'outils d\'&eacute;dition.',
 
-	'other'	=>'Autres options',
+	'other' =>'Autres options',
 	'comments' => 'Commentaires',
 	'comments_long' => 'Autoriser le BBCode dans les commentaires',
 	'urlmaxlen' => 'Longueur maximum URL',
 	'urlmaxlen_long_pre' => 'Pas plus longue que ',
 	'urlmaxlen_long_post'=>' caract&egrave;res.',
+
+	'attachsdir' => 'Téléchargement de fichiers',
+	'attachsdir_long' => 'Cacher le répertoire de téléchargement (fp-content/attachs/)',
+
 	'submit' => 'Enregistrer la configuration',
 	'msgs' => array(
 		1 => 'Configuration BBCode enregistr&eacute;e avec succ&egrave;s.',
@@ -53,6 +57,18 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 
 $lang ['plugin'] ['bbcode'] = array (
 	'go_to' => 'Aller à',
-	'langtag' => 'fr_FR' // language tag for Facebook Video
+
+	// Filewrapper getfille.php
+	'error_403' => 'Erreur 403', 
+	'not_send' => 'Le fichier demandé ne peut pas être envoyé.',
+	'error_404' => 'Erreur 404',
+	'not_found' => 'Le fichier demandé n\'a pas pu être trouvé.',
+	'file' => 'Fichier',
+	'report_error_1' => '',
+	'report_error_2' => 'Signaler une erreur',
+	'blog_search_1' => '',
+	'blog_search_2' => 'chercher dans le blog',
+	'start_page_1' => 'ou retour',
+	'start_page_2' => 'à la page d\'accueil'
 );
 ?>

--- a/fp-plugins/bbcode/lang/lang.it-it.php
+++ b/fp-plugins/bbcode/lang/lang.it-it.php
@@ -13,12 +13,16 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 	'toolbar' => 'Barra strumenti',
 	'toolbar_long' => 'Abilita la barra strumenti dell\'editor.',
 
-	'other'	=> 'Altre opzioni',
+	'other' => 'Altre opzioni',
 	'comments' => 'Commenti',
 	'comments_long' => 'Consenti di usare BBCode nei commenti',
 	'urlmaxlen' => 'Lunghezza massima degli URL',
 	'urlmaxlen_long_pre' => 'Accorcia gli URL più lunghi di ',
 	'urlmaxlen_long_post'=>' caratteri.',
+
+	'attachsdir' => 'Download di file',
+	'attachsdir_long' => 'Nascondere la directory di upload (fp-content/attachs/)',
+
 	'submit' => 'Salva la configurazione',
 	'msgs' => array(
 		1 => 'La configurazione di BBCode è stata salvata con successo.',
@@ -53,6 +57,18 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 
 $lang ['plugin'] ['bbcode'] = array (
 	'go_to' => 'Vai a',
-	'langtag' => 'it_IT' // language tag for Facebook Video
+
+	// Filewrapper getfille.php
+	'error_403' => 'Errore 403',
+	'not_send' => 'Il file richiesto non può essere inviato.',
+	'error_404' => 'Errore 404',
+	'not_found' => 'Il file richiesto non è stato trovato.',
+	'file' => 'File',
+	'report_error_1' => '',
+	'report_error_2' => 'Segnala errore',
+	'blog_search_1' => '',
+	'blog_search_2' => 'cerca nel blog',
+	'start_page_1' => 'o torna alla',
+	'start_page_2' => 'pagina iniziale'
 );
 ?>

--- a/fp-plugins/bbcode/lang/lang.ja-jp.php
+++ b/fp-plugins/bbcode/lang/lang.ja-jp.php
@@ -13,12 +13,16 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 	'toolbar' => 'ツールバー',
 	'toolbar_long' => '編集ツールバーを有効にする',
 
-	'other'	=> 'その他のオプション',
+	'other' => 'その他のオプション',
 	'comments' => 'コメント',
 	'comments_long' => 'コメント欄でBBCodeの使用できるようにする',
 	'urlmaxlen' => 'URLの最大文字数',
 	'urlmaxlen_long_pre' => '何文字以上のとき短縮URL表示に変換するか：',
 	'urlmaxlen_long_post' => ' 文字',
+
+	'attachsdir' => 'ファイルのダウンロード',
+	'attachsdir_long' => 'アップロードディレクトリを隠す (fp-content/attachs/)',
+
 	'submit' => '設定の変更を保存する',
 	'msgs' => array(
 		1 => 'BBCodeの設定変更を保存しました。',
@@ -53,6 +57,18 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 
 $lang ['plugin'] ['bbcode'] = array (
 	'go_to' => 'へ移動',
-	'langtag' => 'ja_JP' // language tag for Facebook Video
+
+	// Filewrapper getfille.php
+	'error_403' => 'エラー 403',
+	'not_send' => '要求されたファイルは送信できません。',
+	'error_404' => 'エラー 404',
+	'not_found' => '要求されたファイルが見つかりません。',
+	'file' => 'ファイル',
+	'report_error_1' => '',
+	'report_error_2' => 'エラーを報告してください',
+	'blog_search_1' => '',
+	'blog_search_2' => 'ブログ検索',
+	'start_page_1' => '', // neu
+	'start_page_2' => 'またはスタートページに戻る'
 );
 ?>

--- a/fp-plugins/bbcode/lang/lang.nl-nl.php
+++ b/fp-plugins/bbcode/lang/lang.nl-nl.php
@@ -19,6 +19,10 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 	'urlmaxlen' => 'URL max lengte',
 	'urlmaxlen_long_pre' => 'Verkort URL langer dan ',
 	'urlmaxlen_long_post' => ' karakters.',
+
+	'attachsdir' => 'Bestanden downloaden',
+	'attachsdir_long' => 'Uploadmap verbergen (fp-content/attachs/)',
+
 	'submit' => 'Bewaar de configuratie',
 	'msgs' => array(
 		1 => 'BBCode-configuratie succesvol opgeslagen.',
@@ -53,6 +57,18 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 
 $lang ['plugin'] ['bbcode'] = array (
 	'go_to' => 'Ga naar',
-	'langtag' => 'nl_NL' // language tag for Facebook Video
+
+	// Filewrapper getfille.php
+	'error_403' => 'Fout 403',
+	'not_send' => 'Het gevraagde bestand kan niet worden verzonden.',
+	'error_404' => 'Fout 404',
+	'not_found' => 'Het gevraagde bestand kon niet worden gevonden.',
+	'file' => 'Bestand',
+	'report_error_1' => '',
+	'report_error_2' => 'Meld een fout',
+	'blog_search_1' => '',
+	'blog_search_2' => 'zoek in het blog',
+	'start_page_1' => 'of terug naar de',
+	'start_page_2' => 'startpagina'
 );
 ?>

--- a/fp-plugins/bbcode/lang/lang.pt-br.php
+++ b/fp-plugins/bbcode/lang/lang.pt-br.php
@@ -13,12 +13,16 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 	'toolbar' => 'Barra de ferramentas',
 	'toolbar_long' => 'Ativar a barra de ferramentas do editor',
 
-	'other'	=> 'Outras opções',
+	'other' => 'Outras opções',
 	'comments' => 'Comentários',
 	'comments_long' => 'Permitir BBCode nos comentários',
 	'urlmaxlen' => 'comprimento máximo do URL',
 	'urlmaxlen_long_pre' => 'Encurte URLs maiores que ',
 	'urlmaxlen_long_post' => ' caracteres',
+
+	'attachsdir' => 'Downloads de arquivos',
+	'attachsdir_long' => 'Ocultar o diretório de upload (fp-content/attachs/)',
+
 	'submit' => 'Salvar configuração',
 	'msgs' => array(
 		1 => 'Configuração do BBCode salva com sucesso',
@@ -53,6 +57,18 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 
 $lang ['plugin'] ['bbcode'] = array (
 	'go_to' => 'Ir para',
-	'langtag' => 'pt_BR' // language tag for Facebook Video
+
+	// Filewrapper getfille.php
+	'error_403' => 'Erro 403',
+	'not_send' => 'O arquivo solicitado não pode ser enviado.',
+	'error_404' => 'Erro 404',
+	'not_found' => 'O arquivo solicitado não pôde ser encontrado.',
+	'file' => 'Arquivo',
+	'report_error_1' => '',
+	'report_error_2' => 'Relatar um erro',
+	'blog_search_1' => '',
+	'blog_search_2' => 'pesquisar no blog',
+	'start_page_1' => 'ou voltar para a',
+	'start_page_2' => 'página inicial'
 );
 ?>

--- a/fp-plugins/bbcode/lang/lang.ru-ru.php
+++ b/fp-plugins/bbcode/lang/lang.ru-ru.php
@@ -12,12 +12,16 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 	'toolbar' => 'Панель инструментов',
 	'toolbar_long' => 'Включить панель инструментов редактора.',
 
-	'other'	=> 'Другие опции',
+	'other' => 'Другие опции',
 	'comments' => 'Комментарии',
 	'comments_long' => 'Разрешить BBCode в комментариях',
 	'urlmaxlen' => 'Максимальная длина URL-адреса',
 	'urlmaxlen_long_pre' => 'Сокращение URL-адресов, длина которых превышает ',
 	'urlmaxlen_long_post' => ' символов.',
+
+	'attachsdir' => 'Загрузка файлов',
+	'attachsdir_long' => 'Скрыть директорию загрузки (fp-content/attachs/)',
+
 	'submit' => 'Сохранить конфигурацию',
 	'msgs' => array(
 		1 => 'Конфигурация BBCode успешно сохранена.',
@@ -52,6 +56,18 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 
 $lang ['plugin'] ['bbcode'] = array (
 	'go_to' => 'Перейти к',
-	'langtag' => 'ru_RU' // language tag for Facebook Video
+
+	// Filewrapper getfille.php
+	'error_403' => 'Ошибка 403', // neu
+	'not_send' => 'Запрошенный файл не может быть отправлен.', // neu
+	'error_404' => 'Ошибка 404', // neu
+	'not_found' => 'Запрашиваемый файл не может быть найден.', // neu
+	'file' => 'Файл', // neu
+	'report_error_1' => '', // neu
+	'report_error_2' => 'Сообщить об ошибке', // neu
+	'blog_search_1' => '', // neu
+	'blog_search_2' => 'выполнить поиск в блоге', // neu
+	'start_page_1' => 'или вернуться на', // neu
+	'start_page_2' => 'стартовую страницу' // neu
 );
 ?>

--- a/fp-plugins/bbcode/lang/lang.sl-si.php
+++ b/fp-plugins/bbcode/lang/lang.sl-si.php
@@ -19,6 +19,10 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 	'urlmaxlen' => 'Največja dolžina URL',
 	'urlmaxlen_long_pre' => 'Skrati URL-je daljše od ',
 	'urlmaxlen_long_post' => ' znakov.',
+
+	'attachsdir' => 'Prenosi datotek',
+	'attachsdir_long' => 'Skrij imenik za nalaganje (fp-content/attachs/)',
+
 	'submit' => 'Shrani konfiguracijo',
 	'msgs' => array(
 		1 => 'BBCode konfiguracija uspešno shranjena.',
@@ -53,6 +57,18 @@ $lang ['admin'] ['plugin'] ['bbcode'] = array(
 
 $lang ['plugin'] ['bbcode'] = array (
 	'go_to' => 'Pojdi na',
-	'langtag' => 'sl_SI' // Language tag for Facebook Video
+
+	// Filewrapper getfille.php
+	'error_403' => 'Napaka 403',
+	'not_send' => 'Zahtevane datoteke ni mogoče poslati.',
+	'error_404' => 'Napaka 404',
+	'not_found' => 'Zahtevane datoteke ni bilo mogoče najti.',
+	'file' => 'Datoteka',
+	'report_error_1' => '',
+	'report_error_2' => 'Prijavite napako',
+	'blog_search_1' => '',
+	'blog_search_2' => 'iskanje v blogu',
+	'start_page_1' => '',
+	'start_page_2' => 'ali se vrnite na začetno stran'
 );
 ?>

--- a/fp-plugins/bbcode/panels/admin.plugin.panel.bbcode.php
+++ b/fp-plugins/bbcode/panels/admin.plugin.panel.bbcode.php
@@ -13,7 +13,6 @@ if (class_exists('AdminPanelAction')){
 		function setup() {
 			$this->smarty->assign('admin_resource', "plugin:bbcode/admin.plugin.bbcode");
 		}
-		
 		/**
 		 * Setups the default panel.
 		 */
@@ -24,23 +23,27 @@ if (class_exists('AdminPanelAction')){
 			$this->smarty->assign(
 				'bbchecked',
 				array(
-					isset($bbconf['escape-html']) && $bbconf['escape-html']
+					isset($bbconf ['escape-html']) && $bbconf ['escape-html']
 						? 1
 						: 0,
-					isset($bbconf['escape-html']) && $bbconf['comments']
+					isset($bbconf ['escape-html']) && $bbconf ['comments']
 						? 1
 						: 0,
-					isset($bbconf['escape-html']) && $bbconf['editor']
+					isset($bbconf ['escape-html']) && $bbconf ['editor']
 						? 1
 						: 0
 				)
 			);
-			$bbconf['number'] = isset($bbconf['url-maxlen']) && is_numeric($bbconf['url-maxlen'])
-				? $bbconf['url-maxlen']
+
+			$bbconf ['maskattachs'] = isset($bbconf ['maskattachs']) ? $bbconf ['maskattachs']
+						: false;
+
+			$bbconf ['number'] = isset($bbconf ['url-maxlen']) && is_numeric($bbconf ['url-maxlen'])
+				? $bbconf ['url-maxlen']
 				: 40;
 			$this->smarty->assign('bbconf', $bbconf);
 		}
-		
+
 		/**
 		 * Will be executed when the BBCode configuration is send.
 		 *
@@ -51,10 +54,11 @@ if (class_exists('AdminPanelAction')){
 				$maxlen = isset($_POST['bb-maxlen']) && is_numeric($_POST['bb-maxlen'])
 					? (int)$_POST['bb-maxlen']
 					: 40;
-				plugin_addoption('bbcode', 'escape-html', isset($_POST['bb-allow-html']));
-				plugin_addoption('bbcode', 'comments',    isset($_POST['bb-comments']));
-				plugin_addoption('bbcode', 'editor',      isset($_POST['bb-toolbar']));
-				plugin_addoption('bbcode', 'url-maxlen',  $maxlen);
+				plugin_addoption('bbcode', 'escape-html', isset($_POST ['bb-allow-html']));
+				plugin_addoption('bbcode', 'comments', isset($_POST ['bb-comments']));
+				plugin_addoption('bbcode', 'editor', isset($_POST ['bb-toolbar']));
+				plugin_addoption('bbcode', 'maskattachs', isset($_POST ['bb-attachs']));
+				plugin_addoption('bbcode', 'url-maxlen', $maxlen);
 				plugin_saveoptions('bbcode');
 				$this->smarty->assign('success', 1);
 			} else {

--- a/fp-plugins/bbcode/res/editor.js
+++ b/fp-plugins/bbcode/res/editor.js
@@ -10,7 +10,7 @@ function insertAtCursor(element, start, end) {
 			caretPos.moveEnd("character", -end.length);
 			caretPos.select();
 		}
-		element.focus(caretPos);    
+		element.focus(caretPos);
 	} else if (element.selectionStart || element.selectionStart == '0') {
 		// MOZILLA
 		element.focus();
@@ -146,7 +146,7 @@ if (typeof(Event.observe) == 'function') {
 }
 
 /**
- * Replacement section for href onclick HTML method
+ * Replacement section for onclick/ onchange HTML method
  */
 // url
 if (document.getElementById('bb_url')) {
@@ -408,4 +408,36 @@ function contentFieldReduce() {
 	if (bb) {
 		document.getElementById('content').form.content.rows -= 5;
 	}
+}
+
+// file selection
+if (document.getElementById('bb_attach')) {
+	bb_file_selection();
+} else {
+	document.addEventListener('DOMContentLoaded', bb_file_selection);
+}
+function bb_file_selection() {
+	const bb = document.getElementById('bb_attach');
+	if (bb) {
+		document.getElementById('bb_attach').addEventListener('change', onChange_insAttach, false);
+	}
+}
+function onChange_insAttach() {
+	insAttach(this.form.attachselect.value);
+}
+
+// image selection
+if (document.getElementById('bb_image')) {
+	bb_image_selection();
+} else {
+	document.addEventListener('DOMContentLoaded', bb_image_selection);
+}
+function bb_image_selection() {
+	const bb = document.getElementById('bb_image');
+	if (bb) {
+		document.getElementById('bb_image').addEventListener('change', onChange_insImge, false);
+	}
+}
+function onChange_insImge() {
+	insImage(this.form.imageselect.value);
 }

--- a/fp-plugins/bbcode/tpls/admin.plugin.bbcode.tpl
+++ b/fp-plugins/bbcode/tpls/admin.plugin.bbcode.tpl
@@ -11,7 +11,7 @@
 		{$plang.allow_html}
 	</label></dt>
 	<dd> 
-		<p><input type="checkbox" name="bb-allow-html" id="bb-allow-html" {if $bbchecked[0]}checked="checked"{/if}> 
+		<p><input type="checkbox" name="bb-allow-html" id="bb-allow-html" {if $bbchecked[0]}checked{/if}> 
 		{$plang.allow_html_long}</p>
 	</dd>
 
@@ -19,21 +19,30 @@
 		{$plang.toolbar}
 	</label></dt>
 	<dd> 
-		<p><input type="checkbox" name="bb-toolbar" id="bb-toolbar" {if $bbchecked[2]}checked="checked"{/if}>
+		<p><input type="checkbox" name="bb-toolbar" id="bb-toolbar" {if $bbchecked[2]}checked{/if}>
 		{$plang.toolbar_long}</p>
 	</dd>
+
+	<dt><label for="bb-comments">
+		{$plang.comments}
+	</label></dt>
+	<dd> 
+		<p><input type="checkbox" name="bb-comments" id="bb-comments" {if $bbchecked[1]}checked{/if}>
+		{$plang.comments_long} </p>
+	</dd>
+
 </dl>
 
 
 <h2>{$plang.other}</h2>
 
 <dl class="option-list">
-	<dt><label for="bb-comments">
-		{$plang.comments}
+	<dt><label for="bb-attachs">
+		{$plang.attachsdir}
 	</label></dt>
 	<dd> 
-		<p><input type="checkbox" name="bb-comments" id="bb-comments" {if $bbchecked[1]}checked="checked"{/if}>
-		{$plang.comments_long} </p>
+		<p><input type="checkbox" name="bb-attachs" id="bb-attachs" {if $bbconf.maskattachs|default:true}checked{/if}>
+		{$plang.attachsdir_long} </p>
 	</dd>
 
 	<dt><label for="bb-urlmaxlen">

--- a/fp-plugins/bbcode/tpls/toolbar.tpl
+++ b/fp-plugins/bbcode/tpls/toolbar.tpl
@@ -31,10 +31,10 @@
 		&nbsp;
 	</p>
 	<p>
-		{$lang.admin.plugin.bbcode.editor.file}{html_options name=attachselect values=$attachs_list output=$attachs_list onchange="insAttach(this.form.attachselect.value)"}
+		{$lang.admin.plugin.bbcode.editor.file}{html_options name=attachselect values=$attachs_list output=$attachs_list id="bb_attach"}
 		&nbsp;
 	</p>
 	<p>
-		{$lang.admin.plugin.bbcode.editor.image}{html_options name=imageselect values=$images_list output=$images_list onchange="insImage(this.form.imageselect.value)"}
+		{$lang.admin.plugin.bbcode.editor.image}{html_options name=imageselect values=$images_list output=$images_list id="bb_image"}
 	</p>
 </fieldset>

--- a/getfile.php
+++ b/getfile.php
@@ -1,0 +1,94 @@
+<?php
+/*
+ * Plugin Name: BBcode
+ * Module: getfile.php
+ * Function: BBCODE_USE_WRAPPER
+ * Purpose: Mask the path of the attachs dir
+ * Change-Date: 24.08.2024, by Fraenkiman
+ */
+require_once 'defaults.php';
+
+// load language file
+require_once CONFIG_DIR . 'settings.conf.php';
+$langId = $fp_config ['locale'] ['lang'];
+$langFile = ABS_PATH . PLUGINS_DIR . 'bbcode/lang/lang.' . $langId . '.php';
+
+if (!file_exists($langFile)) {
+	$langFile = ABS_PATH . PLUGINS_DIR . 'bbcode/lang/lang.en-us.php';
+	$langId =  'en-us';
+}
+require_once $langFile;
+
+$lang = $lang ['plugin'] ['bbcode'];
+
+/*
+ * Wrapper main part
+ */
+$downloadFile = urldecode($_GET ["f"]);
+
+// make sure the files outside of the download directory are not accessed
+if (startsWith($downloadFile, '..') || startsWith($downloadFile, '/') || substr_count($downloadFile, '..') > 0) {
+	error_403($downloadFile);
+	die;
+}
+
+// files are assumed to be in fp-content/attachs directory
+$download = ABS_PATH . ATTACHS_DIR . $downloadFile;
+
+if (file_exists($download)) {
+
+	// if the file cannot be read show 403 error
+	if (!is_readable($download)) {
+		error_403($langId, $lang, $downloadFile);
+		die;
+	}
+
+	// set some response headers to indicate that a file is being sent
+	header('Content-type: application/force-download');
+	header('Content-disposition: attachment; filename=' . basename($downloadFile));
+	header('Content-Transfer-Encoding: Binary');
+	header('Content-length: ' . filesize($download));
+
+readfile($download); // send file to browser
+
+} else {
+	error_404($langId, $lang, $downloadFile);
+	die;
+}
+
+function startsWith($haystack, $needle) {
+	return !strncmp($haystack, $needle, strlen($needle));
+}
+
+function error_403($langId, $lang, $downloadFile) {
+	header('HTTP/1.0 403 Forbidden');
+	header('Content-type: text/html; charset=utf-8');
+	echo '<!DOCTYPE HTML>' . //
+		'<html xmlns="http://www.w3.org/1999/xhtml" lang="' . $langId . '">' . //
+		'<head><title>' . $lang ['error_403'] . '</title></head>' . //
+		'<body>' . //
+		'<h1>' . $lang ['error_403'] . '</h1>' . //
+		'<p><strong>' . $lang ['not_send'] . '<br>' . $lang ['file'] . ': ' . //
+		'<span style="color:#FF0000">' . $downloadFile . '</span>' . //
+		'</strong></p>' . //
+		'<p><small><span style="color:#9c9c9c">' . $lang ['report_error_1'] . ' <a href="contact.php">' . $lang ['report_error_2'] . '</a>, ' . $lang ['blog_search_1'] . ' <a href="search.php">' . $lang ['blog_search_2'] . '</a> ' . $lang ['start_page_1'] . ' <a href="index.php">' . $lang ['start_page_2'] . '</a> .</span></small></p>' . //
+		'</body>' . //
+		'</html>';
+}
+
+function error_404($langId, $lang, $downloadFile,) {
+	header('HTTP/1.0 404 Not Found');
+	header('Content-type: text/html; charset=utf-8');
+	echo '<!DOCTYPE HTML>' . //
+		'<html xmlns="http://www.w3.org/1999/xhtml" lang="' . $langId . '">' . //
+		'<head><title>' . $lang ['error_404'] . '</title></head>' . //
+		'<body>' . //
+		'<h1>' . $lang ['error_404'] . '</h1>' . //
+		'<p><strong>' . $lang ['not_found'] . '<br>' . $lang ['file'] . ': ' . //
+		'<span style="color:#FF0000">' . $downloadFile . '</span>' . //
+		'</strong></p>' . //
+		'<p><small><span style="color:#9c9c9c">' . $lang ['report_error_1'] . ' <a href="contact.php">' . $lang ['report_error_2'] . '</a>, ' . $lang ['blog_search_1'] . ' <a href="search.php">' . $lang ['blog_search_2'] . '</a> ' . $lang ['start_page_1'] . ' <a href="index.php">' . $lang ['start_page_2'] . '</a> .</span></small></p>' . //
+		'</body>' . //
+		'</html>';
+}
+?>


### PR DESCRIPTION
New function: when using the url tag in combination with a file from the attachments directory, the attachs directory is hidden in the URL. (Idea of NWM and DMKE).

without wrapper
![Screenshot 2024-08-26 221009](https://github.com/user-attachments/assets/4f2b4b8d-2fbb-4636-9833-c2dff0bca7ce)


with wrapper
![Screenshot 2024-08-26 221050](https://github.com/user-attachments/assets/e494657d-3507-4fc3-b16a-f60c4b57ab70)
![Screenshot 2024-08-26 221244](https://github.com/user-attachments/assets/60308099-3174-4943-b9bf-e362d44c9ec0)

- unsave inline onchange html-method removed (file/ image selection)
- Fixes #442