### PR TITLE
Embedded videos (iFrames) are permitted

### DIFF
--- a/fp-includes/core/core.plugins.php
+++ b/fp-includes/core/core.plugins.php
@@ -72,6 +72,9 @@ class plugin_indexer extends fs_filelister {
 			apcu_set($key, $$var, 0);
 		}
 
+		// Expose enabled plugin IDs globally for plugins that need to check activation state
+		$GLOBALS [$var] = $$var;
+
 		foreach ($$var as $plugin) {
 			$e = plugin_load($plugin, $checkonly);
 			if ($e) {

--- a/fp-plugins/fpprotect/plugin.fpprotect.php
+++ b/fp-plugins/fpprotect/plugin.fpprotect.php
@@ -32,10 +32,7 @@ function fpprotect_get_options() {
 }
 
 /**
- * Check whether a plugin is enabled (listed in fp-content/config/plugins.conf.php).
- *
- * We cannot reliably use function_exists() here because FlatPress loads plugin files
- * in the order of fp_plugins, and fpprotect may be included before gdprvideoembed.
+ * Check whether a plugin is enabled
  *
  * @param string $id Plugin ID.
  * @return bool
@@ -44,23 +41,6 @@ function fpprotect_is_plugin_enabled($id) {
 	// Preferred: the enabled plugin list already loaded for this request
 	if (isset($GLOBALS ['fp_plugins']) && is_array($GLOBALS ['fp_plugins'])) {
 		return in_array($id, $GLOBALS ['fp_plugins'], true);
-	}
-
-	// Fallback: load enabled plugin list from configuration
-	if (defined('CONFIG_DIR')) {
-		/** @phpstan-ignore-next-line */
-		$conf = CONFIG_DIR . 'plugins.conf.php';
-		/** @phpstan-ignore-next-line */
-		if (file_exists($conf)) {
-			$fp_plugins = array();
-			/** @phpstan-ignore-next-line */
-			include_once ($conf);
-			/** @phpstan-ignore-next-line */
-			if (isset($fp_plugins) && is_array($fp_plugins)) {
-				/** @phpstan-ignore-next-line */
-				return in_array($id, $fp_plugins, true);
-			}
-		}
 	}
 
 	return false;


### PR DESCRIPTION
- Embedded videos (iFrames) are permitted by the FlatPress Protect plugin if the GDPR Video embed plugin is active.
<img width="1484" height="133" alt="image" src="https://github.com/user-attachments/assets/fe86ba7b-31fe-4cfd-b33b-a6e9aea70e0c" />

- This improves the user experience and avoids the admin having to generally allow external iFrames.