### PR TITLE
Update plugin.prettyurls.php

### DIFF
--- a/fp-plugins/prettyurls/plugin.prettyurls.php
+++ b/fp-plugins/prettyurls/plugin.prettyurls.php
@@ -888,8 +888,8 @@ class Plugin_PrettyURLs {
 		// === Cross-mode canonicalization for common routes ===
 		// Routes: page/N, paged/N, category/NAME, tag/NAME, archive[s]/YYYY(/MM)?, static/SLUG, entry/SLUG
 		// Redirect only if there are no extra query params (besides 'u' in GET style).
-		$opt = (int)plugin_getoptions('prettyurls','mode');
-		if (isset($plugin_prettyurls) && isset($plugin_prettyurls->mode)) {
+		$plugin_prettyurls = isset($GLOBALS['plugin_prettyurls']) ? $GLOBALS['plugin_prettyurls'] : null;
+		if ($plugin_prettyurls && isset($plugin_prettyurls->mode)) {
 			$opt = (int)$plugin_prettyurls->mode;
 		}
 


### PR DESCRIPTION
URLs are no longer mode-mixed 


Supported routes (suffix patterns)
----------------------------------
- Pagination:                        /page/{n}/, /paged/{n}/
- Category & Tag:                /category/{name}/, /tag/{name}/
- Archives:                           /archives/{YYYY}/, /archives/{YYYY}/{MM}/, /archive/{YYYY}/, /archive/{YYYY}/{MM}/
- Bare date archives:            /{YYYY}/, /{YYYY}/{MM}/, optional /{YYYY}/{MM}/{DD}/
- Dated permalinks:             /{YYYY}/{MM}/{DD}/{slug}/
- Global feeds:                     /feed/(rss2|atom)/
- Entry comments feeds:     /{YYYY}/{MM}/{DD}/{slug}/comments/feed/(rss2|atom)/
- Static pages and entries:  /static/{slug}/, /entry/{slug}/
