### PR TITLE
Comment filters act according to priority, not alphabetically

### DIFF
--- a/fp-plugins/commentcenter/plugin.commentcenter.php
+++ b/fp-plugins/commentcenter/plugin.commentcenter.php
@@ -34,7 +34,7 @@ class plugin_commentcenter {
 		add_filter('comment_validate', array(
 			&$this,
 			'validate'
-		), 5, 2);
+		), 10, 2);
 		$this->pl_dir = FP_CONTENT . 'plugin_commentcenter/';
 		if (!file_exists($this->pl_dir)) {
 			fs_mkdir($this->pl_dir);

--- a/fp-plugins/qspam/plugin.qspam.php
+++ b/fp-plugins/qspam/plugin.qspam.php
@@ -52,7 +52,7 @@ function plugin_qspam_validate($bool, $contents) {
 	}
 	return true;
 }
-add_action('comment_validate', 'plugin_qspam_validate', 5, 2);
+add_filter('comment_validate', 'plugin_qspam_validate', 5, 2);
 
 if (class_exists('AdminPanelAction')) {
 


### PR DESCRIPTION
- Fixes the problem that other comment filters do not work if the corresponding plugins are loaded alphabetically.

Discovered by [Ross Fruen](https://www.gsys.biz/blog/reducing-priority-of-flatpress-comment-center/) and [broken down](https://www.robertriebisch.de/2022/05/flatpress-nachschlag-zum-kommentarspam) by @bttrx

With this fix, comments filtered by the QuickSpam plugin are immediately rejected and do not have to be manually rejected by the FP admin in the comment center.