### PR TITLE
Update set_locale function

### DIFF
--- a/fp-includes/core/core.system.php
+++ b/fp-includes/core/core.system.php
@@ -190,6 +190,8 @@ function system_init() {
 
 	$GLOBALS ['lang'] = lang_load();
 
+	set_locale();
+
 	plugin_loadall();
 
 	// init smarty

--- a/fp-includes/core/core.system.php
+++ b/fp-includes/core/core.system.php
@@ -198,9 +198,7 @@ function system_init() {
 	$smarty->cache_dir = CACHE_DIR;
 	$smarty->caching = false;
 
-	// PHP error outputs and Smarty debug console
-	@ini_set('display_errors', 'on'); // on or off
-	@error_reporting(E_ALL); // E_ALL or 0
+	// Smarty debug console
 	$smarty->debugging = false; // true or false
 	//$smarty->clearCompiledTemplate();
 

--- a/search.php
+++ b/search.php
@@ -28,9 +28,6 @@ function search_display() {
 function search_main() {
 	global $lang, $smarty;
 
-	// Localize Smarty function {html_select_date}
-	set_locale();
-
 	// register Smarty modifier functions
 	$smarty->registerPlugin('modifier', 'function_exists', 'function_exists');
 	$smarty->registerPlugin('modifier', 'is_numeric', 'is_numeric');


### PR DESCRIPTION
- Plugins can access locale information
- Smarty templates could use functions that require locale information (e.g. date formats or localization strings).

Sequence:
- Before loading plugins
- Before Smarty initialization
- After loading the language configuration

This sequence ensures that all dependent components use the correct locale settings.