### PR TITLE
prep for Smarty 5/direct property access is considered legacy code

### DIFF
--- a/fp-includes/core/core.layout.php
+++ b/fp-includes/core/core.layout.php
@@ -54,8 +54,9 @@ class LayoutDefault {
 
 		// init smarty
 
-		$this->smarty->compile_dir = COMPILE_DIR;
-		$this->smarty->cache_dir = CACHE_DIR;
+		$this->smarty->setCompileDir(COMPILE_DIR);
+		// FlatPress does not use the Smarty cache, only the compiler.
+		$this->smarty->setCacheDir(CACHE_DIR);
 		$this->smarty->caching = false;
 
 		do_action('init');

--- a/fp-includes/core/core.system.php
+++ b/fp-includes/core/core.system.php
@@ -187,9 +187,9 @@ function system_init() {
 	plugin_loadall();
 
 	// init smarty
+	$smarty->setCompileDir(COMPILE_DIR);
 	// FlatPress does not use the Smarty cache, only the compiler
-	$smarty->compile_dir = COMPILE_DIR;
-	$smarty->cache_dir = CACHE_DIR;
+	$smarty->setCacheDir(CACHE_DIR);
 	$smarty->caching = false;
 
 	// Smarty debug console


### PR DESCRIPTION
- Direct property access has been considered legacy since Smarty 3.
- https://smarty-php.github.io/smarty/stable/upgrading/#removed-smarty-api-properties