### PR TITLE
Fixes the bug: Can only throw objects

### DIFF
--- a/fp-includes/core/core.date.php
+++ b/fp-includes/core/core.date.php
@@ -140,7 +140,8 @@ function strftime_replacement(string $format, $timestamp = null, ?string $locale
 		$timestamp = date_create('@' . $timestamp);
 
 		if ($timestamp) {
-			$timestamp->setTimezone(new \DateTimezone(date_default_timezone_get()));
+			$timezone = date_default_timezone_get() ?: 'UTC';
+			$timestamp->setTimezone(new \DateTimezone($timezone));
 		}
 	} elseif (is_string($timestamp)) {
 		$timestamp = date_create($timestamp);

--- a/fp-includes/core/core.theme.php
+++ b/fp-includes/core/core.theme.php
@@ -361,7 +361,7 @@ function theme_smarty_modifier_date_format_daily($string, $format = null, $defau
  */
 function theme_smarty_modifier_date_rfc3339($timestamp = '') {
 	if (!$timestamp) {
-		$timestamp = time();
+		$timestamp = date_time();
 	}
 
 	$date = date('Y-m-d\TH:i:s', $timestamp);


### PR DESCRIPTION
**Improvements:**

- The strftime_replacement function now correctly throws objects of type Exception Error.

- The combination of format, time zone and locale is now cached to reduce IntlDateFormatter objects and save memory.
Before `new \DateTimeZone($timezone)` is called, it is checked whether the time zone passed is contained in the list of valid time zones (`\DateTimeZone::listIdentifiers()`). If not, the time zone is set to 'UTC' to ensure that no error occurs.
- It is now ensured that no infinite loop is created in the callback function for `preg_replace_callback()` and that invalid or unhandled format characters are properly intercepted.
- If no timestamp (0, null invalid) is passed to the `date_strformat` function, the timestamp is determined using the `date_time function`.
- In the `theme_smarty_modifier_date_rfc3339` function (RSS/Atom feed), date, time with time offset is now used.
