### PR TITLE
Fixes #105 | Anonymize visitor IP

### DIFF
--- a/admin/panels/config/admin.config.php
+++ b/admin/panels/config/admin.config.php
@@ -134,7 +134,8 @@ class admin_config_default extends AdminPanelActionValidated {
 			'theme' => $fp_config ['general'] ['theme'],
 			'style' => @$fp_config ['general'] ['style'],
 			'blogid' => $fp_config ['general'] ['blogid'],
-			'charset' => 'utf-8'
+			'charset' => 'utf-8',
+			'noremoteip' => isset($_POST ['noremoteip'])
 		);
 
 		$fp_config ['locale'] = array(

--- a/admin/panels/config/admin.config.tpl
+++ b/admin/panels/config/admin.config.tpl
@@ -1,5 +1,5 @@
 
-{include file='shared:errorlist.tpl'}
+{include file="shared:errorlist.tpl"}
 
 {html_form}
 
@@ -13,35 +13,32 @@
 	<dl class="option-list">
 	<dt><label for="title"> {$panelstrings.blogtitle} </label></dt>
 	{if isset($error) && isset($error.title) && !empty($error.title)}
-		{assign var=class value=" field-error"}
+		{assign var=class value="field-error"}
 	{else}
 		{assign var=class value=""}
 	{/if}
 	<dd><input type="text" name="title" id="title" class="textinput {$class}" 
-	value="{$flatpress.TITLE|escape:"html"}" />
+	value="{$flatpress.TITLE|escape:"html"}">
 	</dd>
-	
-	
+
 	<dt><label for="subtitle"> {$panelstrings.blogsubtitle} </label></dt>
-	<dd><input type="text" name="subtitle" id="subtitle" class="bigtextinput"  value="{$flatpress.subtitle|escape:"html"}" /></dd>
-	
+	<dd><input type="text" name="subtitle" id="subtitle" class="bigtextinput" value="{$flatpress.subtitle|escape:"html"}"></dd>
+
 	<dt><label for="blogfooter"> {$panelstrings.blogfooter} </label></dt>
-	<dd><input type="text" name="blogfooter" id="blogfooter" class="textinput" value="{$flatpress.footer|escape:"html"}" /></dd>
-	
+	<dd><input type="text" name="blogfooter" id="blogfooter" class="textinput" value="{$flatpress.footer|escape:"html"}"></dd>
+
 	<dt><label for="author"> {$panelstrings.blogauthor} </label></dt>
-	<dd><input type="text" name="author" id="author" class="textinput" value="{$flatpress.author}" /></dd>
-	
-	
+	<dd><input type="text" name="author" id="author" class="textinput" value="{$flatpress.author}"></dd>
+
 	<dt><label for="www"> {$panelstrings.blogurl} </label></dt>
 	{if isset($error) && isset($error.www) && !empty($error.www)}
-		{assign var=class value=" field-error"}
+		{assign var=class value="field-error"}
 	{else}
 		{assign var=class value=""}
 	{/if}
-	<dd><input type="text" name="www" id="www" class="textinput {$class}"
-			value="{$flatpress.www|escape:"html"}" /></dd>
-	
-	
+	<dd><input type="text" name="www" id="www" class="textinput {$class}" 
+	value="{$flatpress.www|escape:"html"}"></dd>
+
 	<dt><label for="email"> {$panelstrings.blogemail} </label></dt>
 	{if isset($error) && isset($error.email) && !empty($error.email)}
 		{assign var=class value="field-error"}
@@ -49,16 +46,15 @@
 		{assign var=class value=""}
 	{/if}
 	<dd><input type="text" name="email" id="email" class="textinput {$class}" 
-	value="{$flatpress.email}" /></dd>
-	
+	value="{$flatpress.email}"></dd>
+
 	<dt><label> {$panelstrings.notifications} </label></dt>
-	<dd> 
-	<label for="notify"> 
-	<input type="checkbox" name="notify" id="notify" {if $flatpress.NOTIFY}checked="checked"{/if} /> 
+	<dd><label for="notify"> 
+	<input type="checkbox" name="notify" id="notify"{if $flatpress.NOTIFY} checked{/if}> 
 	{$panelstrings.mailnotify}
-	</label> 
+	</label>
 	</dd>
-	
+
 	<dt><label for="startpage"> {$panelstrings.startpage} </label></dt>
 	<dd><select name="startpage" id="startpage" class="textinput">
 		<option value=":NULL:">
@@ -71,7 +67,7 @@
 	{/foreach}
 	</select>
 	</dd>
-	
+
 	<dt><label for="maxentries"> {$panelstrings.blogmaxentries} </label></dt>
 	{if isset($error) && isset($error.maxentries) && !empty($error.maxentries)}
 		{assign var=class value="field-error"}
@@ -79,33 +75,38 @@
 		{assign var=class value=""}
 	{/if}
 	<dd><input type="text" name="maxentries" id="maxentries" 
-	class="smalltextinput{$class}" value="{$flatpress.maxentries}" /></dd>
-	
-	
+	class="smalltextinput{$class}" value="{$flatpress.maxentries}"></dd>
+
+	<dt><label>{$panelstrings.visitor_ip}</label></dt>
+	<dd><label for="noremoteip">
+	<input type="checkbox" name="noremoteip" id="noremoteip"{if $flatpress.noremoteip} checked{/if}>
+	{$panelstrings.use_anonym_ip}
+	</label>
+	</dd>
+
 	</dl>
 
 </div>
 
 <div id="admin-config-intsetts">
 
-<h2> {$panelstrings.intsetts}  </h2>
+<h2>{$panelstrings.intsetts}</h2>
 
 	<dl class="option-list">
 		<dt><label> {$panelstrings.utctime} </label></dt>
 		{assign var=temp_time value="%b %d %Y %H:%M:%S"}
 		<dd> <code> {"r"|date:$smarty.now} </code> </dd>
-		
+
 		<dt><label for="timeoffset"> {$panelstrings.timeoffset} </label></dt>
 		{if isset($error) && isset($error.timeoffset) && !empty($error.timeoffset)}
-			{assign var=class value=" field-error"}
+			{assign var=class value="field-error"}
 		{else}
 			{assign var=class value=""}
 		{/if}
 		<dd><input type="text" name="timeoffset" id="timeoffset" 
 			class="smalltextinput{$class}" 
-			value="{$fp_config.locale.timeoffset}" /><p class="text"> {$panelstrings.hours} </p>
+			value="{$fp_config.locale.timeoffset}"><p class="text"> {$panelstrings.hours} </p>
 		</dd>
-
 
 		<dt><label for="dateformat"> {$panelstrings.dateformat} </label></dt>
 		{if isset($error) && isset($error.dateformat) && !empty($error.dateformat)}
@@ -113,22 +114,22 @@
 		{else}
 			{assign var=class value=""}
 		{/if}
-		<dd>	<p> <input type="text" name="dateformat" id="dateformat" 
+		<dd><p> <input type="text" name="dateformat" id="dateformat" 
 			class="textinput{$class}" 
-			value="{$fp_config.locale.dateformat}" /> </p>
-			<p class="output"> {$panelstrings.output}:   {$smarty.now|date_format:$fp_config.locale.dateformat}</p>
+			value="{$fp_config.locale.dateformat}"> </p>
+			<p class="output"> {$panelstrings.output}:  {$smarty.now|date_format:$fp_config.locale.dateformat}</p>
 		</dd>
 
 		<dt><label for="dateformatshort"> {$panelstrings.dateformatshort} </label></dt>
 		{if isset($error) && isset($error.dateformatshort) && !empty($error.dateformatshort)}
-			{assign var=class value=" field-error"}
+			{assign var=class value="field-error"}
 		{else}
 			{assign var=class value=""}
 		{/if}
-		<dd>	<p> <input type="text" name="dateformatshort" id="dateformatshort" 
+		<dd><p> <input type="text" name="dateformatshort" id="dateformatshort" 
 			class="textinput{$class}" 
-			value="{$fp_config.locale.dateformatshort}" /> </p>
-			<p class="output"> {$panelstrings.output}:   {$smarty.now|date_format:$fp_config.locale.dateformatshort}</p>
+			value="{$fp_config.locale.dateformatshort}"> </p>
+			<p class="output"> {$panelstrings.output}:  {$smarty.now|date_format:$fp_config.locale.dateformatshort}</p>
 		</dd>
 
 		<dt><label for="timeformat"> {$panelstrings.timeformat} </label></dt>
@@ -137,18 +138,17 @@
 		{else}
 			{assign var=class value=""}
 		{/if}
-		<dd>	<p> <input type="text" name="timeformat" id="timeformat" 
+		<dd><p> <input type="text" name="timeformat" id="timeformat" 
 			class="textinput{$class}" 
-			value="{$fp_config.locale.timeformat}" /> </p>
+			value="{$fp_config.locale.timeformat}"> </p>
 			{assign var=currentTime value=$smarty.now}
 			{assign var=timeDiff value=$fp_config.locale.timeoffset}
 			{assign var=TimeDiffUTC value=$currentTime+$timeDiff*3600}
 			<p class="output"> {$panelstrings.output}:  {$TimeDiffUTC|date_format:$fp_config.locale.timeformat}</p>
 		</dd>
 
-	
 		<dt><label for="lang"> {$panelstrings.langchoice} </label></dt>
-		<dd>	
+		<dd>
 		<select name="lang" id="lang" class="textinput">
 		{foreach from=$lang_list item=langsetts}
 			<option value="{$langsetts.locale}" 
@@ -158,7 +158,7 @@
 		{/foreach}
 		</select>
 		</dd>
-		
+
 		<dt> <label for="charset"> {$panelstrings.charset} </label></dt>
 		{if isset($error) && isset($error.charset) && !empty($error.charset)}
 			{assign var=class value="field-error"}
@@ -167,10 +167,9 @@
 		{/if}
 		<dd> <p><input type="text" name="charset" id="charset" 
 			class="smalltextinput{$class}" 
-			value="{$fp_config.locale.charset}" /></p>
+			value="{$fp_config.locale.charset}"></p>
 			<p class="output">{$panelstrings.charsettip}</p>
 		</dd>
-	
 
 	</dl>
 

--- a/fp-defaults/settings-defaults.php
+++ b/fp-defaults/settings-defaults.php
@@ -13,7 +13,8 @@ $fp_config = array(
 		'theme' => 'leggero',
 		'style' => 'leggero-v2',
 		'blogid' => 'fpdefid',
-		'charset' => 'utf-8'
+		'charset' => 'utf-8',
+		'noremoteip' => true
 	),
 	'locale' => array(
 		'timeoffset' => '2',

--- a/fp-interface/lang/cs-cz/lang.admin.config.php
+++ b/fp-interface/lang/cs-cz/lang.admin.config.php
@@ -24,6 +24,8 @@ $lang ['admin'] ['config'] ['default'] = array(
 	'notifications' => 'Oznámení',
 	'mailnotify' => 'Zasílat upozornění o komentářích na email',
 	'blogmaxentries' => 'Počet příspěvků na stránku',
+	'visitor_ip' => 'IP adresa návštěvníka', //
+	'use_anonym_ip' => 'FlatPress by měl anonymizovat IP adresu návštěvníka', //
 	'langchoice' => 'Jazyk',
 
 	'intsetts' => 'Mezinárodní nastavení',

--- a/fp-interface/lang/da-dk/lang.admin.config.php
+++ b/fp-interface/lang/da-dk/lang.admin.config.php
@@ -24,6 +24,8 @@ $lang ['admin'] ['config'] ['default'] = array(
 	'notifications' => 'Meddelelser',
 	'mailnotify' => 'Aktivér e-mailnotifikation for nye kommentarer',
 	'blogmaxentries' => 'Antal indlæg pr. side',
+	'visitor_ip' => 'Den besøgendes IP',
+	'use_anonym_ip' => 'FlatPress bør anonymisere den besøgendes IP',
 	'langchoice' => 'Sprog',
 
 	'intsetts' => 'Internationale indstillinger',

--- a/fp-interface/lang/de-de/lang.admin.config.php
+++ b/fp-interface/lang/de-de/lang.admin.config.php
@@ -3,14 +3,14 @@ $lang ['admin'] ['config'] ['default'] = array(
 	'head' => 'Konfiguration',
 	'descr' => 'FlatPress konfigurieren und anpassen.',
 	'submit' => 'Einstellungen übernehmen',
-	
+
 	'sysfset' => 'Allgemeine Einstellungen',
 	'syswarning' => '<big>Warnung!</big> Diese Einstellungen sollten sorgfältig eingegeben werden, sonst könnte FlatPress nicht richtig funktionieren.',
 	'blog_root' => '<strong>Absoluter Pfad zu FlatPress</strong>. Hinweis: ' . //
 		'Normalerweise muss hier nichts geändert werden. FlatPress bietet keine interne Funktion um eventuelle Änderungen von sich aus zu prüfen.',
 	'www' => '<strong>Blog Root</strong>. URL deines Blogs mit Angabe des Verzeichnisses.<br>' . //
 		'Beispiel: http://www.mydomain.com/flatpress/ (abschließender Slash wird benötigt)',
-		
+
 	// ------
 	'gensetts' => 'Grundlegende Einstellungen',
 	'blogtitle' => 'Blog Titel',
@@ -24,6 +24,8 @@ $lang ['admin'] ['config'] ['default'] = array(
 	'notifications' => 'Benachrichtigungen',
 	'mailnotify' => 'Aktiviere E-Mail Benachrichtigung bei neuen Kommentaren',
 	'blogmaxentries' => 'Anzahl der Beiträge pro Seite',
+	'visitor_ip' => 'IP des Besuchers',
+	'use_anonym_ip' => 'FlatPress soll die IP des Besuchers anonymisieren',
 	'langchoice' => 'Sprache',
 
 	'intsetts' => 'Internationale Einstellungen',

--- a/fp-interface/lang/el-gr/lang.admin.config.php
+++ b/fp-interface/lang/el-gr/lang.admin.config.php
@@ -24,6 +24,8 @@ $lang ['admin'] ['config'] ['default'] = array(
 	'notifications' => 'Ειδοποιήσεις',
 	'mailnotify' => 'Ενεργοποίηση ειδοποιήσεων για νέα σχόλια',
 	'blogmaxentries' => 'Αριθμός δημοσιεύσεων ανά σελίδα',
+	'visitor_ip' => 'IP του επισκέπτη',
+	'use_anonym_ip' => 'Η FlatPress θα πρέπει να ανωνυμοποιεί την IP του επισκέπτη',
 	'langchoice' => 'Γλώσσα',
 
 	'intsetts' => 'Ρυθμίσεις εντοπιότητας',

--- a/fp-interface/lang/en-us/lang.admin.config.php
+++ b/fp-interface/lang/en-us/lang.admin.config.php
@@ -24,6 +24,8 @@ $lang ['admin'] ['config'] ['default'] = array(
 	'notifications' => 'Notifications',
 	'mailnotify' => 'Enable email notification for comments',
 	'blogmaxentries' => 'Number of posts per page',
+	'visitor_ip' => 'IP of the visitor',
+	'use_anonym_ip' => 'FlatPress should anonymize the IP of the visitor',
 	'langchoice' => 'Language',
 
 	'intsetts' => 'International settings',

--- a/fp-interface/lang/es-es/lang.admin.config.php
+++ b/fp-interface/lang/es-es/lang.admin.config.php
@@ -24,6 +24,8 @@ $lang ['admin'] ['config'] ['default'] = array(
 	'notifications' => 'Notificaciones',
 	'mailnotify' => 'Habilitar notificación por correo electrónico de los comentarios',
 	'blogmaxentries' => 'Número de publicaciones por página',
+	'visitor_ip' => 'IP del visitante',
+	'use_anonym_ip' => 'FlatPress debe anonimizar la IP del visitante',
 	'langchoice' => 'Idioma',
 
 	'intsetts' => 'Configuración internacional',

--- a/fp-interface/lang/fr-fr/lang.admin.config.php
+++ b/fp-interface/lang/fr-fr/lang.admin.config.php
@@ -24,6 +24,8 @@ $lang ['admin'] ['config'] ['default'] = array(
 	'notifications' => 'Notifications',
 	'mailnotify' => 'Activer les notifications par email pour les commentaires',
 	'blogmaxentries' => 'Nombre de sujets par page',
+	'visitor_ip' => 'IP du visiteur',
+	'use_anonym_ip' => 'FlatPress doit anonymiser l\'IP du visiteur',
 	'langchoice' => 'Langage',
 
 	'intsetts' => 'R&eacute;glages Internationaux',

--- a/fp-interface/lang/it-it/lang.admin.config.php
+++ b/fp-interface/lang/it-it/lang.admin.config.php
@@ -24,6 +24,8 @@ $lang ['admin'] ['config'] ['default'] = array(
 	'notifications' => 'Notifiche',
 	'mailnotify' => 'Abilita le notifiche via email per i commenti',
 	'blogmaxentries' => 'Numero di articoli per pagina',
+	'visitor_ip' => 'IP del visitatore',
+	'use_anonym_ip' => 'FlatPress dovrebbe anonimizzare l\'IP del visitatore',
 	'langchoice' => 'Lingua',
 
 	'intsetts' => 'Impostazioni internazionali',

--- a/fp-interface/lang/ja-jp/lang.admin.config.php
+++ b/fp-interface/lang/ja-jp/lang.admin.config.php
@@ -24,6 +24,8 @@ $lang ['admin'] ['config'] ['default'] = array(
 	'notifications' => '通知設定',
 	'mailnotify' => 'コメントがつくとメールで通知する。',
 	'blogmaxentries' => 'ブログの1ページに表示する記事数',
+	'visitor_ip' => '訪問者のIP',
+	'use_anonym_ip' => 'FlatPressは訪問者のIPを匿名化すべきである',
 	'langchoice' => '言語の選択',
 
 	'intsetts' => 'ローカルの設定',

--- a/fp-interface/lang/nl-nl/lang.admin.config.php
+++ b/fp-interface/lang/nl-nl/lang.admin.config.php
@@ -24,6 +24,8 @@ $lang ['admin'] ['config'] ['default'] = array(
 	'notifications' => 'Notificaties',
 	'mailnotify' => 'E-mailmelding inschakelen voor opmerkingen',
 	'blogmaxentries' => 'Aantal berichten per pagina',
+	'visitor_ip' => 'IP van de bezoeker',
+	'use_anonym_ip' => 'FlatPress moet het IP-adres van de bezoeker anonimiseren',
 	'langchoice' => 'Taal',
 
 	'intsetts' => 'Internationale instellingen',

--- a/fp-interface/lang/pt-br/lang.admin.config.php
+++ b/fp-interface/lang/pt-br/lang.admin.config.php
@@ -24,6 +24,8 @@ $lang ['admin'] ['config'] ['default'] = array(
 	'notifications' => 'Notificações',
 	'mailnotify' => 'Ative notificações por email para comentários.',
 	'blogmaxentries' => 'Número de posts por página',
+	'visitor_ip' => 'IP do visitante',
+	'use_anonym_ip' => 'O FlatPress deve tornar anônimo o IP do visitante',
 	'langchoice' => 'Idioma',
 
 	'intsetts' => 'Configurações internacionais',

--- a/fp-interface/lang/ru-ru/lang.admin.config.php
+++ b/fp-interface/lang/ru-ru/lang.admin.config.php
@@ -24,6 +24,8 @@ $lang ['admin'] ['config'] ['default'] = array(
 	'notifications' => 'Уведомления',
 	'mailnotify' => 'Включить уведомление о комментариях по электронной почте',
 	'blogmaxentries' => 'Количество постов на странице',
+	'visitor_ip' => 'IP-адрес посетителя',
+	'use_anonym_ip' => 'FlatPress должен анонимизировать IP посетителя',
 	'langchoice' => 'Язык',
 
 	'intsetts' => 'Международные параметры',

--- a/fp-interface/lang/sl-si/lang.admin.config.php
+++ b/fp-interface/lang/sl-si/lang.admin.config.php
@@ -24,6 +24,8 @@ $lang ['admin'] ['config'] ['default'] = array(
 	'notifications' => 'Obvestila',
 	'mailnotify' => 'Omogoči obvestila prek e-pošte za komentarje',
 	'blogmaxentries' => 'Število prispevkov na stran',
+	'visitor_ip' => 'IP obiskovalca',
+	'use_anonym_ip' => 'FlatPress mora anonimizirati IP obiskovalca',
 	'langchoice' => 'Jezik',
 
 	'intsetts' => 'Mednarodne Nastavitve',


### PR DESCRIPTION
## FlatPress can anonymize the visitor's IP address
 * For IPv4 addresses, the last two blocks are “zeroed”
 * IPv6 addresses are replaced by a hash, which is formed from the user agent and the browser language

![Screenshot 2024-08-28 034225](https://github.com/user-attachments/assets/8efbb2f5-029b-4db4-bf33-7454d84c45a1)

This procedure has the advantage that other scripts do not have to be adapted, as a fake IPv4 or IPv6 is still available. Optionally, the anonymization of the visitor IP can be deactivated in the admin area.

![Screenshot 2024-08-28 034152](https://github.com/user-attachments/assets/08afd0c7-44cf-4dbd-a9cf-2ec87b9c3032)

