### PR TITLE
Update BBCode plugin to version 2.0.0

### DIFF
--- a/fp-plugins/bbcode/plugin.bbcode.php
+++ b/fp-plugins/bbcode/plugin.bbcode.php
@@ -699,6 +699,7 @@ function &plugin_bbcode_init() {
 	// APCu cross-request reuse of parser
 	$apcu_on = function_exists('is_apcu_on') ? is_apcu_on() : false;
 	$apc_hit = false;
+	$sig = null;
 	if ($apcu_on) {
 		$dir = plugin_getdir('bbcode');
 		$sig = 'fp:bbcode:parser:v1:' . md5(implode('|', array(


### PR DESCRIPTION
- Adds request-local memoization and APCu caches across the BBCode plugin without changing output.
- The parser is cached per request and in APCu with a `path|mtime|size` signature; on APCu hits a cloned base parser is filtered so third-party extensions still apply.
- Image handling caches `getimagesize` and IPTC for local files and memoizes scaling, and toolbar image and attachment lists are cached by directory mtime.
- Large regex tables in bbcode2html are made static, and undoHtml uses a single batch replacement to cut allocations.
- APCu use is gated by `is_apcu_on()`, keys auto-invalidate on content changes.