### PR TITLE
Date and time format in templates

### DIFF
--- a/fp-interface/themes/leggero/comments.tpl
+++ b/fp-interface/themes/leggero/comments.tpl
@@ -25,7 +25,7 @@
 				{include file="shared:commentadminctrls.tpl"} {* this shows edit/delete links*}
 				
 				<p class="date">
-				<a href="{$entryid|link:comments_link}#{$id}" title="Permalink to {$name}'s comment">{$date|date_format_daily} {$lang.entryauthor.at} {$date|date_format}</a>
+				<a href="{$entryid|link:comments_link}#{$id}" title="Permalink to {$name}'s comment">{$date|date_format_daily} {$lang.entryauthor.at} {$date|date_format:"`$fp_config.locale.timeformat`"}</a>
 				</p>
 				
 				{$content|tag:comment_text}

--- a/fp-interface/themes/leggero/entry-default.tpl
+++ b/fp-interface/themes/leggero/entry-default.tpl
@@ -19,10 +19,11 @@
 				<ul class="entry-footer">
 
 					<li class="entry-info">{$lang.entryauthor.posted_by} <span itemprop="author">{$author}</span> {$lang.entryauthor.at}
-					{$date|date_format}
+					{$date|date_format:"`$fp_config.locale.timeformat`"}
 
 						<span itemprop="articleSection">
-							{if ($categories)} {$lang.plugin.categories.in} {$categories|@filed}{/if}
+							{assign var="__filed_cats" value=$categories|@filed}
+							{if $__filed_cats} {$lang.plugin.categories.in} {$__filed_cats}{/if}
 						</span>
 					</li>
 

--- a/fp-interface/themes/leggero/preview.tpl
+++ b/fp-interface/themes/leggero/preview.tpl
@@ -5,7 +5,7 @@
 				{$content|tag:the_content}
 				<ul class="entry-footer">
 					<li class="entry-info">
-					<p class="date">{$lang.entryauthor.posted_by} {$author} {$lang.entryauthor.at} {$date|date_format} </p>
+					<p class="date">{$lang.entryauthor.posted_by} {$author} {$lang.entryauthor.at} {$date|date_format:"`$fp_config.locale.timeformat`"} </p>
 					</li>
 				</ul>
 			</div>


### PR DESCRIPTION
- `theme_date_format()` correctly falls back to `$fp_config[‘locale’][‘timeformat’]` without a format.
- However, in a fresh installation, the built-in Smarty modifier date_format often uses the default format “%b %e, %Y” → display as “Aug 31,” instead of the time.
- It is safer to explicitly pass the time format.
- Only output “in” if a category is specified for a post.