### PR TITLE
Various fixes

### DIFF
--- a/defaults.php
+++ b/defaults.php
@@ -26,11 +26,11 @@ define('DUMB_MODE_ENABLED', false);
 define('FILE_PERMISSIONS', 0644); // 0644 is recommended
 define('DIR_PERMISSIONS', 0755); // 0755 is recommended
 
-// FlatPress core: This includes this file, recursively the directories ADMIN_DIR, FP_INCLUDES, CONFIG_DIR, USERS_DIR, LANG_DIR, SHARED_TPLS and PLUGINS_DIR
+// FlatPress core: This includes this file, recursively the directories ADMIN_DIR, FP_INCLUDES, CONFIG_DIR, USERS_DIR, LANG_DIR and SHARED_TPLS
 define('CORE_FILE_PERMISSIONS', 0640); // 0640 for productive operation
 define('CORE_DIR_PERMISSIONS', 0750); // 0750 for productive operation
 
-// For all other files and directories, e.g. FP_INTERFACE, THEMES_DIR
+// For all other files and directories, e.g. FP_INTERFACE, THEMES_DIR and PLUGINS_DIR
 define('RESTRICTED_FILE_PERMISSIONS', 0644); // 0644 is recommended
 define('RESTRICTED_DIR_PERMISSIONS', 0755); // 0755 is recommended
 

--- a/fp-includes/core/core.entry.php
+++ b/fp-includes/core/core.entry.php
@@ -425,7 +425,7 @@ function entry_parse($id, $raw = false) {
 		}
 	}
 
-	$fc = io_load_file($f);
+	$fc = io_load_file($f, array('exists' => true, 'mt' => $mt, 'sz' => $sz));
 	if (!$fc) {
 		return array();
 	}

--- a/fp-includes/core/core.filesystem.php
+++ b/fp-includes/core/core.filesystem.php
@@ -309,7 +309,7 @@ class fs_chmodder extends fs_filelister {
 
 		if (is_dir($path)) {
 			$retval = 1;
-			if ($is_admin_dir || $is_config_dir || $is_users_dir || $is_includes_dir || $is_lang_dir || $is_sharedtpls_dir || $is_plugin_dir) {
+			if ($is_admin_dir || $is_config_dir || $is_users_dir || $is_includes_dir || $is_lang_dir || $is_sharedtpls_dir) {
 				// Core permissions for system-critical directories
 				$chmod_value = CORE_DIR_PERMISSIONS;
 			} else {
@@ -321,7 +321,7 @@ class fs_chmodder extends fs_filelister {
 			if ($is_defaults_file) {
 				// Specific permissions for defaults.php
 				$chmod_value = CORE_FILE_PERMISSIONS;
-			} elseif ($is_admin_dir || $is_config_dir || $is_users_dir || $is_includes_dir || $is_lang_dir || $is_sharedtpls_dir || $is_plugin_dir) {
+			} elseif ($is_admin_dir || $is_config_dir || $is_users_dir || $is_includes_dir || $is_lang_dir || $is_sharedtpls_dir) {
 				// Core permissions for system-critical files
 				$chmod_value = CORE_FILE_PERMISSIONS;
 			} else {
@@ -367,7 +367,6 @@ function restore_chmods() {
 	$files_includes = fs_chmod_recursive(FP_INCLUDES);
 	$files_lang = fs_chmod_recursive(LANG_DIR);
 	$files_sharedtpls = fs_chmod_recursive(SHARED_TPLS);
-	$files_plugins = fs_chmod_recursive(PLUGINS_DIR);
 
 	// Combine results from all directories
 	$files = array_merge(
@@ -378,8 +377,7 @@ function restore_chmods() {
 		$files_users,
 		$files_includes,
 		$files_lang,
-		$files_sharedtpls,
-		$files_plugins
+		$files_sharedtpls
 	);
 	//error_log("DEBUG: Files updated: " . print_r($files, true));
 

--- a/index.php
+++ b/index.php
@@ -41,9 +41,18 @@ function index_404error() {
 function index_singlepost(&$params, &$module) {
 	global $fpdb, $theme, $fp_params;
 
-$entry = array();
+	$entry = array();
 	$params ['id'] = $fp_params ['entry'];
 	$params ['fullparse'] = true;
+
+	// Comments list is only needed on the dedicated comments view.
+	// For the single entry view we keep a cheap comment count to avoid directory scans.
+	if (isset($fp_params ['comments'])) {
+		$params ['comments'] = true;
+	} else {
+		$params ['commentcount'] = true;
+	}
+
 	$fpdb->query($params);
 
 	if (@$theme ['hassingle']) {
@@ -55,7 +64,6 @@ $entry = array();
 	if (isset($fp_params ['comments'])) {
 
 		$module = 'comments.tpl';
-		$params ['comments'] = true;
 
 		include ('comments.php');
 	}
@@ -179,6 +187,11 @@ function index_main() {
 	}
 
 	$params ['fullparse'] = true;
+
+	// Default front-end listing: keep comment count available without loading full comment lists.
+	if (!isset($params ['comments']) && !isset($params ['commentcount'])) {
+		$params ['commentcount'] = true;
+	}
 
 	$fpdb->query($params);
 


### PR DESCRIPTION
Fixes 6 issues:

- "Touch" comment directory per entry (directory scan or `comment_getlist()`) to only get the number of comments.
    - Solution: Stream only fetches count, not list.
- For single entries without comment view, `fullparse=true` still prepared the complete comment list.
    - Solution: After the first scan, it is only 1 read + 1 dir mtime per request.
- Entry parsing in general (each entry file) already does `filemtime/filesize`, then `io_load_file()` did it again.
    - Solution: Removed duplicate file stats for entry files.
- Comment list cache signature
    - Solution: Reduced redundant exists checks
- Missing intl extension in `strftime_replacement()` leads to fatal error.
    - Solution: Fallback built in.
- Overly restrictive access permissions on shared web hosts, e.g., all-inkl, lead to access problems on plugin resources
(#760)
    - Solution: `PLUGINS_DIR` is assigned octal `0755` and its files octal `0644`