### PR TITLE
Update FlatPress Protect plugin to v1.1.0 | PrettyURLs plugin to v3.0.1

### DIFF
--- a/admin/main.php
+++ b/admin/main.php
@@ -168,6 +168,7 @@ function admin_register_smartyplugins() {
 	global $smarty;
 	$smarty->registerPlugin('modifier', 'action_link', 'admin_filter_action');
 	$smarty->registerPlugin('modifier', 'cmd_link', 'admin_filter_command');
+	$smarty->registerPlugin('modifier', 'fpprotect_harden_prettyurls_plugin', 'fpprotect_harden_prettyurls_plugin');
 	$functionsToRegister = array(
 		// FlatPress functions
 		'entry_idtotime',

--- a/fp-defaults/settings-defaults.php
+++ b/fp-defaults/settings-defaults.php
@@ -48,6 +48,10 @@ $fp_config = array(
 			'akismet_key' => '',
 			'akismet_url' => '',
 		),
+		'fpprotect' => array (
+			'allowUnsafeInline' => false,
+			'allowPrettyURLEdit' => false,
+		),
 	),
 );
 

--- a/fp-plugins/fpprotect/lang/lang.cs-cz.php
+++ b/fp-plugins/fpprotect/lang/lang.cs-cz.php
@@ -1,0 +1,34 @@
+<?php
+$lang ['admin'] ['config'] ['submenu'] ['fpprotect'] = 'FlatPress Protect';
+
+$lang ['admin'] ['config'] ['fpprotect'] = array(
+	'head' => 'Nastavení aplikace FlatPress Protect',
+	'desc1' => 'Zde můžete změnit možnosti zabezpečení blogu FlatPress.',
+
+	// Part for unsafe inline scripts
+	'allow_unsafe_inline' => 'Povolit nezabezpečené Java skripty (Nedoporučuje se)',
+
+	'allowUnsafeInlineDsc' => '<p>Povolí načítání nezabezpečeného inline kódu JavaScriptu.</p>' . //
+		'<p><br>Poznámka pro vývojáře zásuvných modulů: Přidejte prosím do svého Java skriptu nonce.</p>' . //
+		'Příklad pro PHP:
+		<pre>$random_hex = RANDOM_HEX;
+' . //
+		'... script nonce="\' . $random_hex . \'" src=" ...' . //
+		'</pre>' . //
+		'Příklad pro šablonu Smarty:
+		<pre>' . //
+		'... script nonce="{$smarty.const.RANDOM_HEX}" ...' . //
+		'</pre>' . //
+		'<p>Tím zajistíte, že prohlížeč návštěvníka spustí pouze skripty Java, které pocházejí z vašeho blogu FlatPress.</p>',
+
+	// Part for the PrettyURLs .htaccess edit-field
+	'allow_htaccess_edit' => 'Umožňuje vytvoření a úpravu souboru .htaccess.',
+	'allowPrettyURLEditDsc' => 'Umožňuje přístup k editačnímu poli .htaccess zásuvného modulu PrettyURLs pro vytvoření nebo úpravu souboru .htaccess.',
+
+	'submit' => 'Uložení nastavení',
+		'msgs' => array(
+		1 => 'Nastavení bylo úspěšně uloženo.',
+		-1 => 'Chyba při ukládání nastavení.'
+	)
+);
+?>

--- a/fp-plugins/fpprotect/lang/lang.da-dk.php
+++ b/fp-plugins/fpprotect/lang/lang.da-dk.php
@@ -1,0 +1,34 @@
+<?php
+$lang ['admin'] ['config'] ['submenu'] ['fpprotect'] = 'FlatPress Protect';
+
+$lang ['admin'] ['config'] ['fpprotect'] = array(
+	'head' => 'FlatPress Protect-indstillinger',
+	'desc1' => 'Her kan du ændre sikkerhedsrelaterede indstillinger for din FlatPress-blog.',
+
+	// Part for unsafe inline scripts
+	'allow_unsafe_inline' => 'Tillad usikre Java-scripts (anbefales ikke)',
+
+	'allowUnsafeInlineDsc' => '<p>Tillader indlæsning af usikker inline JavaScript-kode.</p>' . //
+		'<p><br>Bemærkning til plugin-udviklere: Tilføj venligst en nonce til dit Java-script.</p>' . //
+		'Et eksempel til PHP:
+		<pre>$random_hex = RANDOM_HEX;
+' . //
+		'... script nonce="\' . $random_hex . \'" src=" ...' . //
+		'</pre>' . //
+		'Et eksempel for Smarty-skabelonen:
+		<pre>' . //
+		'... script nonce="{$smarty.const.RANDOM_HEX}" ...' . //
+		'</pre>' . //
+		'<p>Dette sikrer, at den besøgendes browser kun udfører Java-scripts, der stammer fra din FlatPress-blog.</p>',
+
+	// Part for the PrettyURLs .htaccess edit-field
+	'allow_htaccess_edit' => 'Tillad oprettelse og redigering af .htaccess-filen.',
+	'allowPrettyURLEditDsc' => 'Giver adgang til .htaccess-redigeringsfeltet i PrettyURLs-plugin\'et for at oprette eller ændre .htaccess-filen.',
+
+	'submit' => 'Gem indstillinger',
+		'msgs' => array(
+		1 => 'Indstillingerne er gemt med succes.',
+		-1 => 'Fejl ved lagring af indstillingerne.'
+	)
+);
+?>

--- a/fp-plugins/fpprotect/lang/lang.de-de.php
+++ b/fp-plugins/fpprotect/lang/lang.de-de.php
@@ -1,0 +1,34 @@
+<?php
+$lang ['admin'] ['config'] ['submenu'] ['fpprotect'] = 'FlatPress Protect';
+
+$lang ['admin'] ['config'] ['fpprotect'] = array(
+	'head' => 'FlatPress Protect Einstellungen',
+	'desc1' => 'Hier kannst du sicherheitsrelevante Optionen deines FlatPress-Blogs ändern.',
+
+	// Part for unsafe inline scripts
+	'allow_unsafe_inline' => 'Unsichere Java-Scripte zulassen (Nicht empfohlen)',
+
+	'allowUnsafeInlineDsc' => '<p>Erlaubt das Laden von unsicherem Inline-JavaScript-Code.</p>' . //
+		'<p><br>Hinweis an Plugin-Entwickler: Bitte statte dein Java-Skript mit einer Nonce aus.</p>' . //
+		'Ein Beispiel für PHP:
+		<pre>$random_hex = RANDOM_HEX;
+' . //
+		'... script nonce="\' . $random_hex . \'" src=" ...' . //
+		'</pre>' . //
+		'Ein Beispiel für das Smarty-Template:
+		<pre>' . //
+		'... script nonce="{$smarty.const.RANDOM_HEX}" ...' . //
+		'</pre>' . //
+		'<p>So wird sichergestellt, dass der Browser des Besuchers nur Java-Skripte ausführt, welche von deinem FlatPress-Blog stammen.</p>',
+
+	// Part for the PrettyURLs .htaccess edit-field
+	'allow_htaccess_edit' => 'Erlaube das Erstellen und Editieren der .htaccess Datei.',
+	'allowPrettyURLEditDsc' => 'Erlaubt den Zugriff auf das .htaccess Bearbeitungsfeld des PrettyURLs-Plugins, um die .htaccess-Datei zu erstellen oder zu ändern.',
+
+	'submit' => 'Einstellungen speichern',
+		'msgs' => array(
+		1 => 'Einstellungen erfolgreich gespeichert.',
+		-1 => 'Fehler beim Speichern der Einstellungen.'
+	)
+);
+?>

