### PR TITLE
Addition to #791

### DIFF
--- a/fp-includes/core/includes.php
+++ b/fp-includes/core/includes.php
@@ -3,6 +3,7 @@
 // This is just a list of all the standard includes
 require_once INCLUDES_DIR . 'core.filesystem.php';
 require_once INCLUDES_DIR . 'core.fileio.php';
+require_once INCLUDES_DIR . 'core.mbstring-polyfill.php';
 require_once INCLUDES_DIR . 'core.smarty.php';
 
 // Smarty without Composer: Load PSR-4 stub – automatically finds/fetches the latest stub
@@ -25,7 +26,6 @@ $includes = [
 	'core.wp-formatting.php',
 	'core.wp-default-filters.php',
 
-	'core.mbstring-polyfill.php',
 	'core.utils.php',
 	'core.cache.php',
 	'core.blogdb.php',


### PR DESCRIPTION
- MB_CASE_FOLD only exists in PHP 7.3 and later, so it has been removed.
- The polyfill must be loaded before Smarty. That's it.
- https://github.com/symfony/polyfill-mbstring

Notes:
- This is NOT a full mbstring replacement!!!