### PR TITLE
Solves #629 | Versioning Java scripts and stylesheets (RFC-3986)

### DIFF
--- a/fp-includes/core/core.smarty.php
+++ b/fp-includes/core/core.smarty.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Internal Bootstrap error output, usable before core.system.php is loaded.
+ * Uses system_failure() if available, otherwise plain text 500.
+ */
+function utils_boot_failure($msg) {
+	if (function_exists('system_failure')) {
+		system_failure($msg);
+	}
+	if (!headers_sent()) {
+		header('HTTP/1.1 500 Internal Server Error');
+		header('Content-Type: text/plain; charset=utf-8');
+	}
+	echo "FlatPress bootstrap error: " . (string)$msg;
+	exit(1);
+}
+
+/**
+ * Finds the non-Composer stub of Smarty 5 under fp-includes/smarty-X.X.X/libs/Smarty.class.php
+ * and returns [path, version string] or [null, null].
+ */
+function utils_smarty_find_stub() {
+	$base = rtrim(ABS_PATH . FP_INCLUDES, '/\\');
+	$dirs = @glob($base . '/smarty-*', GLOB_ONLYDIR | GLOB_NOSORT);
+	$bestStub = null;
+	$bestVer  = null;
+	if (is_array($dirs)) {
+		foreach ($dirs as $dir) {
+			$name = basename($dir); // e.g. smarty-5.5.1
+			if (preg_match('/^smarty-(\d+\.\d+\.\d+)/', $name, $m)) {
+				$ver  = $m [1];
+				$stub = rtrim($dir, '/\\') . '/libs/Smarty.class.php';
+				if (is_file($stub) && is_readable($stub)) {
+					if ($bestVer === null || version_compare($ver, $bestVer, '>')) {
+						$bestVer  = $ver;
+						$bestStub = $stub;
+					}
+				}
+			}
+		}
+	}
+	return array($bestStub, $bestVer);
+}
+
+/**
+ * Checks and loads Smarty 5 (without Composer). Ensures that at least $minVersion is available.
+ * Uses the PSR-4 stub from fp-includes/smarty-X.X.X/libs/Smarty.class.php.
+ */
+function utils_checksmarty($minVersion = '5.5.1') {
+	// Class already there? (e.g., because it was manually integrated beforehand)
+	if (!class_exists('\\Smarty\\Smarty', false)) {
+		list($stub, $verFromDir) = utils_smarty_find_stub();
+		if (!$stub) {
+			utils_boot_failure('Smarty 5 stub not found. Expected under ' . ABS_PATH . FP_INCLUDES . 'smarty-*/libs/Smarty.class.php');
+		}
+		require_once $stub;
+	}
+
+	// After the require, the class must exist.
+	if (!class_exists('\\Smarty\\Smarty')) {
+		utils_boot_failure('Smarty 5 could not be loaded (\\Smarty\\Smarty is missing).');
+	}
+
+	// Determine version: prefers class constant, otherwise fallback from directory name
+	$detected = null;
+	if (defined('Smarty\\Smarty::SMARTY_VERSION')) { // PHP 7.2+: class constant check
+		$detected = \Smarty\Smarty::SMARTY_VERSION;
+	} else {
+		// If utils_smarty_find_stub() ran before, we use its version.
+		if (!isset($verFromDir)) {
+			list(, $verFromDir) = utils_smarty_find_stub();
+		}
+		if ($verFromDir) {
+			$detected = $verFromDir;
+		}
+	}
+
+	// Check minimum version (only if determinable)
+	if ($detected !== null && version_compare($detected, $minVersion, '<')) {
+		utils_boot_failure(sprintf('Smarty too old: %s found, >= %s required', $detected, $minVersion));
+	}
+}
+
+/**
+ * Register FlatPress Smarty plugins without using addPluginsDir() (deprecated in Smarty 5).
+ * Scans $dir for classic plugin filenames and registers them via registerPlugin()/registerFilter().
+ * Compatible with PHP 7.2–8.4.
+ */
+function fp_register_fp_plugins(\Smarty\Smarty $smarty, string $dir): void {
+	if (!is_dir($dir)) {
+		return;
+	}
+	$dh = @opendir($dir);
+	if (!$dh) {
+		return;
+	}
+	while (($file = readdir($dh)) !== false) {
+		if ($file === '.' || $file === '..' || $file [0] === '.') {
+			continue;
+		}
+		$path = $dir . DIRECTORY_SEPARATOR . $file;
+		if (!is_file($path) || pathinfo($path, PATHINFO_EXTENSION) !== 'php') {
+			continue;
+		}
+
+		// Classic plugin files: function.|modifier.|block.|compiler.|modifiercompiler.
+		if (preg_match('/^(function|modifier|block|compiler|modifiercompiler)\.([A-Za-z0-9_]+)\.php$/', $file, $m)) {
+			require_once $path;
+			$type = $m [1];
+			$name = $m [2];
+			switch ($type) {
+				case 'function':
+					$smarty->registerPlugin(\Smarty\Smarty::PLUGIN_FUNCTION, $name, 'smarty_function_' . $name);
+					break;
+				case 'block':
+					$smarty->registerPlugin(\Smarty\Smarty::PLUGIN_BLOCK, $name, 'smarty_block_' . $name);
+					break;
+				case 'modifier':
+					$smarty->registerPlugin(\Smarty\Smarty::PLUGIN_MODIFIER, $name, 'smarty_modifier_' . $name);
+					break;
+				case 'modifiercompiler':
+					$smarty->registerPlugin(\Smarty\Smarty::PLUGIN_MODIFIERCOMPILER, $name, 'smarty_modifiercompiler_' . $name);
+					break;
+				case 'compiler':
+					$smarty->registerPlugin(\Smarty\Smarty::PLUGIN_COMPILER, $name, 'smarty_compiler_' . $name);
+					break;
+			}
+			continue;
+		}
+
+		// Filters: prefilter.|postfilter.|outputfilter.|variablefilter.
+		if (preg_match('/^(pre|post|output|variable)filter\.([A-Za-z0-9_]+)\.php$/', $file, $m)) {
+			require_once $path;
+			$kind = $m [1]; // pre|post|output|variable
+			$name = $m [2];
+			$smarty->registerFilter($kind, 'smarty_' . $kind . 'filter_' . $name);
+			continue;
+		}
+
+		// Shared helpers used by other plugins (no registration, just load)
+		if (preg_match('/^shared\.([A-Za-z0-9_]+)\.php$/', $file)) {
+			require_once $path;
+			continue;
+		}
+
+		// Validation helpers (no direct registration, just make functions/classes available)
+		if (preg_match('/^validate_[A-Za-z0-9_.]+\.(php)$/', $file)) {
+			require_once $path;
+			continue;
+		}
+
+		// Inserts are removed in Smarty 5 – soft warning for plugin authors.
+		if (preg_match('/^insert\.([A-Za-z0-9_]+)\.php$/', $file, $m)) {
+			@trigger_error('Smarty insert plugin "' . $m [1] . '" is not supported in Smarty 5; convert to a function plugin.', E_USER_DEPRECATED);
+			continue;
+		}
+	}
+	closedir($dh);
+}
+?>