--- a/fp-plugins/fpprotect/lang/lang.el-gr.php
+++ b/fp-plugins/fpprotect/lang/lang.el-gr.php
@@ -1,0 +1,34 @@
+<?php
+$lang ['admin'] ['config'] ['submenu'] ['fpprotect'] = 'FlatPress Protect';
+
+$lang ['admin'] ['config'] ['fpprotect'] = array(
+	'head' => 'Ρυθμίσεις FlatPress Protect',
+	'desc1' => 'Εδώ μπορείτε να αλλάξετε τις επιλογές που σχετίζονται με την ασφάλεια για το ιστολόγιό σας FlatPress.',
+
+	// Part for unsafe inline scripts
+	'allow_unsafe_inline' => 'Επιτρέψτε τα ανασφαλή Java scripts (Δεν συνιστάται)',
+
+	'allowUnsafeInlineDsc' => '<p>Επιτρέπει τη φόρτωση μη ασφαλούς inline κώδικα JavaScript.</p>' . //
+		'<p><br>Σημείωση για τους προγραμματιστές πρόσθετων: Παρακαλούμε προσθέστε ένα nonce στο Java script σας.</p>' . //
+		'Ένα παράδειγμα για PHP:
+		<pre>$random_hex = RANDOM_HEX;
+' . //
+		'... script nonce="\' . $random_hex . \'" src=" ...' . //
+		'</pre>' . //
+		'Ένα παράδειγμα για το πρότυπο Smarty:
+		<pre>' . //
+		'... script nonce="{$smarty.const.RANDOM_HEX}" ...' . //
+		'</pre>' . //
+		'<p>Αυτό διασφαλίζει ότι το πρόγραμμα περιήγησης του επισκέπτη εκτελεί μόνο σενάρια Java που προέρχονται από το ιστολόγιό σας FlatPress.</p>',
+
+	// Part for the PrettyURLs .htaccess edit-field
+	'allow_htaccess_edit' => 'Επιτρέπει τη δημιουργία και την επεξεργασία του αρχείου .htaccess.',
+	'allowPrettyURLEditDsc' => 'Επιτρέπει την πρόσβαση στο πεδίο επεξεργασίας .htaccess του πρόσθετου PrettyURLs για τη δημιουργία ή την τροποποίηση του αρχείου .htaccess.',
+
+	'submit' => 'Αποθήκευση ρυθμίσεων',
+		'msgs' => array(
+		1 => 'Οι ρυθμίσεις αποθηκεύτηκαν με επιτυχία.',
+		-1 => 'Σφάλμα κατά την αποθήκευση των ρυθμίσεων.'
+	)
+);
+?>

--- a/fp-plugins/fpprotect/lang/lang.en-us.php
+++ b/fp-plugins/fpprotect/lang/lang.en-us.php
@@ -1,0 +1,34 @@
+<?php
+$lang ['admin'] ['config'] ['submenu'] ['fpprotect'] = 'FlatPress Protect';
+
+$lang ['admin'] ['config'] ['fpprotect'] = array(
+	'head' => 'FlatPress Protect settings',
+	'desc1' => 'Here you can change security-relevant options for your FlatPress blog.',
+
+	// Part for unsafe inline scripts
+	'allow_unsafe_inline' => 'Allow unsafe Java scripts (Not recommended)',
+
+	'allowUnsafeInlineDsc' => '<p>Allows the loading of unsafe inline JavaScript code.</p>' . //
+		'<p><br>Note to plugin developers: Please add a nonce to your Java script.</p>' . //
+		'An example for PHP:
+		<pre>$random_hex = RANDOM_HEX;
+' . //
+		'... script nonce="\' . $random_hex . \'" src=" ...' . //
+		'</pre>' . //
+		'An example of the Smarty template:
+		<pre>' . //
+		'... script nonce="{$smarty.const.RANDOM_HEX}" ...' . //
+		'</pre>' . //
+		'<p>This ensures that the visitor\'s browser only executes Java scripts that originate from your FlatPress blog.</p>',
+
+	// Part for the PrettyURLs .htaccess edit-field
+	'allow_htaccess_edit' => 'Allow the creation and editing of the .htaccess file.',
+	'allowPrettyURLEditDsc' => 'Allows access to the .htaccess edit field of the PrettyURLs plugin to create or modify the .htaccess file.',
+
+	'submit' => 'Save settings',
+		'msgs' => array(
+		1 => 'Settings saved successfully.',
+		-1 => 'Error when saving the settings.'
+	)
+);
+?>

--- a/fp-plugins/fpprotect/lang/lang.es-es.php
+++ b/fp-plugins/fpprotect/lang/lang.es-es.php
@@ -1,0 +1,34 @@
+<?php
+$lang ['admin'] ['config'] ['submenu'] ['fpprotect'] = 'FlatPress Protect';
+
+$lang ['admin'] ['config'] ['fpprotect'] = array(
+	'head' => 'Configuración de FlatPress Protect',
+	'desc1' => 'Aquí puede cambiar las opciones relacionadas con la seguridad de su blog FlatPress.',
+
+	// Part for unsafe inline scripts
+	'allow_unsafe_inline' => 'Permitir scripts Java inseguros (No recomendado)',
+
+	'allowUnsafeInlineDsc' => '<p>Permite la carga de código JavaScript en línea inseguro.</p>' . //
+		'<p><br>Nota para los desarrolladores de plugins: añada un nonce a su script Java.</p>' . //
+		'Un ejemplo para PHP:
+		<pre>$random_hex = RANDOM_HEX;
+' . //
+		'... script nonce="\' . $random_hex . \'" src=" ...' . //
+		'</pre>' . //
+		'Un ejemplo para la plantilla Smarty:
+		<pre>' . //
+		'... script nonce="{$smarty.const.RANDOM_HEX}" ...' . //
+		'</pre>' . //
+		'<p>Esto garantiza que el navegador del visitante sólo ejecute scripts Java que se originen en su blog FlatPress.</p>',
+
+	// Part for the PrettyURLs .htaccess edit-field
+	'allow_htaccess_edit' => 'Permitir la creación y edición del archivo .htaccess.',
+	'allowPrettyURLEditDsc' => 'Permite acceder al campo de edición .htaccess del plugin PrettyURLs para crear o modificar el archivo .htaccess.',
+
+	'submit' => 'Guardar configuración',
+		'msgs' => array(
+		1 => 'Configuración guardada correctamente.',
+		-1 => 'Error al guardar la configuración.'
+	)
+);
+?>

