### PR TITLE
Deactivate OPcache when the theme panel is called up.

### DIFF
--- a/admin/includes/panels.prototypes.php
+++ b/admin/includes/panels.prototypes.php
@@ -56,25 +56,25 @@ class AdminPanel {
 
 		$this->smarty->assign('actionname', $action);
 
-		$class = get_class($this) . "_$action";
+		$class = get_class($this) . '_' . $action;
 
 		if (!class_exists($class)) {
 
 			$f = str_replace('_', '.', $class);
 
-			$fname = ADMIN_DIR . "panels/{$this->panelname}/$f.php";
+			$fname = ADMIN_DIR . 'panels/' . $this->panelname . '/' . $f . '.php';
 
 			if (file_exists($fname)) {
 				include ($fname);
 
 				if (!class_exists($class)) {
-					trigger_error("No classes for action $action.", E_USER_ERROR);
+					trigger_error('No classes for action ' . $action . '.', E_USER_ERROR);
 				}
 
 				$obj = new $class($this->smarty);
 				return $obj;
 			} else {
-				trigger_error("No script found for action $action", E_USER_ERROR);
+				trigger_error('No script found for action ' . $action, E_USER_ERROR);
 			}
 		} else {
 			$obj = new $class($this->smarty);
@@ -118,7 +118,7 @@ class AdminPanelAction {
 		}
 
 		$this->setup();
-		do_action("admin_{$panel}_{$action}_setup");
+		do_action('admin_' . $panel . '_' . $action . '_setup');
 
 		$result = 0; // if !=0, defaultaction for this panel is called
 
@@ -127,17 +127,17 @@ class AdminPanelAction {
 				foreach ($this->commands as $cmd) {
 					if (isset($_GET [$cmd])) {
 						$result = $this->docommand($cmd, $_GET [$cmd]);
-						return apply_filters("admin_{$panel}_{$action}_{$cmd}_{$_GET[ $cmd ]}", $result);
+						return apply_filters('admin_' . $panel . '_' . $action . '_' . $cmd . '_' . $_GET [$cmd], $result);
 						// return $result;
 					}
 				}
 			}
 
 			$result = $this->main();
-			do_action("admin_{$panel}_{$action}_main");
+			do_action('admin_' . $panel . '_' . $action . '_main');
 			lang_load($this->langres);
 		} else {
-			$data = apply_filters("admin_{$panel}_{$action}_onsubmit", null);
+			$data = apply_filters('admin_' . $panel . '_' . $action . '_onsubmit', null);
 			$result = $this->onsubmit($data);
 		}
 
@@ -167,9 +167,9 @@ class AdminPanelAction {
 		$valid_evts = array_intersect(array_keys($_POST), $this->events);
 
 		if ($the_event = array_pop($valid_evts)) {
-			$event = "on{$the_event}";
+			$event = 'on' . $the_event;
 			if (method_exists($this, $event)) {
-				$data = apply_filters("admin_{$panel}_{$action}_{$event}", $data);
+				$data = apply_filters('admin_' . $panel . '_' . $action . '_' . $event, $data);
 				$returnvalue = call_user_func(array(
 					&$this,
 					$event
@@ -183,8 +183,8 @@ class AdminPanelAction {
 	function docommand($the_cmd, $the_val) {
 		global $panel, $action;
 
-		check_admin_referer("admin_{$panel}_{$action}_{$the_cmd}_{$the_val}");
-		$cmd = "do{$the_cmd}";
+		check_admin_referer('admin_' . $panel . '_' . $action . '_' . $the_cmd . '_' . $the_val);
+		$cmd = 'do' . $the_cmd;
 
 		if (method_exists($this, $cmd)) {
 			return call_user_func(array(
@@ -274,7 +274,7 @@ class AdminPanelActionValidated extends AdminPanelAction {
 		} else {
 			$this->smarty->assign('error', $errors);
 
-			$result = apply_filters("admin_{$panel}_{$action}_onerror", $this->onerror());
+			$result = apply_filters('admin_' . $panel . '_' . $action . '_onerror', $this->onerror());
 		}
 
 		return $result;

--- a/admin/main.php
+++ b/admin/main.php
@@ -8,6 +8,13 @@ utils_nocache_headers();
 
 define('MOD_ADMIN_PANEL', 1);
 
+// Deactivate OPcache when the theme panel is called up
+if (function_exists('opcache_get_status') && ini_get('opcache.enable')) {
+	if (isset($_GET ['p']) && $_GET ['p'] === 'themes') {
+		ini_set('opcache.enable', 0);
+	}
+}
+
 function wp_nonce_ays() {
 	die('We apologize, an error occurred.');
 }
@@ -38,15 +45,15 @@ function main() {
 		die();
 	}
 
-	$panelprefix = "admin.$panel";
-	$panelpath = ADMIN_DIR . "panels/$panel/$panelprefix.php";
+	$panelprefix = 'admin.' . $panel;
+	$panelpath = ADMIN_DIR . 'panels/' . $panel . '/' . $panelprefix . '.php';
 
 	$fp_admin = null;
 
 	if (file_exists($panelpath)) {
 
 		include ($panelpath);
-		$panelclass = "admin_$panel";
+		$panelclass = 'admin_' . $panel;
 
 		if (!class_exists($panelclass)) {
 			trigger_error("No class defined for requested panel", E_USER_ERROR);
@@ -71,22 +78,22 @@ function main() {
 
 	define('ADMIN_PANEL_ACTION', $action);
 	$smarty->assign('action', $action);
-	$panel_url = BLOG_BASEURL . "admin.php?p={$panel}";
-	$action_url = $panel_url . "&action={$action}";
+	$panel_url = BLOG_BASEURL . 'admin.php?p=' . $panel;
+	$action_url = $panel_url . '&action=' . $action;
 	$smarty->assign('panel_url', $panel_url);
 	$smarty->assign('action_url', $action_url);
 
 	if (!empty($_POST)) {
-		check_admin_referer("admin_{$panel}_{$action}");
+		check_admin_referer('admin_' . $panel . '_' . $action);
 	}
 
-	$smarty->assign('success', sess_remove("success_{$panel}"));
+	$smarty->assign('success', sess_remove('success_' . $panel));
 	$retval = $fp_admin_action->exec();
 
 	if ($retval > 0) { // if has REDIRECT option
 	                   // clear postdata by a redirect
 
-		sess_add("success_{$panel}", $smarty->getTemplateVars('success'));
+		sess_add('success_' . $panel, $smarty->getTemplateVars('success'));
 		$smarty->getTemplateVars('success');
 
 		$to_action = $retval > 1 ? ('&action=' . $action) : '';
@@ -99,7 +106,7 @@ function main() {
 			}
 		}
 
-		$url = "admin.php?p={$panel}{$to_action}{$with_mod}{$with_arguments}";
+		$url = 'admin.php?p=' . $panel . $to_action . $with_mod . $with_arguments;
 		utils_redirect($url);
 	}
 }
@@ -107,9 +114,9 @@ function main() {
 // smarty tag
 function admin_filter_action($string, $action) {
 	if (strpos($string, '?') === false) {
-		return $string .= "?action={$action}";
+		return $string .= '?action=' . $action;
 	} else {
-		return $string .= wp_specialchars("&action={$action}");
+		return $string .= wp_specialchars('&action=' . $action);
 	}
 }
 
@@ -117,9 +124,9 @@ function admin_filter_action($string, $action) {
 function admin_filter_command($string, $cmd, $val) {
 	global $panel, $action;
 
-	$arg = $cmd ? "&{$cmd}" : $cmd;
+	$arg = $cmd ? '&' . $cmd : $cmd;
 
-	return wp_nonce_url("{$string}{$arg}={$val}", "admin_{$panel}_{$action}_{$cmd}_{$val}");
+	return wp_nonce_url($string . $arg . '=' . $val, 'admin_' . $panel . '_' . $action . '_' . $cmd . '_' . $val);
 }
 
 function admin_panelstrings($panelprefix) {
@@ -138,7 +145,7 @@ function admin_panel_title($title, $sep) {
 	global $lang, $panel;
 
 	$t = @$lang ['admin'] ['panels'] [$panel];
-	$title = "$title $sep $t";
+	$title = $title . ' ' . $sep . ' ' . $t;
 	return $title;
 }
 
@@ -149,7 +156,7 @@ function showcontrolpanel($params, $smarty) {
 // html header
 function admin_title($title, $sep) {
 	global $lang;
-	return $title = "$title $sep {$lang['admin']['head']}";
+	return $title = $title . ' ' . $sep . ' ' . $lang ['admin'] ['head'];
 }
 
 add_filter('wp_title', 'admin_title', 10, 2);
@@ -157,7 +164,7 @@ add_filter('wp_title', 'admin_title', 10, 2);
 // setup admin_header
 function admin_header_default_action() {
 	global $panel, $action;
-	do_action("admin_{$panel}_{$action}_head");
+	do_action('admin_' . $panel . '_' . $action . '_head');
 }
 add_filter('admin_head', 'admin_header_default_action');
 


### PR DESCRIPTION
- When the theme panel is called, OPcache is deactivated, if available. This means that the change is displayed immediately after changing the theme or style.
- Further interpolations removed