### PR TITLE
Replace assignByRef() with assign() (Smarty 4.5.5-safe; prep for Smarty 5)

### DIFF
--- a/admin/main.php
+++ b/admin/main.php
@@ -219,8 +219,8 @@ $smarty->registerPlugin('function', 'controlpanel', 'showcontrolpanel');
 
 $v = $lang ['admin'] [$panel] [$action];
 
-$smarty->assignByRef('panelstrings', $v);
-$smarty->assignByRef('plang', $v);
+$smarty->assign('panelstrings', $v);
+$smarty->assign('plang', $v);
 
 if (isset($_GET ['mod'])) {
 

--- a/contact.php
+++ b/contact.php
@@ -162,7 +162,7 @@ function contactform() {
 	// Initial call of the contact form
 	if (empty($_POST)) {
 		$smarty->assign('success', system_geterr('contact'));
-		$smarty->assignByRef('panelstrings', $lang ['contact']);
+		$smarty->assign('panelstrings', $lang ['contact']);
 		return;
 	}
 

--- a/fp-includes/core/core.fpdb.class.php
+++ b/fp-includes/core/core.fpdb.class.php
@@ -855,10 +855,10 @@ function smarty_block_entry($params, $content, &$smarty, &$repeat) {
 		}
 
 		foreach ($entry as $k => $v) {
-			$smarty->assignByRef($k, $entry [$k]);
+			$smarty->assign($k, $entry [$k]);
 		}
 
-		$smarty->assignByRef('id', $id);
+		$smarty->assign('id', $id);
 
 		// If PostViews plugin is active: Trigger view counter!
 		// This seems a bit hackish; please fix if possible.
@@ -905,7 +905,7 @@ function smarty_block_comment($params, $content, &$smarty, &$repeat) {
 
 		foreach ($comment as $k => $v) {
 			$kk = str_replace('-', '_', $k);
-			$smarty->assignByRef($kk, $comment [$k]);
+			$smarty->assign($kk, $comment [$k]);
 		}
 
 		if (THEME_LEGACY_MODE) {

--- a/fp-includes/core/core.theme.php
+++ b/fp-includes/core/core.theme.php
@@ -281,7 +281,7 @@ function theme_init(&$smarty, $layout = null) { /* &$mode */
 
 	$smarty->assign('pagetitle', apply_filters('wp_title', "", '&laquo;'));
 
-	$smarty->assignByRef('fp_config', $fp_config);
+	$smarty->assign('fp_config', $fp_config);
 
 	$smarty->registerPlugin('modifier', 'tag', 'theme_apply_filters_wrapper');
 	$smarty->registerPlugin('modifier', 'link', 'theme_apply_filters_link_wrapper');

--- a/fp-plugins/blockparser/plugin.blockparser.php
+++ b/fp-plugins/blockparser/plugin.blockparser.php
@@ -144,7 +144,7 @@ if (class_exists('AdminPanelAction')) {
 
 		function main() {
 			global $fp_config;
-			// $this->smarty->assignByRef('enabledpages', plugin_getoptions('blockparser'));
+			// $this->smarty->assign('enabledpages', plugin_getoptions('blockparser'));
 			$this->smarty->assign('statics', $assign = static_getlist());
 		}
 


### PR DESCRIPTION
- Replace assignByRef() with assign() (Smarty 4.5.5-safe; prep for Smarty 5)
- By-ref semantics are not used anywhere in the templates. Therefore, `$smarty->assign()` also works when FlatPress uses Smarty 4.5.5.