--- a/fp-plugins/fpprotect/lang/lang.fr-fr.php
+++ b/fp-plugins/fpprotect/lang/lang.fr-fr.php
@@ -1,0 +1,34 @@
+<?php
+$lang ['admin'] ['config'] ['submenu'] ['fpprotect'] = 'FlatPress Protect';
+
+$lang ['admin'] ['config'] ['fpprotect'] = array(
+	'head' => 'Paramètres de FlatPress Protect',
+	'desc1' => 'Ici, tu peux modifier les options relatives à la sécurité de ton blog FlatPress.',
+
+	// Part for unsafe inline scripts
+	'allow_unsafe_inline' => 'Autoriser les scripts Java non sécurisés (Non recommandé)',
+
+	'allowUnsafeInlineDsc' => '<p>Autorise le chargement de code JavaScript en ligne non sécurisé.</p>' . //
+		'<p><br>Remarque aux développeurs de plugins : merci d\'équiper ton script Java d\'un nonce.</p>' . //
+		'Un exemple pour PHP:
+		<pre>$random_hex = RANDOM_HEX;
+' . //
+		'... script nonce="\' . $random_hex . \'" src=" ...' . //
+		'</pre>' . //
+		'Un exemple pour le modèle Smarty:
+		<pre>' . //
+		'... script nonce="{$smarty.const.RANDOM_HEX}" ...' . //
+		'</pre>' . //
+		'<p>Cela permet de garantir que le navigateur du visiteur n\'exécute que des scripts Java qui proviennent de ton blog FlatPress.</p>',
+
+	// Part for the PrettyURLs .htaccess edit-field
+	'allow_htaccess_edit' => 'Permet de créer et d\'éditer le fichier .htaccess.',
+	'allowPrettyURLEditDsc' => 'Permet d\'accéder au champ d\'édition .htaccess du plugin PrettyURLs pour créer ou modifier le fichier .htaccess.',
+
+	'submit' => 'Enregistrer les paramètres',
+		'msgs' => array(
+		1 => 'Paramètres enregistrés avec succès.',
+		-1 => 'Erreur lors de l\'enregistrement des paramètres.'
+	)
+);
+?>

--- a/fp-plugins/fpprotect/lang/lang.it-it.php
+++ b/fp-plugins/fpprotect/lang/lang.it-it.php
@@ -1,0 +1,34 @@
+<?php
+$lang ['admin'] ['config'] ['submenu'] ['fpprotect'] = 'FlatPress Protect';
+
+$lang ['admin'] ['config'] ['fpprotect'] = array(
+	'head' => 'Impostazioni di FlatPress Protect',
+	'desc1' => 'Qui è possibile modificare le opzioni relative alla sicurezza del blog FlatPress.',
+
+	// Part for unsafe inline scripts
+	'allow_unsafe_inline' => 'Consenti script Java non sicuri (non consigliato)',
+
+	'allowUnsafeInlineDsc' => '<p>Consente il caricamento di codice JavaScript in linea non sicuro.</p>' . //
+		'<p><br>Nota per gli sviluppatori di plugin: aggiungete un nonce al vostro script Java.</p>' . //
+		'Un esempio per PHP:
+		<pre>$random_hex = RANDOM_HEX;
+' . //
+		'... script nonce="\' . $random_hex . \'" src=" ...' . //
+		'</pre>' . //
+		'Un esempio per il template Smarty:
+		<pre>' . //
+		'... script nonce="{$smarty.const.RANDOM_HEX}" ...' . //
+		'</pre>' . //
+		'<p>Questo assicura che il browser del visitatore esegua solo gli script Java provenienti dal vostro blog FlatPress.</p>',
+
+	// Part for the PrettyURLs .htaccess edit-field
+	'allow_htaccess_edit' => 'Consente la creazione e la modifica del file .htaccess.',
+	'allowPrettyURLEditDsc' => 'Consente l\'accesso al campo di modifica .htaccess del plugin PrettyURLs per creare o modificare il file .htaccess.',
+
+	'submit' => 'Salva le impostazioni',
+		'msgs' => array(
+		1 => 'Impostazioni salvate con successo.',
+		-1 => 'Errore nel salvataggio delle impostazioni.'
+	)
+);
+?>

--- a/fp-plugins/fpprotect/lang/lang.ja-jp.php
+++ b/fp-plugins/fpprotect/lang/lang.ja-jp.php
@@ -1,0 +1,34 @@
+<?php
+$lang ['admin'] ['config'] ['submenu'] ['fpprotect'] = 'FlatPress Protect';
+
+$lang ['admin'] ['config'] ['fpprotect'] = array(
+	'head' => 'FlatPressプロテクト設定',
+	'desc1' => 'ここでは、FlatPressブログのセキュリティ関連のオプションを変更することができます。',
+
+	// Part for unsafe inline scripts
+	'allow_unsafe_inline' => '安全でないJavaスクリプトを許可する（推奨しない）',
+
+	'allowUnsafeInlineDsc' => '<p>安全でないインラインJavaScriptコードの読み込みを許可します。</p>' . //
+		'<p><br>プラグイン開発者への注意：Javaスクリプトにnonceを追加してください。</p>' . //
+		'PHPの例:
+		<pre>$random_hex = RANDOM_HEX;
+' . //
+		'... script nonce="\' . $random_hex . \'" src=" ...' . //
+		'</pre>' . //
+		'Smartyテンプレートの例:
+		<pre>' . //
+		'... script nonce="{$smarty.const.RANDOM_HEX}" ...' . //
+		'</pre>' . //
+		'<p>これにより、訪問者のブラウザはFlatPressブログから発信されたJavaスクリプトのみを実行するようになります。</p>',
+
+	// Part for the PrettyURLs .htaccess edit-field
+	'allow_htaccess_edit' => '.htaccess ファイルの作成と編集を許可します。',
+	'allowPrettyURLEditDsc' => 'PrettyURLsプラグインの.htaccess編集フィールドにアクセスし、.htaccessファイルの作成・修正を許可します。',
+
+	'submit' => '設定の保存',
+		'msgs' => array(
+		1 => '設定は正常に保存されました。',
+		-1 => '設定の保存エラー'
+	)
+);
+?>

--- a/fp-plugins/fpprotect/lang/lang.nl-nl.php
+++ b/fp-plugins/fpprotect/lang/lang.nl-nl.php
@@ -1,0 +1,34 @@
+<?php
+$lang ['admin'] ['config'] ['submenu'] ['fpprotect'] = 'FlatPress Protect';
+
+$lang ['admin'] ['config'] ['fpprotect'] = array(
+	'head' => 'FlatPress Instellingen Beschermen',
+	'desc1' => 'Hier kun je de beveiligingsopties voor je FlatPress-blog wijzigen.',
+
+	// Part for unsafe inline scripts
+	'allow_unsafe_inline' => 'Sta onveilige Java-scripts toe (Niet aanbevolen)',
+
+	'allowUnsafeInlineDsc' => '<p>Staat het laden van onveilige inline JavaScript-code toe.</p>' . //
+		'<p><br>Opmerking voor plugin-ontwikkelaars: Voeg een nonce toe aan uw Java-script.</p>' . //
+		'Een voorbeeld voor PHP:
+		<pre>$random_hex = RANDOM_HEX;
+' . //
+		'... script nonce="\' . $random_hex . \'" src=" ...' . //
+		'</pre>' . //
+		'Een voorbeeld voor het Smarty-sjabloon:
+		<pre>' . //
+		'... script nonce="{$smarty.const.RANDOM_HEX}" ...' . //
+		'</pre>' . //
+		'<p>Dit zorgt ervoor dat de browser van de bezoeker alleen Java scripts uitvoert die afkomstig zijn van je FlatPress blog.</p>',
+
+	// Part for the PrettyURLs .htaccess edit-field
+	'allow_htaccess_edit' => 'Laat het aanmaken en bewerken van het .htaccess bestand toe.',
+	'allowPrettyURLEditDsc' => 'Geeft toegang tot het .htaccess bewerkingsveld van de PrettyURLs plugin om het .htaccess bestand aan te maken of te wijzigen.',
+
+	'submit' => 'Instellingen opslaan',
+		'msgs' => array(
+		1 => 'Instellingen succesvol opgeslagen.',
+		-1 => 'Fout bij het opslaan van de instellingen.'
+	)
+);
+?>

