### PR TITLE
Media Manager update to version 1.0.2

### DIFF
--- a/fp-plugins/mediamanager/plugin.mediamanager.php
+++ b/fp-plugins/mediamanager/plugin.mediamanager.php
@@ -1,7 +1,7 @@
 <?php
 /*
  * Plugin Name: Media Manager
- * Version: 1.0.1
+ * Version: 1.0.2
  * Plugin URI: https://www.flatpress.org
  * Author: FlatPress
  * Author URI: https://www.flatpress.org
@@ -12,41 +12,136 @@
 define('ITEMSPERPAGE', 50);
 
 function mediamanager_updateUseCountArr(&$files, $fupd) {
-	$params = array();
-	$params ['start'] = 0;
-	$params ['count'] = -1;
-	$params ['fullparse'] = true;
-	$q = new FPDB_Query($params, null);
+	// Expand target quantity: all images in affected galleries
+	$targets = is_array($fupd) ? $fupd : array();
+	$galleriesTouched = array(); // lc gallery names
+	foreach ($targets as $fid) {
+		if (!isset($files [$fid])) {
+			continue;
+		}
+		$t = isset($files [$fid] ['type']) ? $files [$fid] ['type'] : '';
+		if ($t === 'images' && !empty($files [$fid] ['relpath']) && strpos($files [$fid] ['relpath'], '/') !== false) {
+			$galleriesTouched [strtolower(substr($files [$fid] ['relpath'], 0, strpos($files [$fid] ['relpath'], '/')))] = true;
+		} elseif ($t === 'gallery' && !empty($files [$fid] ['name'])) {
+			$galleriesTouched [strtolower($files [$fid] ['name'])] = true;
+		}
+	}
+	if ($galleriesTouched) {
+		foreach ($files as $fid => $info) {
+			if (!isset($info ['type']) || $info ['type'] !== 'images') {
+				continue;
+			}
+			$rel = isset($info ['relpath']) ? $info ['relpath'] : '';
+			if ($rel !== '' && strpos($rel, '/') !== false) {
+				$g = strtolower(substr($rel, 0, strpos($rel, '/')));
+				if (isset($galleriesTouched [$g])) {
+					$targets [] = $fid;
+				}
+			}
+		}
+		// uniq
+		$targets = array_values(array_unique($targets, SORT_REGULAR));
+	}
 
+	// Nothing to update -> skip costly entry scan
+	if (empty($targets)) {
+		return;
+	}
+
+	// Lookup tables: one-time
+	$imgMap = array(); // relpath(lower) => [fileIds]
+	$galToImg = array(); // gallery(lower) => [image fileIds]
+	$galItems = array(); // gallery(lower) => gallery fileId
+	foreach ($targets as $fid) {
+		if (!isset($files [$fid] ['usecount'])) {
+			$files [$fid] ['usecount'] = 0;
+		}
+		$type = isset($files [$fid] ['type']) ? $files [$fid] ['type'] : '';
+		if ($type === 'images') {
+			$rel = (isset($files [$fid] ['relpath']) && $files [$fid] ['relpath'] !== '') ? $files [$fid] ['relpath'] : $files [$fid] ['name'];
+			$k = strtolower($rel);
+			$imgMap [$k] [] = $fid;
+			if (strpos($rel, '/') !== false) {
+				$g = strtolower(substr($rel, 0, strpos($rel, '/')));
+				$galToImg [$g] [] = $fid;
+			}
+		} elseif ($type === 'gallery') {
+			$galItems [strtolower($files [$fid] ['name'])] = $fid;
+		}
+	}
+
+	// Once over all entries
+	$q = new FPDB_Query(array('start' => 0, 'count' => -1, 'fullparse' => true), null);
+	// [img=images/<relpath>], with optional additional attributes
+	$reImg = '/\\[\\s*img\\b[^\\]]*?=\\s*images\\/([^\\s\\]"]+)/i';
+	// [gallery="images/<gallery>"/...] allows quotation marks, optional slash, and subsequent attributes
+	$reGal = '/\\[\\s*gallery\\b[^\\]]*?images\\/([^\\/"\\]]+)/i';
 	while ($q->hasMore()) {
 		list($entryId, $e) = $q->getEntry();
-		if (!empty($e ['content'])) {
-			foreach ($fupd as $fileId) {
-				if (!isset($files [$fileId] ['usecount'])) {
-					$files [$fileId] ['usecount'] = 0;
+		if (empty($e ['content'])) continue;
+		$c = $e ['content'];
+		// Per entry: prevents double counting of the same file
+		$counted = array();
+
+		// Direct image uses (once per unique relpath)
+		if ($imgMap && preg_match_all($reImg, $c, $m)) {
+			$rels = array_unique($m [1]);
+			foreach ($rels as $rel) {
+				$k = strtolower($rel);
+				if (!isset($imgMap [$k])) {
+					continue;
 				}
-
-				$searchterm = ($files [$fileId] ['type'] == 'gallery')
-					? "[gallery=images/" . $files [$fileId] ['name']
-					: $files [$fileId] ['type'] . "/" . $files [$fileId] ['name'];
-
-				if (strpos($e ['content'], $searchterm) !== false) {
-					$files [$fileId] ['usecount']++;
+				foreach ($imgMap [$k] as $fid) {
+					if (isset($counted [$fid])) {
+						continue;
+					}
+					$files [$fid] ['usecount']++;
+					$counted [$fid] = true;
+				}
+			}
+		}
+		// Gallery uses (once per unique gallery); only count files that have not yet been counted in this entry
+		if (($galToImg || $galItems) && preg_match_all($reGal, $c, $mg)) {
+			$gals = array_unique($mg[1]);
+			foreach ($gals as $g) {
+				$g = strtolower($g);
+				if (isset($galItems [$g]) && !isset($counted [$galItems [$g]])) {
+					$files [$galItems [$g]] ['usecount']++;
+					$counted [$galItems [$g]] = true;
+				}
+				if (isset($galToImg [$g])) {
+					foreach ($galToImg [$g] as $fid) {
+						if (isset($counted [$fid])) {
+							continue;
+						}
+						$files [$fid] ['usecount']++;
+						$counted [$fid] = true;
+					}
 				}
 			}
 		}
 	}
 
+	// Persistence: only usecount (key = relpath, fallback name)
 	$usecount = array();
-	foreach ($files as $info) {
-		if (isset($info ['name'], $info ['usecount'])) {
-			$usecount [$info ['name']] = $info ['usecount'];
+	foreach ($files as $fid => $info) {
+		if (!isset($info ['name'], $info ['usecount'])) {
+			continue;
 		}
+		$key = (!empty($info ['relpath'])) ? $info ['relpath'] : $info ['name'];
+		$usecount [$key] = (int)$info ['usecount'];
 	}
-
 	if (!empty($usecount)) {
-		plugin_addoption('mediamanager', 'usecount', $usecount);
-		plugin_saveoptions('mediamanager');
+		$opts = plugin_getoptions('mediamanager');
+		$old = (isset($opts['usecount']) && is_array($opts ['usecount'])) ? $opts ['usecount'] : array();
+		$new = $old;
+		foreach ($usecount as $k => $v) {
+			$new [$k] = $v;
+		}
+		if ($new !== $old) {
+			plugin_addoption('mediamanager', 'usecount', $new);
+			plugin_saveoptions('mediamanager');
+		}
 	}
 }
 
@@ -54,7 +149,9 @@ if (class_exists('AdminPanelAction')) {
 	include (plugin_getdir('mediamanager') . '/panels/panel.mediamanager.file.php');
 }
 
-/* invalidate count on entry save and delete */
+/**
+ * Invalidate count on entry save and delete
+ */
 function mediamanager_invalidatecount($arg) {
 	plugin_addoption('mediamanager', 'usecount', array());
 	plugin_saveoptions('mediamanager');
@@ -62,3 +159,4 @@ function mediamanager_invalidatecount($arg) {
 }
 add_filter('delete_post', 'mediamanager_invalidatecount', 1);
 add_filter('content_save_pre', 'mediamanager_invalidatecount', 1);
+?>

--- a/fp-plugins/mediamanager/tpls/admin.plugin.mediamanager.files.tpl
+++ b/fp-plugins/mediamanager/tpls/admin.plugin.mediamanager.files.tpl
@@ -34,7 +34,7 @@
 				<a class="link-general" href="admin.php?p=uploader&action=mediamanager&gallery={$v.name}">{$v.name}</a>
 			</td>
 			<td>{if $v.usecount>0}
-				<a class="link-general" href="search.php?q=images%2F{$v.name}&stype=full&Date_Day=&Date_Month=&Date_Year=&submit=Search">{$v.usecount}</a>
+				<a class="link-general" href="search.php?q=images%2F{$v.name|escape:'url'}&stype=full&author=&cat=-1&phrasetype=all&Date_Day=&Date_Month=&Date_Year=&submit=Search">{$v.usecount}</a>
 				{else}
 				0
 				{/if}
@@ -47,7 +47,7 @@
 		</tr>
 	{/foreach}
 {/if}
-{if $totalfilescount=="0" }
+{if $totalfilescount=="0"}
 	<tr><td colspan="6"><br>{$plang.nofiles} <a class="link-general" href="admin.php?p=uploader&action=default">{$plang.loadfile}</a><br><br></td></tr>
 {else}
 	{foreach from=$files item=v}
@@ -60,11 +60,19 @@
 				{/if}
 			</td>
 			<td class="main-cell type-{$v.type}"><a class="link-general{if $v.type=='images'} bbcode-popup{/if}" {if $v.type=='images'}rel="lightbox[mm]"{/if} href="{$v.url}">{$v.name}</a></td>
-			<td>{if $v.usecount>0}
-				<a class="link-general" href="search.php?q={$v.type}%2F{$v.name}&stype=full&Date_Day=&Date_Month=&Date_Year=&submit=Search">{$v.usecount}</a>
+			<td>
+			{if $v.usecount>0}
+				{assign var="vrel" value=$v.relpath|default:$v.name}
+				{assign var="vfolder" value=$v.relpath|default:''|regex_replace:"/\\/.+$/":""}
+				{if $v.type == 'images' && $v.relpath ne '' && $v.relpath ne $vfolder}
+					{assign var="vq" value="images/`$vfolder`"}
+				{else}
+					{assign var="vq" value="`$v.type`/`$vrel`"}
+				{/if}
+				<a class="link-general" href="search.php?q={$vq|escape:'url'}&stype=full&author=&cat=-1&phrasetype=all&Date_Day=&Date_Month=&Date_Year=&submit=Search">{$v.usecount}</a>
 				{else}
 				0
-				{/if}
+			{/if}
 			</td>
 			<td>{$v.size}</td>
 			<td>{$v.mtime}</td>
@@ -88,7 +96,6 @@
 		{if $smarty.foreach.pagelist.last==false} - {/if}
 	{/foreach}
 </p>
-	
 
 <p>
 	{$plang.selected}:
@@ -100,6 +107,7 @@
 	</select>
 	<input type="submit" name="mm-addto" value="{$plang.go}">
 </p>
+
 <p>
 	<label>{$plang.newgallery}:
 	<input type="text" name="mm-newgallery-name">
@@ -108,4 +116,3 @@
 </p>
 
 {/html_form}
-


### PR DESCRIPTION
- Fix Media Manager usage detection for images in subfolders and galleries.
- Count gallery references and map them to all images within the gallery folder.
- Store use counts by relative path with legacy fallback; add usage flags.
- Speed up panel by single entry pass and one `stat()` per file.
- Update UI links to search by gallery where appropriate.

<img width="1538" height="411" alt="image" src="https://github.com/user-attachments/assets/1a8bc703-f708-4fde-9e40-f3dc85cd4734" />
