### PR TITLE
Update French language strings in admin config

### DIFF
--- a/fp-interface/lang/fr-fr/lang.admin.config.php
+++ b/fp-interface/lang/fr-fr/lang.admin.config.php
@@ -30,7 +30,7 @@ $lang ['admin'] ['config'] ['default'] = array(
 	'langchoice' => 'Langue utilisée',
 
 	'intsetts' => 'Internationalisation',
-	'utctime' => 'L’heure (UTC) actuelle est',
+	'utctime' => '<abbr title="Universal Coordinated Time">L’heure (UTC) </abbr>actuelle est',
 	'timeoffset' => 'Fuseau horaire (exemple : GMT+)',
 	'hours' => 'heures',
 	'timeformat' => 'Format par défaut pour l’heure',


### PR DESCRIPTION
Hi, macadoum from the forum.

The french translation is bad and outdated.

I asked Copilot to update the translation using common and natural french based on usual translations found in other blog engines. I asked him to preserve the file structure and to update only the translated part.

I reviewed the whole file and the result is pretty good IMO. 

This is only the first file. Let me know if this looks good to you and I'll commit the rest.