### PR TITLE
Fixes an update problem with the disposable email blocklist

### DIFF
--- a/fp-plugins/newsletter/plugin.newsletter.php
+++ b/fp-plugins/newsletter/plugin.newsletter.php
@@ -226,11 +226,14 @@ function plugin_newsletter_http_get(string $url, ?int &$httpCode = null, ?string
 			],
 		]);
 
+		/** @var array<int, string> $http_response_header */
+		$http_response_header = [];
+
 		$data = @file_get_contents($url, false, $context);
 
 		// Determine final HTTP code (after redirects, if any)
 		/** @var array<int, string> $headers */
-		$headers = $http_response_header ?? [];
+		$headers = $http_response_header;
 		foreach ($headers as $h) {
 			if (preg_match('#^HTTP/[\d.]+\s+(\d{3})#', $h, $m)) {
 				$httpCode = (int) $m[1];


### PR DESCRIPTION
An error in the newsletter plugin has been fixed:
- No more `get_headers()` preflight per request. Instead, external loading only occurs when absolutely necessary:
    - Blocklist file missing → immediate initial fetch
    - or from the 25th and not yet updated this month → monthly update

Throttle against log spam:
- Initial fetch: max. 1 attempt per hour
- Monthly update: max. 1 attempt per day