### PR TITLE
The logged-in admin can now also edit other comments

### DIFF
--- a/admin/panels/entry/admin.entry.commedit.php
+++ b/admin/panels/entry/admin.entry.commedit.php
@@ -4,7 +4,7 @@
  *
  * Type:
  * Name:
- * Date: 21.02.2024
+ * Date: 30.12.2024
  * Purpose: Provides the option to edit comments
  * Input:
  *
@@ -123,12 +123,16 @@ class admin_entry_commedit extends AdminPanelActionValidated {
 	}
 
 	function onsave($content) {
+
+		$success = false;
+
 		if ($this->nosuchcomment) {
 			return PANEL_REDIRECT_DEFAULT;
 		}
 
 		$comment = comment_parse($_REQUEST ['entry'], $_REQUEST ['comment']);
-		if (isset($comment ['loggedin'])) {
+
+		if (isset($comment ['loggedin']) || user_loggedin()) {
 			$content ['loggedin'] = $comment ['loggedin'];
 			$content ['ip-address'] = $comment ['ip-address'];
 			$content ['date'] = $comment ['date'];
@@ -136,7 +140,7 @@ class admin_entry_commedit extends AdminPanelActionValidated {
 			$this->smarty->assign('success', $success ? 1 : -1);
 		}
 
-		if ($success < 0) {
+		if ($success === false || $success < 0) {
 			$this->main();
 			return PANEL_NOREDIRECT;
 		}

--- a/fp-includes/core/core.comment.php
+++ b/fp-includes/core/core.comment.php
@@ -15,6 +15,7 @@ class comment_indexer extends fs_filelister {
 			array_push($this->_list, basename($file, EXT));
 			return 0;
 		}
+		return;
 	}
 
 	// overrides parent method to return sorted results


### PR DESCRIPTION
- Fixes the error "Undefined variable $success" under PHP8.4
- Solves the problem that the admin can only edit his own comments.
- _checkFile: Return of null made explicit to fulfill the strictness of PHP 8+.