--- a/fp-includes/core/core.theme.php
+++ b/fp-includes/core/core.theme.php
@@ -165,32 +165,51 @@ function theme_wp_head() {
 function theme_head_stylesheet() {
 	global $fp_config, $theme;
 
-	echo "\n<!-- FP STD STYLESHEET -->\n";
+	$charset = strtoupper($fp_config ['locale'] ['charset'] ?? 'UTF-8');
 
-	// echo '<link media="screen,projection,handheld" href="';
-	echo '<link media="screen" href="';
-	echo BLOG_BASEURL . THEMES_DIR . THE_THEME;
+	echo '
+		<!-- FP STD STYLESHEET -->';
 
 	$css = defined('MOD_ADMIN_PANEL') ? $theme ['style'] ['style_admin'] : $theme ['style'] ['style_def'];
-
 	$substyle = '/' . (isset($fp_config ['general'] ['style']) ? $fp_config ['general'] ['style'] . '/' : '');
+	$base = BLOG_BASEURL . THEMES_DIR . THE_THEME . $substyle . 'res/';
 
-	echo $substyle . 'res/' . $css . '" type="text/css" rel="stylesheet">';
+	$raw_screen = $base . $css;
+	if (function_exists('utils_asset_ver')) {
+		$explicit = isset($theme ['version']) ? (string)$theme ['version'] : null;
+		$href_screen = utils_asset_ver($raw_screen, $explicit);
+	} else {
+		$href_screen = $raw_screen . ((strpos($raw_screen, '?') === false) ? '?' : '&') . 'v=' . (defined('SYSTEM_VER') ? rawurlencode(SYSTEM_VER) : time());
+	}
+	echo '
+		<link media="screen" href="' . htmlspecialchars($href_screen, ENT_QUOTES, $charset) . '" type="text/css" rel="stylesheet">';
 
-	if (@$theme ['style'] ['style_print']) {
-		echo '<link media="print" href="';
-		echo BLOG_BASEURL . THEMES_DIR . THE_THEME;
-		echo $substyle . 'res/' . $theme ['style'] ['style_print'] . '" type="text/css" rel="stylesheet">';
+	if (!empty(@$theme ['style'] ['style_print'])) {
+		$raw_print = $base . @$theme ['style'] ['style_print'];
+		if (function_exists('utils_asset_ver')) {
+			$href_print = utils_asset_ver($raw_print);
+		} else {
+			$href_print = $raw_print . ((strpos($raw_print, '?') === false) ? '?' : '&') . 'v=' . (defined('SYSTEM_VER') ? rawurlencode(SYSTEM_VER) : time());
+		}
+		echo '<link media="print" href="' . htmlspecialchars($href_print, ENT_QUOTES, $charset) . '" type="text/css" rel="stylesheet">';
 	}
 
-	echo "\n<!-- FP STD STYLESHEET -->\n";
+	echo '
+		<!-- FP STD STYLESHEET -->
+	';
 }
 
 function admin_head_action() {
-	global $theme;
-	if (!$theme ['admin_custom_interface']) {
-		echo '<link media="screen" href="' . BLOG_BASEURL . 'admin/res/admin.css" type="text/css" rel="stylesheet">';
+	global $fp_config, $theme;
+
+	$charset = strtoupper($fp_config ['locale'] ['charset'] ?? 'UTF-8');
+	$raw = BLOG_BASEURL . 'admin/res/admin.css';
+	if (function_exists('utils_asset_ver')) {
+		$href = utils_asset_ver($raw);
+	} else {
+		$href = $raw . ((strpos($raw, '?') === false) ? '?' : '&') . 'v=' . (defined('SYSTEM_VER') ? rawurlencode(SYSTEM_VER) : time());
 	}
+	echo '<link media="screen" href="' . htmlspecialchars($href, ENT_QUOTES, $charset) . '" type="text/css" rel="stylesheet">';
 }
 
 add_filter('admin_head', 'admin_head_action');

--- a/fp-includes/core/includes.php
+++ b/fp-includes/core/includes.php
@@ -1,6 +1,7 @@
 <?php
 // includes.php
 // This is just a list of all the standard includes
+require_once INCLUDES_DIR . 'core.smarty.php';
 require_once INCLUDES_DIR . 'core.utils.php';
 
 // Smarty 5 without Composer: Load PSR-4 stub – automatically finds/pulls the stub

--- a/fp-includes/fp-smartyplugins/modifier.ver.php
+++ b/fp-includes/fp-smartyplugins/modifier.ver.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Smarty modifier |ver – appends ?v=… (see utils_asset_ver()).
+ * Use in template:
+ *   <script src={" /editor.js"|ver}></script>
+ *   <link rel="stylesheet" href={"/css/app.css"|ver:$smarty.const.SYSTEM_VER}>
+ */
+function smarty_modifier_ver($path, $version = null) {
+	if (!function_exists('utils_asset_ver')) {
+		// core.utils.php should be loaded via includes.php.
+		return (string)$path;
+	}
+	return utils_asset_ver((string)$path, $version);
+}
+?>

--- a/fp-plugins/archives/plugin.archives.php
+++ b/fp-plugins/archives/plugin.archives.php
@@ -76,13 +76,15 @@ class plugin_archives_monthlist extends fs_filelister {
 function plugin_archives_head() {
 	$random_hex = RANDOM_HEX;
 	$pdir = plugin_geturl('archives');
+	$css = utils_asset_ver($pdir . 'res/togglearchive.css', SYSTEM_VER);
+	$js = utils_asset_ver($pdir . 'res/togglearchive.js', SYSTEM_VER);
 	global $PLUGIN_ARCHIVES_MONTHLIST;
 	$PLUGIN_ARCHIVES_MONTHLIST = new plugin_archives_monthlist();
 
 	echo '
 		<!-- archives -->
-		<script nonce="' . $random_hex . '" src="' . $pdir . 'res/togglearchive.js" defer></script>
-		<link rel="stylesheet" type="text/css" href="' . $pdir . 'res/togglearchive.css">
+		<script nonce="' . $random_hex . '" src="' . $js . '" defer></script>
+		<link rel="stylesheet" type="text/css" href="' . $css . '">
 	';
 
 	foreach ($PLUGIN_ARCHIVES_MONTHLIST->getList() as $y => $months) {

--- a/fp-plugins/bbcode/plugin.bbcode.php
+++ b/fp-plugins/bbcode/plugin.bbcode.php
@@ -71,12 +71,14 @@ plugin_bbcode_startup();
 function plugin_bbcode_head() {
 	$plugindir = plugin_geturl('bbcode');
 	$random_hex = RANDOM_HEX;
+	$css = utils_asset_ver($plugindir . 'res/bbcode.css', SYSTEM_VER);
+	$js = utils_asset_ver($plugindir . 'res/editor.js', SYSTEM_VER);
 
 	echo '
-		<!-- bbcode plugin -->
-		<link rel="stylesheet" type="text/css" href="' . $plugindir . 'res/bbcode.css">
-		<script nonce="' . $random_hex . '" src="' . $plugindir . 'res/editor.js"></script>
-		<!-- end of bbcode plugin -->';
+		<!-- BOF bbcode plugin -->
+		<link rel="stylesheet" type="text/css" href="' . $css . '">
+		<script nonce="' . $random_hex . '" src="' . $js . '" defer></script>
+		<!-- EOF bbcode plugin -->';
 }
 add_action('wp_head', 'plugin_bbcode_head');
 

--- a/fp-plugins/commentcenter/inc/admin.php
+++ b/fp-plugins/commentcenter/inc/admin.php
@@ -96,10 +96,25 @@ class admin_entry_commentcenter extends AdminPanelAction {
 		if (!function_exists('plugin_jquery_head')) {
 			return;
 		}
-		$src1 = plugin_geturl('commentcenter') . 'res/ajax.js';
-		$src2 = BLOG_BASEURL . 'admin.php?jslang=commentcenter';
-		echo '<script type="text/javascript" src="' . $src1 . "\"></script>\n";
-		echo '<script type="text/javascript" src="' . $src2 . "\"></script>\n";
+		global $fp_config;
+		$charset = strtoupper($fp_config ['locale'] ['charset'] ?? 'UTF-8');
+
+		$raw1 = plugin_geturl('commentcenter') . 'res/ajax.js';
+		$raw2 = BLOG_BASEURL . 'admin.php?jslang=commentcenter';
+
+		$ver1 = function_exists('utils_asset_ver') ? utils_asset_ver($raw1) : $raw1;
+		$ver2 = function_exists('utils_asset_ver') ? utils_asset_ver($raw2, defined('SYSTEM_VER') ? SYSTEM_VER : null) : $raw2 . (strpos($raw2, '?') === false ? '?' : '&') . 'v=' . (defined('SYSTEM_VER') ? rawurlencode(SYSTEM_VER) : time());
+
+		$nonce = defined('RANDOM_HEX') ? RANDOM_HEX : '';
+		$nonceAttr = $nonce !== '' ? ' nonce="' . htmlspecialchars($nonce, ENT_QUOTES, $charset) . '"' : '';
+
+		$s1 = htmlspecialchars($ver1, ENT_QUOTES, $charset);
+		$s2 = htmlspecialchars($ver2, ENT_QUOTES, $charset);
+
+		echo '
+			<script' . $nonceAttr . ' src="' . $s1 . '"></script>
+			<script' . $nonceAttr . ' src="' . $s2 . '"></script>
+		';
 	}
 
 	/**

--- a/fp-plugins/cookiebanner/plugin.cookiebanner.php
+++ b/fp-plugins/cookiebanner/plugin.cookiebanner.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * Plugin Name: CookieBanner
  * Plugin URI: https://flatpress.org
  * Description: Displays a discreet banner that informs the visitor about the use of cookies and provides a link to the <a href="./admin.php?p=static&action=write&page=privacy-policy" title="Edit me!" >privacy policy</a>. Part of the standard distribution. <a href="#" id="DeleteCookie" title="Reset CookieBanner">[Reset]</a>
@@ -10,11 +10,13 @@
 function plugin_cookiebanner_head() {
 	$pdir = plugin_geturl('cookiebanner');
 	$random_hex = RANDOM_HEX;
+	$css = utils_asset_ver($pdir . 'res/cookiebanner.css', SYSTEM_VER);
+	$js = utils_asset_ver($pdir . 'res/cookiebanner.js', SYSTEM_VER);
 	echo '
-		<!-- BOF CookieBanner CSS -->
-		<link rel="stylesheet" type="text/css" href="' . $pdir . 'res/cookiebanner.css">
-		<script nonce="' . $random_hex . '" src="' . $pdir . 'res/cookiebanner.js"></script>
-		<!-- EOF Cookiebanner CSS -->
+		<!-- BOF CookieBanner -->
+		<link rel="stylesheet" type="text/css" href="' . $css . '">
+		<script nonce="' . $random_hex . '" src="' . $js . '" defer></script>
+		<!-- EOF Cookiebanner -->
 ';
 }
 

--- a/fp-plugins/emoticons/plugin.emoticons.php
+++ b/fp-plugins/emoticons/plugin.emoticons.php
@@ -78,14 +78,16 @@ function plugin_emoticons_filter ($emostring) {
 
 // Css and js file
 function plugin_emoticons_head() {
-	global $plugin_emoticons;
+	global $plugin_emoticons, $buttonData;
 	$random_hex = RANDOM_HEX;
 	$pdir = plugin_geturl('emoticons');
+	$css = utils_asset_ver($pdir . 'res/emoticons.css', SYSTEM_VER);
+	$js = utils_asset_ver($pdir . 'res/emoticons.js', SYSTEM_VER);
 
 	$buttonData = [];
 	foreach ($plugin_emoticons as $emoText => $emoticon) {
 		$elementById = emoticon_id($emoText);
-		$buttonData[] = [
+		$buttonData [] = [
 			'id' => $elementById,
 			'text' => $emoText,
 			'icon' => $emoticon,
@@ -94,8 +96,18 @@ function plugin_emoticons_head() {
 
 	echo '
 		<!-- BOF Emoticons -->
-		<link rel="stylesheet" type="text/css" href="' . $pdir . 'res/emoticons.css">
-		<script nonce="' . $random_hex . '" src="' . $pdir . 'res/emoticons.js"></script>
+		<link rel="stylesheet" type="text/css" href="' . $css . '">
+		<script nonce="' . $random_hex . '" src="' . $js . '" defer></script>
+		<!-- EOF Emoticons -->
+	';
+}
+
+function plugin_emoticons_footer() {
+	global $buttonData;
+	$random_hex = RANDOM_HEX;
+
+	echo '
+		<!-- BOF Emoticons -->
 		<script nonce="' . $random_hex . '">
 			/**
 			 * Emoticons Plugin
@@ -104,7 +116,6 @@ function plugin_emoticons_head() {
 			document.addEventListener(\'DOMContentLoaded\', function() {
 				const existingEmoIds = buttonData.map(item => item.id);
 				const allEmoIdsExist = existingEmoIds.every(id => document.getElementById(id) !== null);
-
 				if (allEmoIdsExist) {
 					registerEmoticonButtons(buttonData);
 				}
@@ -121,6 +132,8 @@ function emoticon_id($text) {
 
 // register emoticon head
 add_action('wp_head', 'plugin_emoticons_head', 10);
+// register emoticon footer
+add_action('wp_footer', 'plugin_emoticons_footer', 10);
 // register editor toolbar
 add_filter('simple_toolbar_form', 'plugin_emoticons');
 // register to the hook

--- a/fp-plugins/favicon/plugin.favicon.php
+++ b/fp-plugins/favicon/plugin.favicon.php
@@ -9,46 +9,76 @@
  */
 
 function plugin_favicon_head() {
+	global $fp_config;
+	$charset = strtoupper($fp_config ['locale'] ['charset'] ?? 'UTF-8');
 
 	// Google Search, for example, only supports one favicon per website, whereby a website is defined by the host name.
 	// If an icon is in the main directory, do not load it, but redirect it temporarily!!!
 	redir_favicon();
 
-	// Indicates the version of the symbol. Increase it by one when you change the image ($v = '?v=3', $v = '?v=4', etc.).
+	// Indicates the version of the symbol.
 	// The browser will then immediately display the latest version.
-	$v = '?v=2';
+	$p = plugin_geturl('favicon') . 'imgs/';
+	$ver = function (string $url, $force = null): string {
+		if (function_exists('utils_asset_ver')) {
+			return utils_asset_ver($url, $force);
+		}
+		$sep = (strpos($url, '?') === false) ? '?' : '&';
+		$v = ($force !== null) ? (string)$force : (defined('SYSTEM_VER') ? (string)SYSTEM_VER : (string)time());
+		return $url . $sep . 'v=' . rawurlencode($v);
+	};
+	$e = function (string $s) use ($charset): string {
+		return htmlspecialchars($s, ENT_QUOTES, $charset);
+	};
+
+	$apple180 = $ver($p . 'apple-touch-icon.png');
+	$apple152 = $ver($p . 'apple-touch-icon-152x152.png');
+	$apple120 = $ver($p . 'apple-touch-icon-120x120.png');
+	$apple76 = $ver($p . 'apple-touch-icon-76x76.png');
+	$apple60 = $ver($p . 'apple-touch-icon-60x60.png');
+	$applePre = $ver($p . 'apple-touch-icon-precomposed.png');
+	$and256 = $ver($p . 'android-chrome-256x256.png');// For Android home screen
+	$and192 = $ver($p . 'android-chrome-192x192.png');
+	$png32 = $ver($p . 'favicon-32x32.png');
+	$png16 = $ver($p . 'favicon-16x16.png');
+	$icoMulti = $ver($p . 'favicon.ico'); // FlatPress multilayer icon
+	$safari = $ver($p . 'safari-pinned-tab.svg'); // Mask icon for Safari pinned tabs
+	$manifest = $ver($p . 'site.webmanifest.json.php', defined('SYSTEM_VER') ? SYSTEM_VER : null); // This file must be located in the imgs directory!
+	$msconfig = $ver($p . 'browserconfig.xml.php', defined('SYSTEM_VER') ? SYSTEM_VER : null);
+	$mstile = $ver($p . 'mstile-144x144.png');
 
 	echo '
 		<!-- BOF FavIcon -->
 		' . //
 
 		// Smartphone iOS Safari
-		'<link rel="apple-touch-icon" sizes="180x180" href="' . plugin_geturl('favicon') . 'imgs/apple-touch-icon.png' . $v . '">' . //
-		'<link rel="apple-touch-icon" sizes="152x152" href="' . plugin_geturl('favicon') . 'imgs/apple-touch-icon-152x152.png' . $v . '">' . //
-		'<link rel="apple-touch-icon" sizes="120x120" href="' . plugin_geturl('favicon') . 'imgs/apple-touch-icon-120x120.png' . $v . '">' . //
-		'<link rel="apple-touch-icon" sizes="76x76" href="' . plugin_geturl('favicon') . 'imgs/apple-touch-icon-76x76.png' . $v . '">' . //
-		'<link rel="apple-touch-icon" sizes="60x60" href="' . plugin_geturl('favicon') . 'imgs/apple-touch-icon-60x60.png' . $v . '">' . //
-		'<link rel="apple-touch-icon-precomposed" sizes="180x180" href="' . plugin_geturl('favicon') . 'imgs/apple-touch-icon-precomposed.png' . $v . '">' . //
+		'<link rel="apple-touch-icon" sizes="180x180" href="' . $e($apple180) . '">' . //
+		'<link rel="apple-touch-icon" sizes="152x152" href="' . $e($apple152) . '">' . //
+		'<link rel="apple-touch-icon" sizes="120x120" href="' . $e($apple120) . '">' . //
+		'<link rel="apple-touch-icon" sizes="76x76" href="' . $e($apple76)  . '">' . //
+		'<link rel="apple-touch-icon" sizes="60x60" href="' . $e($apple60)  . '">' . //
+		'<link rel="apple-touch-icon-precomposed" sizes="180x180" href="' . $e($applePre) . '">' . //
 
 		// Smartphone Android Chrome
-		'<link rel="icon" type="image/png" sizes="256x256" href="' . plugin_geturl('favicon') . 'imgs/android-chrome-256x256.png' . $v . '">' . // For Android home screen
-		'<link rel="icon" type="image/png" sizes="192x192" href="' . plugin_geturl('favicon') . 'imgs/android-chrome-192x192.png' . $v . '">' . //
-		'<link rel="icon" type="image/png" sizes="32x32" href="' . plugin_geturl('favicon') . 'imgs/favicon-32x32.png' . $v . '">' . //
-		'<link rel="icon" type="image/png" sizes="16x16" href="' . plugin_geturl('favicon') . 'imgs/favicon-16x16.png' . $v . '">' . //
-		'<link rel="manifest" href="' . plugin_geturl('favicon') . 'imgs/site.webmanifest.json.php' . $v . '">' . // This file must be located in the imgs directory!
+		'<link rel="icon" type="image/png" sizes="256x256" href="' . $e($and256) . '">' . //
+		'<link rel="icon" type="image/png" sizes="192x192" href="' . $e($and192) . '">' . //
+		'<link rel="icon" type="image/png" sizes="32x32" href="' . $e($png32) . '">' . //
+		'<link rel="icon" type="image/png" sizes="16x16" href="' . $e($png16) . '">' . //
+		'<link rel="manifest" href="' . $e($manifest) . '">' . //
 
 		// Mac OS Safari
-		'<link rel="mask-icon" href="' . plugin_geturl('favicon') . 'imgs/safari-pinned-tab.svg' . $v . '" color="#aa4142">' . // Mask icon for Safari pinned tabs
+		'<link rel="mask-icon" href="' . $e($safari) . '" color="#aa4142">' . //
 
-		// Classic/, desktop browsers
-		'<link rel="icon" sizes="16x16 32x32 48x48" href="' . plugin_geturl('favicon') . 'imgs/favicon.ico' . $v . '">' . // FlatPress multilayer icon
+		// Classic/desktop browsers
+		'<link rel="icon" sizes="16x16 32x32 48x48" href="' . $e($icoMulti) . '">' . //
 
 		// Windows 10 or higher
 		'<meta name="msapplication-TileColor" content="#b77b7b">' . //
-		'<meta name="msapplication-config" content="' . plugin_geturl('favicon') . 'imgs/browserconfig.xml.php' . $v . '">' . // This file must be located in the imgs directory!
-		'<meta name="msapplication-TileImage" content="' . plugin_geturl('favicon') . 'imgs/mstile-144x144.png' . $v . '">' . //
+		'<meta name="msapplication-config" content="' . $e($msconfig) . '">' . //
+		'<meta name="msapplication-TileImage" content="' . $e($mstile) . '">' . //
 
 		'<meta name="theme-color" content="#b77b7b">' . // Specify a color for the browser toolbar and the status bar on mobile devices
+
 		'
 		<!-- EOF FavIcon -->
 		';

--- a/fp-plugins/feed/plugin.feed.php
+++ b/fp-plugins/feed/plugin.feed.php
@@ -1,6 +1,5 @@
 <?php
-
-/*
+/**
  * Plugin Name: RSS and Atom Feed
  * Version: 1.0.1
  * Plugin URI: https://www.flatpress.org
@@ -9,14 +8,20 @@
  * Description: Activates feed buttons in the <a href="./admin.php?p=widgets" title="Widget menu">widget menu</a>. Part of the standard distribution.
  */
 
-
-function plugin_feed_head() { // stytesheet-file
+function plugin_feed_head() { // stylesheet-file
 	$pdir = plugin_geturl('feed');
+	$raw  = $pdir . 'res/feed.css.php';
+
+	if (function_exists('utils_asset_ver')) {
+		$href = utils_asset_ver($raw, defined('SYSTEM_VER') ? SYSTEM_VER : null);
+	} else {
+		$href = $raw . ((strpos($raw, '?') === false) ? '?' : '&') . 'v=' . (defined('SYSTEM_VER') ? rawurlencode(SYSTEM_VER) : time());
+	}
 
 	echo '
-	<!-- BOF Feed-Button Stylesheet -->
-	<link rel="stylesheet" type="text/css" href="' . $pdir . 'res/feed.css.php">
-	<!-- EOF Feed Stylesheet  -->
+		<!-- BOF Feed-Button Stylesheet -->
+		<link rel="stylesheet" type="text/css" href="' . htmlspecialchars($href, ENT_QUOTES, 'UTF-8') . '">
+		<!-- EOF Feed Stylesheet -->
 	';
 }
 

--- a/fp-plugins/gdprvideoembed/plugin.gdprvideoembed.php
+++ b/fp-plugins/gdprvideoembed/plugin.gdprvideoembed.php
@@ -17,9 +17,7 @@ function plugin_gdprvideoembed_head() {
 	lang_load('plugin:gdprvideoembed');
 
 	// Ensure that the language variables are correctly available as arrays
-	$lang_plugin = isset($lang ['plugin'] ['gdprvideoembed']) && is_array($lang ['plugin'] ['gdprvideoembed'])
-		? $lang ['plugin'] ['gdprvideoembed']
-		: [];
+	$lang_plugin = isset($lang ['plugin'] ['gdprvideoembed']) && is_array($lang ['plugin'] ['gdprvideoembed']) ? $lang ['plugin'] ['gdprvideoembed'] : [];
 
 	// Language variables with fallback values and type checking
 	$link = isset($lang_plugin ['link']) && is_string($lang_plugin ['link']) ? $lang_plugin ['link'] : 'Link';
@@ -42,10 +40,13 @@ function plugin_gdprvideoembed_head() {
 	$random_hex = RANDOM_HEX;
 	$plugindir = plugin_geturl('gdprvideoembed');
 
+	$css = utils_asset_ver($plugindir . 'res/gdpr-video-embed.css.php', SYSTEM_VER);
+	$js = utils_asset_ver($plugindir . 'res/gdpr-video-embed.js', SYSTEM_VER);
+
 	echo '
 		<!-- BOF GDPR Video embed -->
-		<link rel="stylesheet" type="text/css" href="' . $plugindir . 'res/gdpr-video-embed.css.php">
-		<script nonce="' . $random_hex . '" src="' . $plugindir . 'res/gdpr-video-embed.js"></script>
+		<link rel="stylesheet" type="text/css" href="' . $css . '">
+		<script nonce="' . $random_hex . '" src="' . $js . '"></script>
 		<script nonce="' . $random_hex . '">
 			/**
 			 * GDPR-Video-Embed | dynamic part
@@ -57,13 +58,11 @@ function plugin_gdprvideoembed_head() {
 						'<a class="video-link" href="https://youtu.be/%id%" rel="noopener" target="_blank" ' . //
 						'title="' . $link_title_youtube . '">' . $link . ': https://youtu.be/%id%</a>' . //
 						'<button title="' . $button_title . '">' . $button . '</button>\',
-
 					vimeo: \'<strong>' . $head_vimeo . '</strong>' . //
 						'<div>' . $hint_vimeo . '</div>' . //
 						'<a class="video-link" href="https://vimeo.com/%id%" rel="noopener" target="_blank" ' . //
 						'title="' . $link_title_vimeo . '">' . $link . ': https://vimeo.com/%id%</a>' . //
 						'<button title="' . $button_title . '">' . $button . '</button>\',
-
 					facebook: \'<strong>' . $head_facebook . '</strong>' . //
 						'<div>' . $hint_facebook . '</div>' . //
 						'<a class="video-link" href="%video_url%" rel="noopener" target="_blank" ' . //

--- a/fp-plugins/jquery/plugin.jquery.php
+++ b/fp-plugins/jquery/plugin.jquery.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * Plugin Name: jQuery
  * Version: 2.2.1
  * Plugin URI: https://www.flatpress.org
@@ -7,17 +7,21 @@
  * Author URI: https://www.flatpress.org
  * Description: Provides <a href="https://jquery.com/" title="jQuery">jQuery</a> and <a href="https://jqueryui.com/" title="jQueryUI">jQueryUI</a> locally. Part of the standard distribution.
  */
-add_action('wp_head', 'plugin_jquery_head', 0);
-
 function plugin_jquery_head() {
 	$random_hex = RANDOM_HEX;
-
 	$pdir = plugin_geturl('jquery');
+	$css = utils_asset_ver($pdir . 'res/jqueryui/1.14.1/jquery-ui.css', SYSTEM_VER);
+	$js = utils_asset_ver($pdir . 'res/jquery/3.7.1/jquery-3.7.1.js', SYSTEM_VER);
+	$jsUi = utils_asset_ver($pdir . 'res/jqueryui/1.14.1/jquery-ui.js', SYSTEM_VER);
+
 	echo '
 		<!-- start of jsUtils -->
-		<script nonce="' . $random_hex . '" src="' . $pdir . 'res/jquery/3.7.1/jquery-3.7.1.js"></script>
-		<script nonce="' . $random_hex . '" src="' . $pdir . 'res/jqueryui/1.14.1/jquery-ui.js"></script>
-		<!-- end of jsUtils -->';
+		<link rel="stylesheet" href="' . $css . '">
+		<script nonce="' . $random_hex . '" src="' . $js . '"></script>
+		<script nonce="' . $random_hex . '" src="' . $jsUi . '"></script>
+		<!-- end of jsUtils -->
+	';
 }
 
+add_action('wp_head', 'plugin_jquery_head', 0);
 ?>

--- a/fp-plugins/mediamanager/tpls/admin.plugin.mediamanager.files.tpl
+++ b/fp-plugins/mediamanager/tpls/admin.plugin.mediamanager.files.tpl
@@ -1,4 +1,4 @@
-<link rel="stylesheet" type="text/css" href="{$mmurl}res/style.css" />
+<link rel="stylesheet" type="text/css" href="{($mmurl|cat:'res/style.css')|ver:$smarty.const.SYSTEM_VER}">
 <h2>{$plang.head}</h2>
 <p>{$plang.description}</p>
 {include file="shared:errorlist.tpl"}
@@ -19,7 +19,7 @@
 	</thead>
 	<tbody>
 {if $currentgallery!=""}
-    <tr><td>&nbsp;</td>
+	<tr><td>&nbsp;</td>
 		<td class="main-cell type-gallery" colspan="5">
 			<a class="link-general" href="admin.php?p=uploader&action=mediamanager">{$plang.up}</a>
 		</td>
@@ -91,20 +91,20 @@
 	
 
 <p>
-    {$plang.selected}:
-    <select name='action'>
-        <option value='-'>{$plang.selectaction}</option>
-        {foreach from=$dwgalleries item=v}
-            <option value='atg-{$v.name}'>{$plang.addtogallery} '{$v.name}'</option>
-        {/foreach}
-    </select>
-	<input type="submit" name="mm-addto" value="{$plang.go}"/>
+	{$plang.selected}:
+	<select name='action'>
+		<option value='-'>{$plang.selectaction}</option>
+		{foreach from=$dwgalleries item=v}
+			<option value='atg-{$v.name}'>{$plang.addtogallery} '{$v.name}'</option>
+		{/foreach}
+	</select>
+	<input type="submit" name="mm-addto" value="{$plang.go}">
 </p>
 <p>
 	<label>{$plang.newgallery}:
-	<input type="text" name="mm-newgallery-name" />
+	<input type="text" name="mm-newgallery-name">
 	</label>
-	<input type="submit" name="mm-newgallery" value="{$plang.add}"/>
+	<input type="submit" name="mm-newgallery" value="{$plang.add}">
 </p>
 
 {/html_form}

--- a/fp-plugins/photoswipe/photoswipefunctions.class.php
+++ b/fp-plugins/photoswipe/photoswipefunctions.class.php
@@ -268,18 +268,24 @@ class PhotoSwipeFunctions {
 	static function pswpHead() {
 		$random_hex = RANDOM_HEX;
 		$pdir = plugin_geturl('photoswipe');
-		echo '<!-- BOF PhotoSwipe head -->
-';
+		$jQueryOldJs = utils_asset_ver($pdir . 'res/jquery-2.2.2/jquery-2.2.2.min.js', SYSTEM_VER);
+		$pswpUiJs = utils_asset_ver($pdir . 'res/photoswipe-4.1.3/photoswipe-ui-default.js', SYSTEM_VER);
+		$pswpJs = utils_asset_ver($pdir . 'res/photoswipe-4.1.3/photoswipe.js', SYSTEM_VER);
+		$pswpSkinCss = utils_asset_ver($pdir . 'res/photoswipe-4.1.3/default-skin/default-skin.css', SYSTEM_VER);
+		$pswpCss = utils_asset_ver($pdir . 'res/photoswipe-4.1.3/photoswipe.css', SYSTEM_VER);
+		echo '
+		<!-- BOF PhotoSwipe head -->';
 		if (!function_exists('plugin_jquery_head')) {
-			echo '<script nonce="' . $random_hex . '" src="' . $pdir . 'res/jquery-2.2.2/jquery-2.2.2.min.js"></script>
-';
+			echo '<script nonce="' . $random_hex . '" src="' . $jQueryOldJs . '"></script>
+		';
 		}
 		echo '
-	<script nonce="' . $random_hex . '" src="' . $pdir . 'res/photoswipe-4.1.3/photoswipe-ui-default.js" defer></script>
-	<script nonce="' . $random_hex . '" src="' . $pdir . 'res/photoswipe-4.1.3/photoswipe.js" defer></script>
-	<link rel="stylesheet" property="stylesheet" href="' . $pdir . 'res/photoswipe-4.1.3/default-skin/default-skin.css">
-	<link media="screen" href="' . $pdir . 'res/photoswipe-4.1.3/photoswipe.css" type="text/css" rel="stylesheet">
-	<!-- EOF PhotoSwipe head -->';
+		<script nonce="' . $random_hex . '" src="' . $pswpUiJs . '" defer></script>
+		<script nonce="' . $random_hex . '" src="' . $pswpJs . '" defer></script>
+		<link rel="stylesheet" property="stylesheet" href="' . $pswpSkinCss . '">
+		<link media="screen" href="' . $pswpCss . '" type="text/css" rel="stylesheet">
+		<!-- EOF PhotoSwipe head -->
+		';
 	}
 
 	/**

--- a/fp-plugins/support/plugin.support.php
+++ b/fp-plugins/support/plugin.support.php
@@ -82,12 +82,15 @@ if (class_exists('AdminPanelAction')) {
 	function plugin_support_head() {
 		$plugindir = plugin_geturl('support');
 		$random_hex = RANDOM_HEX;
+		$css = utils_asset_ver($plugindir . 'res/support.css', SYSTEM_VER);
+		$js = utils_asset_ver($plugindir . 'res/support.js', SYSTEM_VER);
 
 		echo '
-			<!-- BOF support files -->
-			<link rel="stylesheet" type="text/css" href="' . $plugindir . 'res/support.css">
-			<script nonce="' . $random_hex . '" src="' . $plugindir . 'res/support.js"></script>
-			<!-- EOF support files -->';
+		<!-- BOF support files -->
+		<link rel="stylesheet" type="text/css" href="' . $css . '">
+		<script nonce="' . $random_hex . '" src="' . $js . '" defer></script>
+		<!-- EOF support files -->
+		';
 	}
 
 	class admin_maintain_support extends AdminPanelAction {


### PR DESCRIPTION
- Sets/replaces a query parameter in a URL (RFC-3986)
- New Smarty modifier |ver – appends ?v=… (see utils_asset_ver()).
    - Use in the template: 
       - `<script src={“ /editor.js”|ver}></script>`
       - `<link rel="stylesheet" href={“/css/app.css”|ver:$smarty.const.SYSTEM_VER}>
`
- New core function utils_asset_ver()
    - Priority:
        - $version (explicit) > filemtime (local file) > SYSTEM_VER (fallback).
    - Use in PHP code, e.g.: Plugins:
        - `utils_asset_ver($url[, $version]) Example: $js = utils_asset_ver($pdir . ‘res/cookiebanner.js’, SYSTEM_VER);`