### PR TITLE
Remove old Smarty alias _FP_SMARTY

### DIFF
--- a/fp-includes/core/core.fpdb.class.php
+++ b/fp-includes/core/core.fpdb.class.php
@@ -972,16 +972,16 @@ function smarty_function_prevpage($params) {
 	return "<div class=\"alignleft\"><a href=\"" . $link . "\">" . $caption . "</a></div>";
 }
 
-$_FP_SMARTY->registerPlugin('block', 'comment', 'smarty_block_comment');
-$_FP_SMARTY->registerPlugin('block', 'comments', 'smarty_block_comments');
-$_FP_SMARTY->registerPlugin('block', 'comment_block', 'smarty_block_comments');
+$smarty->registerPlugin('block', 'comment', 'smarty_block_comment');
+$smarty->registerPlugin('block', 'comments', 'smarty_block_comments');
+$smarty->registerPlugin('block', 'comment_block', 'smarty_block_comments');
 
-$_FP_SMARTY->registerPlugin('block', 'entries', 'smarty_block_entries');
-$_FP_SMARTY->registerPlugin('block', 'entry_block', 'smarty_block_entries');
+$smarty->registerPlugin('block', 'entries', 'smarty_block_entries');
+$smarty->registerPlugin('block', 'entry_block', 'smarty_block_entries');
 
-$_FP_SMARTY->registerPlugin('block', 'entry', 'smarty_block_entry');
+$smarty->registerPlugin('block', 'entry', 'smarty_block_entry');
 
-$_FP_SMARTY->registerPlugin('function', 'nextpage', 'smarty_function_nextpage');
-$_FP_SMARTY->registerPlugin('function', 'prevpage', 'smarty_function_prevpage');
+$smarty->registerPlugin('function', 'nextpage', 'smarty_function_nextpage');
+$smarty->registerPlugin('function', 'prevpage', 'smarty_function_prevpage');
 
 ?>

--- a/fp-includes/core/core.layout.php
+++ b/fp-includes/core/core.layout.php
@@ -38,7 +38,11 @@ class LayoutDefault {
 		$this->fp_widgets = new widget_indexer();
 		$GLOBALS ['fp_widgets'] = $this->fp_widgets;
 
-		$this->smarty = $GLOBALS ['_FP_SMARTY'];
+		// Prefer modern global $smarty; fallback to legacy alias for BC.
+		$this->smarty = isset($GLOBALS ['smarty']) ? $GLOBALS ['smarty'] : (isset($GLOBALS ['_FP_SMARTY']) ? $GLOBALS ['_FP_SMARTY'] : null);
+		if ($this->smarty === null) {
+			utils_boot_failure('Smarty instance not initialized');
+		}
 
 		$this->config = $GLOBALS ['fp_config'] ['general'];
 

--- a/fp-includes/core/core.plugins.php
+++ b/fp-includes/core/core.plugins.php
@@ -138,8 +138,8 @@ function plugin_do($id, $type = null) {
 function plugin_require($id) {
 	return !plugin_loaded($id);
 	/*
-	 * global $_FP_SMARTY;
-	 * $_FP_SMARTY->trigger_error("A plugin required <strong>$id</strong> to be loaded to work properly, but $id ".
+	 * global $smarty;
+	 * $smarty->trigger_error("A plugin required <strong>$id</strong> to be loaded to work properly, but $id ".
 	 * "does not appear to be loaded. Maybe the plugins have been loaded in the wrong sequence. ".
 	 * "Check your <a href=\"admin.php?p=plugins\">plugin config</a> in the control panel");
 	 */
@@ -232,6 +232,6 @@ function plugin_getinfo($plugin) {
 	);
 }
 
-$_FP_SMARTY->registerPlugin('function', 'plugin_getdir', 'smarty_function_plugin_getdir');
+$smarty->registerPlugin('function', 'plugin_getdir', 'smarty_function_plugin_getdir');
 
 ?>

--- a/fp-includes/core/core.static.php
+++ b/fp-includes/core/core.static.php
@@ -150,8 +150,8 @@ function smarty_block_static($params, $content, &$smarty, &$repeat) {
 	return $content;
 }
 
-$_FP_SMARTY->registerPlugin('block', 'statics', 'smarty_block_statics');
-$_FP_SMARTY->registerPlugin('block', 'static_block', 'smarty_block_statics');
-$_FP_SMARTY->registerPlugin('block', 'static', 'smarty_block_static');
+$smarty->registerPlugin('block', 'statics', 'smarty_block_statics');
+$smarty->registerPlugin('block', 'static_block', 'smarty_block_statics');
+$smarty->registerPlugin('block', 'static', 'smarty_block_static');
 
 ?>

--- a/fp-includes/core/core.system.php
+++ b/fp-includes/core/core.system.php
@@ -167,7 +167,10 @@ function system_init() {
 
 	$GLOBALS ['fp_widgets'] = new widget_indexer();
 
-	$GLOBALS ['smarty'] = &$GLOBALS ['_FP_SMARTY'];
+	// Prefer modern global $smarty; keep legacy alias as fallback for BC.
+	if (!isset($GLOBALS ['smarty']) && isset($GLOBALS ['_FP_SMARTY'])) {
+		$GLOBALS ['smarty'] = &$GLOBALS ['_FP_SMARTY'];
+	}
 	$smarty = &$GLOBALS ['smarty'];
 
 	$GLOBALS ['fp_config'] = config_load();

--- a/fp-includes/core/includes.php
+++ b/fp-includes/core/includes.php
@@ -4,12 +4,13 @@
 require_once INCLUDES_DIR . 'core.smarty.php';
 require_once INCLUDES_DIR . 'core.utils.php';
 
-// Smarty 5 without Composer: Load PSR-4 stub – automatically finds/pulls the stub
-utils_checksmarty('5.5.1');
+// Smarty without Composer: Load PSR-4 stub – automatically finds/fetches the latest stub
+utils_checksmarty();
 
-// Namespace class in v5
+// Namespace class
 $smarty = new \Smarty\Smarty();
 
+// Legacy alias for historical plugins/core code.
 $_FP_SMARTY = &$smarty;
 
 // FlatPress custom resources: Classes are NOT located in the Smarty namespace -> load explicitly
@@ -17,7 +18,7 @@ require_once FP_SMARTYPLUGINS_DIR . 'resource.admin.php';
 require_once FP_SMARTYPLUGINS_DIR . 'resource.plugin.php';
 require_once FP_SMARTYPLUGINS_DIR . 'resource.shared.php';
 
-// In Smarty 5, registration is done exclusively via objects.
+// Since Smarty 5, registration is done exclusively via objects.
 $smarty->registerResource('admin',  new \Smarty_Resource_Admin());
 $smarty->registerResource('plugin', new \Smarty_Resource_Plugin());
 $smarty->registerResource('shared', new \Smarty_Resource_Shared());


### PR DESCRIPTION
- No code changes required with new, stable Smarty version.
- FlatPress automatically loads the latest PSR-4 stub.