--- a/fp-plugins/fpprotect/lang/lang.pt-br.php
+++ b/fp-plugins/fpprotect/lang/lang.pt-br.php
@@ -1,0 +1,34 @@
+<?php
+$lang ['admin'] ['config'] ['submenu'] ['fpprotect'] = 'FlatPress Protect';
+
+$lang ['admin'] ['config'] ['fpprotect'] = array(
+	'head' => 'Configurações do FlatPress Protect',
+	'desc1' => 'Aqui você pode alterar as opções relacionadas à segurança do seu blog FlatPress.',
+
+	// Part for unsafe inline scripts
+	'allow_unsafe_inline' => 'Permitir scripts Java inseguros (Não recomendado)',
+
+	'allowUnsafeInlineDsc' => '<p>Permite o carregamento de código JavaScript inseguro em linha.</p>' . //
+		'<p><br>Observação para desenvolvedores de plug-ins: adicione um nonce ao seu script Java.</p>' . //
+		'Um exemplo para PHP:
+		<pre>$random_hex = RANDOM_HEX;
+' . //
+		'... script nonce="\' . $random_hex . \'" src=" ...' . //
+		'</pre>' . //
+		'Um exemplo para o modelo Smarty:
+		<pre>' . //
+		'... script nonce="{$smarty.const.RANDOM_HEX}" ...' . //
+		'</pre>' . //
+		'<p>Isso garante que o navegador do visitante só execute scripts Java originários do seu blog do FlatPress.</p>',
+
+	// Part for the PrettyURLs .htaccess edit-field
+	'allow_htaccess_edit' => 'Permitir a criação e a edição do arquivo .htaccess.',
+	'allowPrettyURLEditDsc' => 'Permite o acesso ao campo de edição .htaccess do plug-in PrettyURLs para criar ou modificar o arquivo .htaccess.',
+
+	'submit' => 'Salvar configurações',
+		'msgs' => array(
+		1 => 'Configurações salvas com êxito.',
+		-1 => 'Erro ao salvar as configurações.'
+	)
+);
+?>

--- a/fp-plugins/fpprotect/lang/lang.ru-ru.php
+++ b/fp-plugins/fpprotect/lang/lang.ru-ru.php
@@ -1,0 +1,34 @@
+<?php
+$lang ['admin'] ['config'] ['submenu'] ['fpprotect'] = 'FlatPress Protect';
+
+$lang ['admin'] ['config'] ['fpprotect'] = array(
+	'head' => 'Настройки FlatPress Protect',
+	'desc1' => 'Здесь вы можете изменить параметры безопасности для вашего блога FlatPress.',
+
+	// Part for unsafe inline scripts
+	'allow_unsafe_inline' => 'Разрешить небезопасные Java-скрипты (Не рекомендуется)',
+
+	'allowUnsafeInlineDsc' => '<p>Разрешает загрузку небезопасного встроенного кода JavaScript.</p>' . //
+		'<p><br>Примечание для разработчиков плагинов: пожалуйста, добавьте nonce к вашему Java-скрипту.</p>' . //
+		'Пример для PHP:
+		<pre>$random_hex = RANDOM_HEX;
+' . //
+		'... script nonce="\' . $random_hex . \'" src=" ...' . //
+		'</pre>' . //
+		'Пример для шаблона Smarty:
+		<pre>' . //
+		'... script nonce="{$smarty.const.RANDOM_HEX}" ...' . //
+		'</pre>' . //
+		'<p>Это гарантирует, что браузер посетителя будет выполнять только те Java-скрипты, которые исходят от вашего блога FlatPress.</p>',
+
+	// Part for the PrettyURLs .htaccess edit-field
+	'allow_htaccess_edit' => 'Разрешить создание и редактирование файла .htaccess.',
+	'allowPrettyURLEditDsc' => 'Позволяет получить доступ к полю редактирования .htaccess плагина PrettyURLs для создания или изменения файла .htaccess.',
+
+	'submit' => 'Сохранить настройки',
+		'msgs' => array(
+		1 => 'Настройки успешно сохранены.',
+		-1 => 'Ошибка при сохранении настроек.'
+	)
+);
+?>

--- a/fp-plugins/fpprotect/lang/lang.sl-si.php
+++ b/fp-plugins/fpprotect/lang/lang.sl-si.php
@@ -1,0 +1,34 @@
+<?php
+$lang ['admin'] ['config'] ['submenu'] ['fpprotect'] = 'FlatPress Protect';
+
+$lang ['admin'] ['config'] ['fpprotect'] = array(
+	'head' => 'Nastavitve FlatPress Protect',
+	'desc1' => 'Tukaj lahko spremenite možnosti, povezane z varnostjo, za svoj blog FlatPress.',
+
+	// Part for unsafe inline scripts
+	'allow_unsafe_inline' => 'Dovoli negotove Java skripte (Ni priporočljivo)',
+
+	'allowUnsafeInlineDsc' => '<p>Omogoča nalaganje nezanesljive vdelane kode JavaScript.</p>' . //
+		'<p><br>Opomba za razvijalce vtičnikov: Prosimo, dodajte nonce skriptam Java.</p>' . //
+		'Primer za PHP:
+		<pre>$random_hex = RANDOM_HEX;
+' . //
+		'... script nonce="\' . $random_hex . \'" src=" ...' . //
+		'</pre>' . //
+		'Primer za predlogo Smarty:
+		<pre>' . //
+		'... script nonce="{$smarty.const.RANDOM_HEX}" ...' . //
+		'</pre>' . //
+		'<p>S tem zagotovite, da brskalnik obiskovalca izvede samo skripte Java, ki izvirajo iz vašega bloga FlatPress.</p>',
+
+	// Part for the PrettyURLs .htaccess edit-field
+	'allow_htaccess_edit' => 'Omogoča ustvarjanje in urejanje datoteke .htaccess.',
+	'allowPrettyURLEditDsc' => 'Omogoča dostop do polja za urejanje datoteke .htaccess v vtičniku PrettyURLs za ustvarjanje ali spreminjanje datoteke .htaccess.',
+
+	'submit' => 'Shranjevanje nastavitev',
+		'msgs' => array(
+		1 => 'Nastavitve so bile uspešno shranjene.',
+		-1 => 'Napaka pri shranjevanju nastavitev.'
+	)
+);
+?>

