### PR TITLE
Fixes #517 |  "Array to string conversion" warning

### DIFF
--- a/fp-plugins/lastcomments/plugin.lastcomments.php
+++ b/fp-plugins/lastcomments/plugin.lastcomments.php
@@ -271,8 +271,6 @@ function plugin_lastcomments_def_atom_link() {
 	return BLOG_BASEURL . '?feed=lastcomments-atom';
 }
 
-add_action('wp_head', 'plugin_lastcomments_rsshead');
-
 /**
  * Function: plugin_lastcomments_rsshead
  *
@@ -313,11 +311,23 @@ function plugin_lastcomments_rsshead() {
 
 	$lang = lang_load('plugin:lastcomments');
 
+	// Ugly solution for #517: Type checking and validation for language strings
+	$last_key = $lang ['plugin'] ['lastcomments'] ['last'] ?? '';
+	$comments_key = $lang ['plugin'] ['lastcomments'] ['comments'] ?? '';
+
+	if (is_array($last_key)) {
+		$last_key = implode(', ', $last_key);
+	}
+
+	if (is_array($comments_key)) {
+		$comments_key = implode(', ', $comments_key);
+	}
+
 	if (plugin_lastcomments_rss()) {
 		echo '
-			<link rel="alternate" type="application/rss+xml" title="' . $lang ['plugin'] ['lastcomments'] ['last'] . ' ' . $lastcomments_count . ' ' . $lang ['plugin'] ['lastcomments'] ['comments'] . ' | RSS 2.0" href="' . plugin_lastcomments_rss_link() . '">' . //
+			<link rel="alternate" type="application/rss+xml" title="' . htmlspecialchars($last_key) . ' ' . $lastcomments_count . ' ' . htmlspecialchars($comments_key) . ' | RSS 2.0" href="' . plugin_lastcomments_rss_link() . '">' . //
 			'
-			<link rel="alternate" type="application/rss+xml" title="' . $lang ['plugin'] ['lastcomments'] ['last'] . ' ' . $lastcomments_count . ' ' . $lang ['plugin'] ['lastcomments'] ['comments'] . ' | Atom 1.0" href="' . plugin_lastcomments_atom_link() . '">
+			<link rel="alternate" type="application/rss+xml" title="' . htmlspecialchars($last_key) . ' ' . $lastcomments_count . ' ' . htmlspecialchars($comments_key) . ' | Atom 1.0" href="' . plugin_lastcomments_atom_link() . '">
 		';
 	}
 }
@@ -546,5 +556,6 @@ function truncate_with_bbcode($content, $maxLength) {
 
 add_action('comment_post', 'plugin_lastcomments_cache', 0, 2);
 add_action('init', 'plugin_lastcomments_rssinit');
+add_action('wp_head', 'plugin_lastcomments_rsshead');
 register_widget('lastcomments', 'LastComments', 'plugin_lastcomments_widget');
 ?>


### PR DESCRIPTION
Hi @azett,

I can also reproduce it. Once with my test system without cache mechanisms, but also on Pi, with the production system. However, I firmly believe that it is not a side effect of #499. When the configuration menu page is reloaded (F5), only the currently set lang_load language is loaded.

The language arrays for the configuration menu were only assigned to the template after reloading the page until 1.3.1. For users with OPcache and/or APCu, nothing happened after clicking on “Save change”. Saved changes were only loaded after reloading the configuration page. Therefore the 18 year old problem was never noticed. Now onsave() with setup() immediately pushes the changed keys into the template. And now we have two keys in lang_load - 0 and 1. After reloading the page, everything is fine again.

One possible cause may be that we are using two different Smarty instances ($smarty and $_FP_SMARTY). I hope that this will not be a problem when we switch to Smarty 5.

I have now fiddled with an ugly solution in the plugin_lastcomments_rsshead function. Wasn't the first, won't be the last :-D.