### PR TITLE
QuickSpamFilter update to version 3.5.2

### DIFF
--- a/fp-plugins/qspam/lang/lang.cs-cz.php
+++ b/fp-plugins/qspam/lang/lang.cs-cz.php
@@ -3,8 +3,8 @@ $lang ['plugin'] ['qspam'] = array(
 	'error' => 'ERROR: Komentář obsahoval zakázané výrazy'
 );
 
-$lang ['admin'] ['plugin'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
-$lang ['admin'] ['plugin'] ['qspam'] = array(
+$lang ['admin'] ['entry'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
+$lang ['admin'] ['entry'] ['qspam'] = array(
 	'head' => 'Nastavení QuickSpam',
 	'desc1' => 'Nepovolit komentáře, které obsahují tato slova (napsat jedno na řádek):',
 	'desc2' => '<strong>Výstraha:</strong> Komentář bude zakázán i když jedno slovo je součástí druhého.', 

--- a/fp-plugins/qspam/lang/lang.da-dk.php
+++ b/fp-plugins/qspam/lang/lang.da-dk.php
@@ -3,8 +3,8 @@ $lang ['plugin'] ['qspam'] = array(
 	'error' => 'FEJL: Denne kommentar indeholder forbudte ord'
 );
 
-$lang ['admin'] ['plugin'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
-$lang ['admin'] ['plugin'] ['qspam'] = array(
+$lang ['admin'] ['entry'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
+$lang ['admin'] ['entry'] ['qspam'] = array(
 	'head' => 'QuickSpam Konfiguration',
 	'desc1' => 'Bloker kommentarer, der indeholder følgende forbudte ord. For hvert nyt ord skal du starte en ny linje:',
 	'desc2' => '<strong>Advarsel:</strong> En kommentar vil også blive blokeret, hvis et andet ord indeholder denne streng! (e.g. "old" matches "b<em>old</em>" too)',

--- a/fp-plugins/qspam/lang/lang.de-de.php
+++ b/fp-plugins/qspam/lang/lang.de-de.php
@@ -3,8 +3,8 @@ $lang ['plugin'] ['qspam'] = array(
 	'error' => 'Fehler: Dieser Kommentar beinhaltet verbotene Wörter'
 );
 
-$lang ['admin'] ['plugin'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
-$lang ['admin'] ['plugin'] ['qspam'] = array(
+$lang ['admin'] ['entry'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
+$lang ['admin'] ['entry'] ['qspam'] = array(
 	'head' => 'QuickSpam Konfiguration',
 	'desc1' => 'Blocke Kommentare die folgende verbotene Wörter enthalten. Für jedes neue Wort bitte eine neue Zeile beginnen:',
 	'desc2' => '<strong>Warnung:</strong> Ein Kommentar wird auch geblockt, wenn ein anderes Wort diese Zeichenfolge enthält! (Beispiel: "alt" ist auch Teil von "h<strong>alt</strong>")',

--- a/fp-plugins/qspam/lang/lang.el-gr.php
+++ b/fp-plugins/qspam/lang/lang.el-gr.php
@@ -3,8 +3,8 @@ $lang ['plugin'] ['qspam'] = array(
 	'error' => 'ΣΦΑΛΜΑ: Το σχόλιο αυτό περιέχει απαγορευμένες λέξεις'
 );
 
-$lang ['admin'] ['plugin'] ['submenu'] ['qspam'] = 'Φίλτρο QuickSpam';
-$lang ['admin'] ['plugin'] ['qspam'] = array(
+$lang ['admin'] ['entry'] ['submenu'] ['qspam'] = 'Φίλτρο QuickSpam';
+$lang ['admin'] ['entry'] ['qspam'] = array(
 	'head' => 'Ρύθμιση του QuickSpam',
 	'desc1' => 'Αποτροπή σχολίων που περιέχουν τις παρακάτω λέξεις (γράψτε μία ανά σειρά):',
 	'desc2' => '<strong>Προσοχή:</strong> Το σχόλιο θα αποτραπεί ακόμη κι αν η απαγορευμένη λέξη είναι μέρος κάποιας άλλης. (π.χ. Το "παλιά" ταιριάζει με το "b<em>παλιάλογο</em>" επίσης)',

--- a/fp-plugins/qspam/lang/lang.en-us.php
+++ b/fp-plugins/qspam/lang/lang.en-us.php
@@ -3,8 +3,8 @@ $lang ['plugin'] ['qspam'] = array(
 	'error' => 'ERROR: The comment contained banned words'
 );
 
-$lang ['admin'] ['plugin'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
-$lang ['admin'] ['plugin'] ['qspam'] = array(
+$lang ['admin'] ['entry'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
+$lang ['admin'] ['entry'] ['qspam'] = array(
 	'head' => 'QuickSpam Configuration',
 	'desc1' => 'Do not allow comments containing these words (write one per line):',
 	'desc2' => '<strong>Warning:</strong> A comment will be disallowed even when one word is part of another. (e.g. "old" matches "b<em>old</em>" too)',

--- a/fp-plugins/qspam/lang/lang.es-es.php
+++ b/fp-plugins/qspam/lang/lang.es-es.php
@@ -3,8 +3,8 @@ $lang ['plugin'] ['qspam'] = array(
 	'error' => 'ERROR: El comentario contenía palabras prohibidas.'
 );
 
-$lang ['admin'] ['plugin'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
-$lang ['admin'] ['plugin'] ['qspam'] = array(
+$lang ['admin'] ['entry'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
+$lang ['admin'] ['entry'] ['qspam'] = array(
 	'head' => 'Configuración de QuickSpam',
 	'desc1' => 'no permita comentarios que contengan estas palabras (escriba uno por línea):',
 	'desc2' => '<strong>Warning:</strong> No se permitirá un comentario incluso cuando una palabra sea parte de otra. (Por Ej. "old" también coincide con "b<em>old</em>")',

--- a/fp-plugins/qspam/lang/lang.eu-es.php
+++ b/fp-plugins/qspam/lang/lang.eu-es.php
@@ -3,8 +3,8 @@ $lang ['plugin'] ['qspam'] = array(
 	'error' => 'ERROREA: iruzkinak debekatuta dauden hitzak ditu.'
 );
 
-$lang ['admin'] ['plugin'] ['submenu'] ['qspam'] = 'QuickSpam iragazkia';
-$lang ['admin'] ['plugin'] ['qspam'] = array(
+$lang ['admin'] ['entry'] ['submenu'] ['qspam'] = 'QuickSpam iragazkia';
+$lang ['admin'] ['entry'] ['qspam'] = array(
 	'head' => 'QuickSpam konfigurazioa',
 	'desc1' => 'Ez onartu hitz hauek dituzten iruzkinak (idatzi lerro bakoitzeko bat):',
 	'desc2' => '<strong>Abisua:</strong> iruzkin bat ez da onartuko blokeatutako hitz bat beste baten barne idazten denean. Adib. "ero" hitza blokeatu nahi bada, "goiz<em>ero</em>" hitza ere blokeatuko da.',

--- a/fp-plugins/qspam/lang/lang.fr-fr.php
+++ b/fp-plugins/qspam/lang/lang.fr-fr.php
@@ -3,8 +3,8 @@ $lang ['plugin'] ['qspam'] = array(
 	'error' => 'ERREUR: le commentaire contient des mots bannis'
 );
 
-$lang ['admin'] ['plugin'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
-$lang ['admin'] ['plugin'] ['qspam'] = array(
+$lang ['admin'] ['entry'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
+$lang ['admin'] ['entry'] ['qspam'] = array(
 	'head' => 'Configuration de QuickSpam',
 	'desc1' => 'Ne pas autoriser les commentaires qui contiennent les mots suivants (un par ligne):',
 	'desc2' => '<strong>Attention:</strong> Un commentaire sera d&eacute;sactiv&eacute; s\'il contient un ou des mots bannis. (Exemple: "old" est pr&eacute;sent dans le mot "b<em>old</em>" &eacute;galement)',

--- a/fp-plugins/qspam/lang/lang.it-it.php
+++ b/fp-plugins/qspam/lang/lang.it-it.php
@@ -3,8 +3,8 @@ $lang ['plugin'] ['qspam'] = array(
 	'error' => 'ERRORE: Il commento contiene parole vietate'
 );
 
-$lang ['admin'] ['plugin'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
-$lang ['admin'] ['plugin'] ['qspam'] = array(
+$lang ['admin'] ['entry'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
+$lang ['admin'] ['entry'] ['qspam'] = array(
 	'head' => 'Configurazione di QuickSpam',
 	'desc1' => 'Non consentire commenti che contengono queste parole (scrivine una per riga):',
 	'desc2' => '<strong>Attenzione:</strong> Un commento verrà vietato anche quando una parola fa parte di un\'altra parola. (ad esempio. "gomma" corrisponde anche a "s<em>gomma</em>ta" )',

--- a/fp-plugins/qspam/lang/lang.ja-jp.php
+++ b/fp-plugins/qspam/lang/lang.ja-jp.php
@@ -3,8 +3,8 @@ $lang ['plugin'] ['qspam'] = array(
 	'error' => 'エラー: 禁止単語が、含まれていました。'
 );
 
-$lang ['admin'] ['plugin'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
-$lang ['admin'] ['plugin'] ['qspam'] = array(
+$lang ['admin'] ['entry'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
+$lang ['admin'] ['entry'] ['qspam'] = array(
 	'head' => 'QuickSpamFilterの設定',
 	'desc1' => 'これらの禁止単語を含むコメントを許可しません (一行に一語を記述してください):',
 	'desc2' => '<strong>注意:</strong> もし禁止単語が記述の一部であっても、コメントを許可しません。 (例. "全部" は "完<em>全部</em>分" にもマッチします)',

--- a/fp-plugins/qspam/lang/lang.nl-nl.php
+++ b/fp-plugins/qspam/lang/lang.nl-nl.php
@@ -3,8 +3,8 @@ $lang ['plugin'] ['qspam'] = array(
 	'error' => 'ERROR: Het commentaar bevatte verboden woorden'
 );
 
-$lang ['admin'] ['plugin'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
-$lang ['admin'] ['plugin'] ['qspam'] = array(
+$lang ['admin'] ['entry'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
+$lang ['admin'] ['entry'] ['qspam'] = array(
 	'head' => 'QuickSpam Configuratie',
 	'desc1' => 'Commentaren met deze woorden niet toestaan (schrijf er één per regel):',
 	'desc2' => '<strong>Waarschuwing:</strong> Een commentaar wordt niet toegestaan, zelfs als het ene woord deel uitmaakt van een ander woord. (e.g. "old" matches "b<em>old</em>" too)',

--- a/fp-plugins/qspam/lang/lang.pt-br.php
+++ b/fp-plugins/qspam/lang/lang.pt-br.php
@@ -3,8 +3,8 @@ $lang ['plugin'] ['qspam'] = array(
 	'error' => 'ERRO: O comentário continha palavras proibidas.'
 );
 
-$lang ['admin'] ['plugin'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
-$lang ['admin'] ['plugin'] ['qspam'] = array(
+$lang ['admin'] ['entry'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
+$lang ['admin'] ['entry'] ['qspam'] = array(
 	'head' 	=> 'Configuração do QuickSpam',
 	'desc1' => 'Não permita comentários contendo estas palavras (escreva um por linha):',
 	'desc2' => '<strong>Aviso:</strong> Um comentário não será permitido, mesmo quando uma palavra fizer parte de outra. (exemplo, "arte" também corresponde a "p<em>arte</em>")',

--- a/fp-plugins/qspam/lang/lang.ru-ru.php
+++ b/fp-plugins/qspam/lang/lang.ru-ru.php
@@ -3,8 +3,8 @@ $lang ['plugin'] ['qspam'] = array(
 	'error' => 'ОШИБКА: Комментарий содержит запрещенные слова'
 );
 
-$lang ['admin'] ['plugin'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
-$lang ['admin'] ['plugin'] ['qspam'] = array(
+$lang ['admin'] ['entry'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
+$lang ['admin'] ['entry'] ['qspam'] = array(
 	'head' => 'Конфигурация QuickSpam',
 	'desc1' => 'Не допускаются комментарии, содержащие эти слова (пишите по одному в строке):',
 	'desc2' => '<strong>Предупреждение:</strong> Комментарий будет запрещен даже в том случае, если одно слово является частью другого. ' .

--- a/fp-plugins/qspam/lang/lang.sl-si.php
+++ b/fp-plugins/qspam/lang/lang.sl-si.php
@@ -3,8 +3,8 @@ $lang ['plugin'] ['qspam'] = array(
 	'error' => 'NAPAKA: Komentar vsebuje prepovedane besede'
 );
 
-$lang ['admin'] ['plugin'] ['submenu'] ['qspam'] = 'Hitri Spam Filter';
-$lang ['admin'] ['plugin'] ['qspam'] = array(
+$lang ['admin'] ['entry'] ['submenu'] ['qspam'] = 'Hitri Spam Filter';
+$lang ['admin'] ['entry'] ['qspam'] = array(
 	'head' => 'Nastavitve Hitrega Spam FIltra',
 	'desc1' => 'Ne dovoli komentarjev, ki vsebujejo naslednje besede (napiši eno besedo na vrstico):',
 	'desc2' => '<strong>Opozorilo:</strong> Komentar ne bo dovoljen, če vsebuje eno prepovedano besedo tudi kot del druge besede. (npr. "stara" se ujema tudi z "pre<strong>stara</strong>")',

--- a/fp-plugins/qspam/lang/lang.tr-tr.php
+++ b/fp-plugins/qspam/lang/lang.tr-tr.php
@@ -3,8 +3,8 @@ $lang ['plugin'] ['qspam'] = array(
 	'error' => 'HATA: Yorumda yasaklı kelimeler bulundu'
 );
 
-$lang ['admin'] ['plugin'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
-$lang ['admin'] ['plugin'] ['qspam'] = array(
+$lang ['admin'] ['entry'] ['submenu'] ['qspam'] = 'QuickSpamFilter';
+$lang ['admin'] ['entry'] ['qspam'] = array(
 	'head' => 'QuickSpam Yapılandırması',
 	'desc1' => 'Bu kelimeleri içeren yorumlara izin verme (her birini bir satıra yazın):',
 	'desc2' => '<strong>Uyarı:</strong> Bir kelime başka bir kelimenin içinde olsa bile yorum engellenecektir. (Örneğin, "old" kelimesi "<em>old</em>" içinde de eşleşir)',

--- a/fp-plugins/qspam/tpls/admin.plugin.qspam.tpl
+++ b/fp-plugins/qspam/tpls/admin.plugin.qspam.tpl
@@ -17,13 +17,12 @@
 	<dt><label>{$plang.desc3}</label></dt>
 	<dd>
 		{$plang.desc3pre}
-		<input type="text" class="smalltextinput" id="qs-number" name="qs-number" value="{$qscfg.number}" />
+		<input type="text" class="smalltextinput" id="qs-number" name="qs-number" value="{$qscfg.number}">
 		{$plang.desc3post}
 	</dd>
-	
 </dl>
 
 <div class="buttonbar">
-	<input type="submit" value="{$plang.submit}"/>
+	<input type="submit" value="{$plang.submit}">
 </div>
 {/html_form}


### PR DESCRIPTION
Fixes two issues:
- BBcode `[url` and `href` are blocked, but not generic URLs
- The admin cannot see which standard bad words are set

Thank you for reporting the bug to macadoum
https://forum.flatpress.org/viewtopic.php?p=3349#p3349