--- a/fp-plugins/fpprotect/plugin.fpprotect.php
+++ b/fp-plugins/fpprotect/plugin.fpprotect.php
@@ -1,35 +1,58 @@
 <?php
 /*
  * Plugin Name: FlatPress Protect
- * Plugin URI: http://www.flatpress.org/
- * Description: Hardens your blog with additional features in the HTTP response header. <a href="./fp-plugins/fpprotect/doc_fpprotect.txt" title="More information" target="_blank">[More information]</a><br>Removes the htaccess editor from the PrettyURLs plugin.
+ * Plugin URI: https://www.flatpress.org/
+ * Description: Offers various options for the security of your blog. <a href="./fp-plugins/fpprotect/doc_fpprotect.txt" title="More information" target="_blank">[More information]</a><br>Removes the htaccess editor from the PrettyURLs plugin.
  * Author: FlatPress
- * Version: 1.0
+ * Version: 1.1.0
  * Author URI: https://www.flatpress.org
  */
 
 if (function_exists('is_https')) {
 
+	// $random_hex is only required if unsafe-inline is not set
 	$random_hex = RANDOM_HEX;
+
+	// Get the configuration from the fp_config file
+	global $fp_config;
+
+	if (isset($fp_config ['plugins'] ['fpprotect'] ['allowUnsafeInline'])) {
+		$allowUnsafeInline = $fp_config ['plugins'] ['fpprotect'] ['allowUnsafeInline'];
+	} else {
+		// Default value, if not available
+		$allowUnsafeInline = false;
+	}
+
+	if (isset($fp_config ['plugins'] ['fpprotect'] ['allowPrettyURLEdit'])) {
+		$allowUnsafeInline = $fp_config ['plugins'] ['fpprotect'] ['allowPrettyURLEdit'];
+	} else {
+		// Default value, if not available
+		$allowPrettyURLEdit = false;
+	}
 
 	if (is_https()) {
 		/**
 		 * Content Security Policy rules for Youtube, Facebook and Vimeo embedded video / BBCode [video], embedded OSM '
 		 * https://scotthelme.co.uk/content-security-policy-an-introduction/
 		 */
+
+		// Create the script-src header based on the configuration
+		$scriptSrc = 'script-src \'self\' ';
+		if ($allowUnsafeInline) {
+			// Allow unsafe inline JavaScript
+			$scriptSrc .= '\'unsafe-inline\' https:; ';
+		} else {
+			// use nonce to ensure that only approved scripts are loaded
+			$scriptSrc .= '\'nonce-' . $random_hex . '\' https:; ';
+		}
+
+		// Setze den gesamten CSP-Header
 		header('Content-Security-Policy: upgrade-insecure-requests; ' . // Is migrating from HTTP to HTTPS, will ensure that all requests will be sent over HTTPS with no fallback to HTTP
-			'default-src \'self\'; ' . // The default-src directive is the default setting for all directives that load additional content such as JavaScript, images, CSS, fonts, AJAX requests, frames and HTML5 media.
+			'default-src \'none\'; ' . // The default-src directive is the default setting for all directives that load additional content such as JavaScript, images, CSS, fonts, AJAX requests, frames and HTML5 media.
 			'frame-src \'self\' https: data:; ' . // Allows iframes from other sources - only via https
 			'base-uri \'self\'; ' . //
 			'font-src \'self\' https: data:; ' . // Allows fonts from other sources (e.g. font awesome) - only via https
-
-			/**
-			 * To make XSS attacks more difficult, remove all inline code in your plugins and templates and remove the “script-src inline-unsave” directive.
-			 * https://content-security-policy.com/nonce/
-			 */
-			'script-src \'self\' \'unsafe-inline\' https:; ' . // Allows the use of inline code such as style attributes, event handler attributes such as onclick and JavaScript code noted in <script> elements
-			//'script-src \'self\' \'nonce-' . $random_hex . '\' https:; ' . // No inline code without nonce-123xyz, no onclick e.t.c, other sources only https
-
+			$scriptSrc . // Use the dynamic script-src directive based on the configuration
 			'style-src \'self\' \'unsafe-inline\' https:; ' . // Defines permitted sources for stylesheets e.g Youtube - only via https
 			'img-src \'self\' https: data:; ' . // Defines permitted sources for images - only via https (e.g. base64-encoded images)
 			'frame-ancestors \'self\' https:; ' . // Defines permitted sources that may have embedded content, such as <frame>, <iframe>, <object>, <embed> and <applet>. 
@@ -52,11 +75,83 @@ if (function_exists('is_https')) {
 
 		header('X-Permitted-Cross-Domain-Policies: none');
 		header('X-Download-Options: noopen');
+		//header('Access-Control-Allow-Origin: ' . BLOG_BASEURL . ''); // Otherwise, clients could be prevented from retrieving a feed.
 	}
 }
 
 function fpprotect_harden_prettyurls_plugin() {
-	// If active, the input field and the save button of the PrettyURLs plugin are hidden
-	return true;
+	// If the checkbox is checked, the htaccess input field and the save button of the PrettyURLs plugin are displayed
+	$config = plugin_getoptions('fpprotect');
+	return isset($config['allowPrettyURLEdit']) ? !(bool)$config['allowPrettyURLEdit'] : true;
+}
+
+/**
+ * Admin-Panel
+ */
+if (class_exists('AdminPanelAction')) {
+
+	class admin_config_fpprotect extends AdminPanelAction {
+
+		var $lang = 'plugin:fpprotect';
+
+		function setup() {
+			global $lang;
+
+			// Load the language file
+			$lang = lang_load('plugin:fpprotect');
+			$this->smarty->assign('admin_resource', 'plugin:fpprotect/admin.plugin.fpprotect');
+		}
+
+		function main() {
+			global $lang;
+			$lang = lang_load('plugin:fpprotect');
+
+			// Load the current checkbox selections
+			$config = $this->load_config();
+
+			// Process the form once it has been submitted
+			if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+				// Use the onsubmit method to save the configuration
+				$this->onsubmit($_POST);
+			}
+
+			// Transfer the values of the checkboxes to the template
+			$this->smarty->assign('allowUnsafeInline', $config['allowUnsafeInline']);
+			$this->smarty->assign('allowPrettyURLEdit', $config['allowPrettyURLEdit']);
+
+			// Render template
+			$this->smarty->assign('admin_resource', 'plugin:fpprotect/admin.plugin.fpprotect');
+		}
+
+		function load_config() {
+			// Load the plugin options
+			$config = plugin_getoptions('fpprotect');
+
+			// Return the values of the options, or set default values if they do not exist
+			return array(
+				'allowUnsafeInline' => isset($config['allowUnsafeInline']) ? (bool)$config['allowUnsafeInline'] : false,
+				'allowPrettyURLEdit' => isset($config['allowPrettyURLEdit']) ? (bool)$config['allowPrettyURLEdit'] : false,
+			);
+		}
+
+		function onsubmit($data = null) {
+			// Check whether the checkboxes are set or not
+			$allowUnsafeInline = isset($_POST['allowUnsafeInline']) ? true : false;
+			$allowPrettyURLEdit = isset($_POST['allowPrettyURLEdit']) ? true : false;
+
+			// Save the new settings in the configuration
+			plugin_addoption('fpprotect', 'allowUnsafeInline', $allowUnsafeInline);
+			plugin_addoption('fpprotect', 'allowPrettyURLEdit', $allowPrettyURLEdit); // Neue Option
+
+			plugin_saveoptions('fpprotect');
+
+			// Show success message
+			global $lang;
+			$this->smarty->assign('success', 1);
+		}
+	}
+
+	// Registration of the panel in the 'config' menu
+	admin_addpanelaction('config', 'fpprotect', true);
 }
 ?>

--- a/fp-plugins/fpprotect/tpls/admin.plugin.fpprotect.tpl
+++ b/fp-plugins/fpprotect/tpls/admin.plugin.fpprotect.tpl
@@ -1,0 +1,28 @@
+<h2>{$plang.head}</h2>
+<p>{$plang.desc1}</p>
+
+{include file="shared:errorlist.tpl"}
+
+{html_form class="option-set"}
+
+	<fieldset>
+		<label for="allowUnsafeInline">
+			<input type="checkbox" name="allowUnsafeInline" id="allowUnsafeInline" value="1" {if isset($allowUnsafeInline) && $allowUnsafeInline == true}checked{/if}>
+			{$plang.allow_unsafe_inline}
+		</label>
+		<p>{$plang.allowUnsafeInlineDsc}</p>
+	</fieldset>
+
+	<fieldset>
+		<label for="allowPrettyURLEdit">
+			<input type="checkbox" name="allowPrettyURLEdit" id="allowPrettyURLEdit" value="1" {if isset($allowPrettyURLEdit) && $allowPrettyURLEdit == true}checked{/if}>
+			{$plang.allow_htaccess_edit}
+		</label>
+		<p>{$plang.allowPrettyURLEditDsc}</p>
+	</fieldset>
+
+	<div class="buttonbar">
+		<input type="submit" value="{$plang.submit}">
+	</div>
+
+{/html_form}

--- a/fp-plugins/prettyurls/lang/lang.cs-cz.php
+++ b/fp-plugins/prettyurls/lang/lang.cs-cz.php
@@ -8,7 +8,7 @@ $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'Nastavení PrettyURLs',
 	'description1' => 'Zde můžete přeměnit standardní adresy URL FlatPressu na krásné adresy URL vhodné pro SEO.',
 	'fpprotect_is_on' => 'Zásuvný modul PrettyURLs vyžaduje soubor .htaccess. ' . //
-		'Chcete-li tento soubor vytvořit nebo změnit, <a href="admin.php?p=plugin&action=default" title="Přejděte do administrace zásuvného modulu">deaktivujte</a> zásuvný modul FlatPress Protect. ',
+		'Chcete-li tento soubor vytvořit nebo upravit, aktivujte tuto možnost v zásuvném <a href="admin.php?p=config&action=fpprotect" title="přejít na zásuvný modul FlatPress Protect">modulu FlatPress Protect</a>. ',
 	'fpprotect_is_off' => 'Zásuvný modul FlatPress Protect chrání soubor .htaccess před nechtěnými změnami. ' . //
 		'Zásuvný modul můžete aktivovat <a href="admin.php?p=plugin&action=default" title="Přejděte do administrace zásuvného modulu">zde</a>!',
 	'nginx' => 'PrettyURLs se službou NGINX',

--- a/fp-plugins/prettyurls/lang/lang.da-dk.php
+++ b/fp-plugins/prettyurls/lang/lang.da-dk.php
@@ -9,7 +9,7 @@ $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'PrettyURLs Konfiguration',
 	'description1' => 'Her kan du forvandle FlatPress\' standard-URL\'er til smukke, SEO-venlige URL\'er.',
 	'fpprotect_is_on' => 'PrettyURLs-plugin\'et kræver en .htaccess-fil. ' . //
-		'For at oprette eller ændre denne fil skal du <a href="admin.php?p=plugin&action=default" title="Gå til plugin-administrationen">deaktivere</a> FlatPress Protect-plugin\'et. ',
+		'For at oprette eller ændre denne fil skal du aktivere indstillingen i <a href="admin.php?p=config&action=fpprotect" title="Gå til FlatPress Protect-plugin">FlatPress Protect Plugin\'et</a>. ',
 	'fpprotect_is_off' => 'FlatPress Protect-plugin\'et beskytter .htaccess-filen mod utilsigtede ændringer. ' . //
 		'Du kan aktivere pluginet <a href="admin.php?p=plugin&action=default" title="Gå til plugin-administrationen">her</a>!',
 	'nginx' => 'PrettyURLs med NGINX',

--- a/fp-plugins/prettyurls/lang/lang.de-de.php
+++ b/fp-plugins/prettyurls/lang/lang.de-de.php
@@ -9,7 +9,7 @@ $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'PrettyURLs Konfiguration',
 	'description1' => 'Hier kannst du die Standard-URL\'s von FlatPress in schöne, SEO-freundliche URL\'s verwandeln.',
 	'fpprotect_is_on' => 'Das Plugin PrettyURLs benötigt eine .htaccess-Datei. ' . //
-		'Um diese Datei zu erstellen oder zu verändern, <a href="admin.php?p=plugin&action=default" title="gehe zur Plugin Verwaltung">deaktiviere</a> dazu das FlatPress Protect Plugin. ',
+		'Um diese Datei zu erstellen oder zu verändern, aktiviere dazu die Option im <a href="admin.php?p=config&action=fpprotect" title="gehe zum FlatPress Protect Plugin">FlatPress Protect Plugin</a>. ',
 	'fpprotect_is_off' => 'Das FlatPress Protect Plugin schützt die .htaccess Datei vor unbeabsichtigten Änderungen. ' . //
 		'<a href="admin.php?p=plugin&action=default" title="gehe zur Plugin Verwaltung">Hier</a> kannst du das Plugin aktivieren!',
 	'nginx' => 'PrettyURLs mit NGINX',

--- a/fp-plugins/prettyurls/lang/lang.el-gr.php
+++ b/fp-plugins/prettyurls/lang/lang.el-gr.php
@@ -10,7 +10,7 @@ $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'description1' => 'Εδώ μπορείτε να μετατρέψετε τις τυπικές διευθύνσεις URL του FlatPress σε όμορφες, φιλικές προς το SEO διευθύνσεις URL.',
 	'nginx' => 'PrettyURLs με NGINX',
 	'fpprotect_is_on' => 'Το πρόσθετο PrettyURLs απαιτεί ένα αρχείο .htaccess. ' . //
-		'Για να δημιουργήσετε ή να αλλάξετε αυτό το αρχείο, <a href="admin.php?p=plugin&action=default" title="Μεταβείτε στη διαχείριση του πρόσθετου">απενεργοποιήστε</a> το πρόσθετο FlatPress Protect. ',
+		'Για να δημιουργήσετε ή να τροποποιήσετε αυτό το αρχείο, ενεργοποιήστε την επιλογή στο πρόσθετο <a href="admin.php?p=config&action=fpprotect" title="μεταβείτε στο πρόσθετο FlatPress Protect">FlatPress Protect</a>. ',
 	'fpprotect_is_off' => 'Το πρόσθετο FlatPress Protect προστατεύει το αρχείο .htaccess από ακούσιες αλλαγές. ' . //
 		'Μπορείτε να ενεργοποιήσετε το πρόσθετο <a href="admin.php?p=plugin&action=default" title="Μεταβείτε στη διαχείριση του πρόσθετου">εδώ</a>!',
 	'wiki_nginx' => 'https://wiki.flatpress.org/res:plugins:prettyurls#nginx',

--- a/fp-plugins/prettyurls/lang/lang.en-us.php
+++ b/fp-plugins/prettyurls/lang/lang.en-us.php
@@ -9,7 +9,7 @@ $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'PrettyURLs Configuration',
 	'description1' => 'Here you can turn the standard FlatPress URLs into beautiful, SEO-friendly URLs.',
 	'fpprotect_is_on' => 'The PrettyURLs plugin requires an .htaccess file. ' . //
-		'To create or change this file, <a href="admin.php?p=plugin&action=default" title="Go to the plugin administration">deactivate</a> the FlatPress Protect plugin. ',
+		'To create or modify this file, activate the option in the <a href="admin.php?p=config&action=fpprotect" title="go to FlatPress Protect Plugin">FlatPress Protect Plugin</a>. ',
 	'fpprotect_is_off' => 'The FlatPress Protect plugin protects the .htaccess file from unintentional changes. ' . //
 		'You can activate the plugin <a href="admin.php?p=plugin&action=default" title="Go to the plugin administration">here</a>!',
 	'nginx' => 'PrettyURLs with NGINX',

--- a/fp-plugins/prettyurls/lang/lang.es-es.php
+++ b/fp-plugins/prettyurls/lang/lang.es-es.php
@@ -9,7 +9,7 @@ $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'Configuración de PrettyURLs',
 	'description1' => 'Aquí puedes transformar las URLs estándar de FlatPress en URLs bonitas y SEO-friendly.',
 	'fpprotect_is_on' => 'El plugin PrettyURLs requiere un archivo .htaccess. ' . //
-		'Para crear o modificar este archivo, <a href="admin.php?p=plugin&action=default" title="Vaya a la administración del plugin">desactive</a> el plugin FlatPress Protect. ',
+		'Para crear o modificar este archivo, active la opción en el <a href="admin.php?p=config&action=fpprotect" title="ir a FlatPress Protect Plugin">plugin FlatPress Protect</a>. ',
 	'fpprotect_is_off' => 'El plugin FlatPress Protect protege el archivo .htaccess de cambios involuntarios. ' . //
 		'Puede activar el plugin <a href="admin.php?p=plugin&action=default" title="Vaya a la administración del plugin">aquí</a>!',
 	'nginx' => 'PrettyURLs con NGINX',

--- a/fp-plugins/prettyurls/lang/lang.fr-fr.php
+++ b/fp-plugins/prettyurls/lang/lang.fr-fr.php
@@ -9,7 +9,7 @@ $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'Configuration de PrettyURLs',
 	'description1' => 'Ici, tu peux transformer les URL standard de FlatPress en de jolies URL adaptées au SEO.',
 	'fpprotect_is_on' => 'Le plugin PrettyURLs nécessite un fichier .htaccess. ' . //
-		'Pour créer ou modifier ce fichier, <a href="admin.php?p=plugin&action=default" title="Va dans la gestion des plugins">désactive</a> le plugin FlatPress Protect. ',
+		'Pour créer ou modifier ce fichier, active l\'option dans le <a href="admin.php?p=config&action=fpprotect" title="aller au plugin FlatPress Protect">plugin FlatPress Protect</a>. ',
 	'fpprotect_is_off' => 'Le plugin FlatPress Protect protège le fichier .htaccess contre les modifications involontaires. ' . //
 		'Tu peux activer le plugin <a href="admin.php?p=plugin&action=default" title="Va dans la gestion des plugins">ici</a>!',
 	'nginx' => 'PrettyURLs avec NGINX',

--- a/fp-plugins/prettyurls/lang/lang.it-it.php
+++ b/fp-plugins/prettyurls/lang/lang.it-it.php
@@ -9,7 +9,7 @@ $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'Configurazione di PrettyURLs',
 	'description1' => 'Qui è possibile trasformare gli URL standard di FlatPress in URL belli e SEO-friendly.',
 	'fpprotect_is_on' => 'Il plugin PrettyURLs richiede un file .htaccess. ' . //
-		'Per creare o modificare questo file, <a href="admin.php?p=plugin&action=default" title="Andate all\'amministrazione del plugin">disattivare</a> il plugin FlatPress Protect. ',
+		'Per creare o modificare questo file, attivare l\'opzione nel <a href="admin.php?p=config&action=fpprotect" title="vai al plugin FlatPress Protect">plugin FlatPress Protect</a>. ',
 	'fpprotect_is_off' => 'Il plugin FlatPress Protect protegge il file .htaccess da modifiche involontarie. ' . //
 		'Potete attivare il plugin <a href="admin.php?p=plugin&action=default" title="Andate all\'amministrazione del plugin">qui</a>!',
 	'nginx' => 'PrettyURL con NGINX',

--- a/fp-plugins/prettyurls/lang/lang.ja-jp.php
+++ b/fp-plugins/prettyurls/lang/lang.ja-jp.php
@@ -9,7 +9,7 @@ $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'PrettyURLsの設定',
 	'description1' => 'FlatPressの標準的なURLを、SEOに配慮した美しいURLに変換することができます。',
 	'fpprotect_is_on' => 'PrettyURLsプラグインには.htaccessファイルが必要です。 ' . //
-		'このファイルを作成または変更するには、FlatPress Protect プラグインを<a href="admin.php?p=plugin&action=default" title="プラグイン管理画面へ">無効にしてください</a>。 ',
+		'このファイルを作成または変更するには、<a href="admin.php?p=config&action=fpprotect" title="FlatPress Protect プラグインへ">FlatPress Protect</a>プラグインのオプションを有効にしてください。 ',
 	'fpprotect_is_off' => 'FlatPress Protectプラグインは、.htaccessファイルを意図しない変更から保護します。 ' . //
 		'<a href="admin.php?p=plugin&action=default" title="プラグ</a>イン管理画面へ">プラグインの有効化はこちらから！',
 	'nginx' => 'NGINXによるPrettyURLs',

--- a/fp-plugins/prettyurls/lang/lang.nl-nl.php
+++ b/fp-plugins/prettyurls/lang/lang.nl-nl.php
@@ -9,7 +9,7 @@ $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'PrettyURLs Configuratie',
 	'description1' => 'Hier kun je de standaard FlatPress URL\'s omzetten in mooie, SEO-vriendelijke URL\'s.',
 	'fpprotect_is_on' => 'De PrettyURLs plugin heeft een .htaccess bestand nodig. ' . //
-		'Om dit bestand aan te maken of te wijzigen moet je de FlatPress Protect plugin <a href="admin.php?p=plugin&action=default" title="Ga naar de plugin administratie">deactiveren</a>. ',
+		'Als u dit bestand wilt maken of wijzigen, activeert u de optie in de <a href="admin.php?p=config&action=fpprotect" title="ga naar FlatPress Beschermen Plugin">FlatPress Protect plugin</a>. ',
 	'fpprotect_is_off' => 'De FlatPress Protect plugin beschermt het .htaccess bestand tegen onbedoelde wijzigingen. ' . //
 		'U kunt de plugin <a href="admin.php?p=plugin&action=default" title="Ga naar de plugin administratie">hier</a> activeren!',
 	'nginx' => 'PrettyURLs met NGINX',

--- a/fp-plugins/prettyurls/lang/lang.pt-br.php
+++ b/fp-plugins/prettyurls/lang/lang.pt-br.php
@@ -9,7 +9,7 @@ $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'Configurar PrettyURLs',
 	'description1' => 'Aqui, você pode transformar os URLs padrão do FlatPress em URLs bonitos e compatíveis com SEO.',
 	'fpprotect_is_on' => 'O plug-in PrettyURLs requer um arquivo .htaccess. ' . //
-		'Para criar ou alterar esse arquivo, <a href="admin.php?p=plugin&action=default" title="Vá para a administração do plug-in">desative</a> o plug-in FlatPress Protect. ',
+		'Para criar ou modificar esse arquivo, ative a opção no <a href="admin.php?p=config&action=fpprotect" title="ir para Plugin FlatPress Protect">plug-in FlatPress Protect</a>. ',
 	'fpprotect_is_off' => 'O plug-in FlatPress Protect protege o arquivo .htaccess de alterações não intencionais. ' . //
 		'Você pode ativar o plug-in <a href="admin.php?p=plugin&action=default" title="Vá para a administração do plug-in">aqui</a>!',
 	'nginx' => 'PrettyURLs com NGINX',

--- a/fp-plugins/prettyurls/lang/lang.ru-ru.php
+++ b/fp-plugins/prettyurls/lang/lang.ru-ru.php
@@ -9,7 +9,7 @@ $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'Конфигурация PrettyURLs',
 	'description1' => 'Здесь вы можете превратить стандартные URL из FlatPress в красивые, SEO-дружественные URL.',
 	'fpprotect_is_on' => 'Плагин PrettyURLs требует наличия файла .htaccess. ' . //
-		'Чтобы создать или изменить этот файл, <a href="admin.php?p=plugin&action=default" title="Перейдите в админку плагина">деактивируйте</a> плагин FlatPress Protect. ',
+		'Чтобы создать или изменить этот файл, активируйте опцию в плагине <a href="admin.php?p=config&action=fpprotect" title="перейти к плагину FlatPress Protect">FlatPress Protect</a>. ',
 	'fpprotect_is_off' => 'Плагин FlatPress Protect защищает файл .htaccess от непреднамеренных изменений. ' . //
 		'Вы можете активировать плагин <a href="admin.php?p=plugin&action=default" title="Перейдите в админку плагина">здесь</a>!',
 	'nginx' => 'PrettyURLs с NGINX',

--- a/fp-plugins/prettyurls/lang/lang.sl-si.php
+++ b/fp-plugins/prettyurls/lang/lang.sl-si.php
@@ -9,7 +9,7 @@ $lang ['admin'] ['plugin'] ['prettyurls'] = array(
 	'head' => 'Nastavitve PrettyURLs',
 	'description1' => 'Tu lahko standardne URL-je iz FlatPressa spremenite v čudovite, SEO prijazne URL-je.',
 	'fpprotect_is_on' => 'Vtičnik PrettyURLs zahteva datoteko .htaccess. ' . //
-		'Če želite ustvariti ali spremeniti to datoteko, <a href="admin.php?p=plugin&action=default" title="Pojdite v administracijo vtičnika">deaktivirajte</a> vtičnik FlatPress Protect. ',
+		'Če želite ustvariti ali spremeniti to datoteko, aktivirajte to možnost v vtičniku <a href="admin.php?p=config&action=fpprotect" title="pojdite na FlatPress Protect Plugin">FlatPress Protect</a>. ',
 	'fpprotect_is_off' => 'Vtičnik FlatPress Protect ščiti datoteko .htaccess pred nenamernimi spremembami. ' . //
 		'Vtičnik lahko aktivirate <a href="admin.php?p=plugin&action=default" title="Pojdite v administracijo vtičnika">tukaj</a>!',
 	'nginx' => 'PrettyURLs med NGINX',

--- a/fp-plugins/prettyurls/plugin.prettyurls.php
+++ b/fp-plugins/prettyurls/plugin.prettyurls.php
@@ -1,7 +1,7 @@
 <?php
 /*
  * Plugin Name: PrettyURLs
- * Version: 3.0
+ * Version: 3.0.1
  * Plugin URI: https://www.flatpress.org
  * Author: FlatPress
  * Author URI: https://www.flatpress.org

--- a/fp-plugins/prettyurls/tpls/admin.plugin.prettyurls.tpl
+++ b/fp-plugins/prettyurls/tpls/admin.plugin.prettyurls.tpl
@@ -11,23 +11,21 @@
 
 {include file="shared:errorlist.tpl"}
 
-
 {html_form}
-
 
 	<h3>{$plang.mode}</h3>
 	<dl>
-		<dt><label><input type="radio" name="mode" value="0" {if $pconfig.mode == 0 }checked=checked{/if}> 
-						{$plang.auto} 	</label>	</dt>
+		<dt><label><input type="radio" name="mode" value="0" {if $pconfig.mode == 0 }checked=checked{/if}>
+						{$plang.auto}</label></dt>
 						<dd>{$plang.autodescr}</dd>
-		<dt><label><input type="radio" name="mode" value="1" {if $pconfig.mode==1}checked=checked{/if}> 
-						 {$plang.pathinfo}	</label> </dt>
+		<dt><label><input type="radio" name="mode" value="1" {if $pconfig.mode == 1}checked=checked{/if}>
+						 {$plang.pathinfo}</label></dt>
 						<dd>{$plang.pathinfodescr}</dd>
-		<dt><label><input type="radio" name="mode" value="2" {if $pconfig.mode==2}checked=checked{/if}> 
-						 {$plang.httpget} 	</label>	</dt>
+		<dt><label><input type="radio" name="mode" value="2" {if $pconfig.mode == 2}checked=checked{/if}>
+						 {$plang.httpget}</label></dt>
 						<dd>{$plang.httpgetdescr}</dd>
-		<dt><label><input type="radio" name="mode" value="3" {if $pconfig.mode==3}checked=checked{/if}> 
-						 {$plang.pretty}	</label>	</dt>
+		<dt><label><input type="radio" name="mode" value="3" {if $pconfig.mode == 3}checked=checked{/if}>
+						 {$plang.pretty}</label></dt>
 						<dd>{$plang.prettydescr}</dd>
 	</dl>
 
@@ -35,27 +33,27 @@
 		<input type="submit" name="saveopt" value="{$plang.saveopt}">
 	</div>
 
+	{if function_exists('fpprotect_harden_prettyurls_plugin')}
+		{if not fpprotect_harden_prettyurls_plugin()} {* If the FlatPress Protect plugin option is activated, the .htaccess file can be edited and saved. *}
+			<p class="alignright">
+				<a class="hint externlink" href="{$lang.admin.plugin.prettyurls.wiki_nginx}" target="_blank">{$lang.admin.plugin.prettyurls.nginx}</a>
+			</p>
+			<h3>{$plang.htaccess}</h3>
 
-	{if not function_exists('fpprotect_harden_prettyurls_plugin')} {* If the FlatPress Protect plugin is deactivated, the .htaccess file can be edited and saved. *}
-		<p class="alignright">
-			<a class="hint externlink" href="{$lang.admin.plugin.prettyurls.wiki_nginx}" target="_blank">{$lang.admin.plugin.prettyurls.nginx}</a>
-		</p>
-		<h3>{$plang.htaccess}</h3>
+			<p>{$plang.description2}</p>
+			<p>
+			<textarea id="htaccess" name="htaccess" {if $cantsave}readonly="readonly" {/if}cols="70" rows="16">{$htaccess|escape:'html'}</textarea>
+			</p>
 
-		<p>{$plang.description2}</p>
-		<p>
-		<textarea id="htaccess" name="htaccess" 
-		{if $cantsave}readonly="readonly" {/if}cols="70" rows="16">{$htaccess|escape:'html'}</textarea>
-		</p>
-
-		<div class="buttonbar">
-		{if $cantsave}
-			<p><em>{$plang.cantsave}</em></p>
-		{else}
-			<p>{$lang.admin.plugin.prettyurls.location}</p>
-			<input type="submit" name="htaccess-submit" value="{$plang.submit}">
+			<div class="buttonbar">
+			{if $cantsave}
+				<p><em>{$plang.cantsave}</em></p>
+			{else}
+				<p>{$lang.admin.plugin.prettyurls.location}</p>
+				<input type="submit" name="htaccess-submit" value="{$plang.submit}">
+			{/if}
+			</div>
 		{/if}
-		</div>
 	{/if}
 
 {/html_form}


### PR DESCRIPTION
- The FlatPress Protect plugin now has a submenu in the configuration menu in the admin area.
- It is possible to allow insecure Java scripts in this submenu if it is not equipped with a nonce.
- It is also possible to enable/disable the htaccess edit field to create or edit the file in the PrettyURLs plugin without having to disable the FlatPress Protect plugin.