### PR TITLE
Fixes #805 | Gallery images are displayed again in the RSS feed

### DIFF
--- a/fp-plugins/photoswipe/photoswipefunctions.class.php
+++ b/fp-plugins/photoswipe/photoswipefunctions.class.php
@@ -99,6 +99,50 @@ class PhotoSwipeFunctions {
 		$titlePlain = str_replace(array("\r", "\n"), ' ', strip_tags($titleDecoded));
 		$titleEscaped = htmlspecialchars($titlePlain, ENT_QUOTES | ENT_HTML5, $charset);
 
+		// In RSS/Atom feeds, output a plain <img> element (no PhotoSwipe wrappers, no thumbnail generation).
+		if (function_exists('is_rss_feed') && is_rss_feed()) {
+			$altRaw = isset($attr ['alt']) ? (string)$attr ['alt'] : $titlePlain;
+			$altDecoded = self::decode_title_entities($altRaw, $charset);
+			$altPlain = str_replace(array("\r", "\n"), ' ', strip_tags($altDecoded));
+			$altEscaped = htmlspecialchars($altPlain, ENT_QUOTES | ENT_HTML5, $charset);
+
+			$wAttr = '';
+			if (isset($attr ['width']) && is_scalar($attr ['width'])) {
+				$tmp = (string)$attr ['width'];
+				if (preg_match('/^\d+$/', $tmp)) {
+					$wAttr = ' width="' . $tmp . '"';
+				}
+			}
+			$hAttr = '';
+			if (isset($attr ['height']) && is_scalar($attr ['height'])) {
+				$tmp = (string)$attr ['height'];
+				if (preg_match('/^\d+$/', $tmp)) {
+					$hAttr = ' height="' . $tmp . '"';
+				}
+			}
+
+			$class = ' class="center"';
+			if (isset($attr ['float']) && is_scalar($attr ['float'])) {
+				$f = strtolower((string)$attr ['float']);
+				if ($f === 'left' || $f === 'right') {
+					$class = ' class="float' . $f . '"';
+				}
+			}
+
+			$src = $imgUrl;
+			if ($imageIsLocal && ($wAttr !== '' || $hAttr !== '')) {
+				$thumbRel = 'fp-content/' . dirname($img) . '/.thumbs/' . basename($img);
+				$thumbPathRel = $thumbRel;
+				bbcode_remap_url($thumbPathRel);
+				if (file_exists($thumbPathRel)) {
+					$src = BLOG_BASEURL . $thumbPathRel;
+				}
+			}
+			$srcUrl = htmlspecialchars($src, ENT_QUOTES | ENT_HTML5, $charset);
+			$hrefUrl = htmlspecialchars($imgUrl, ENT_QUOTES | ENT_HTML5, $charset);
+			return '<a href="' . $hrefUrl . '"><img src="' . $srcUrl . '" alt="' . $altEscaped . '" title="' . $titleEscaped . '"' . $class . $wAttr . $hAttr . '></a>';
+		}
+
 		// image may float, according the the given float attribute - if not given, use "nofloat" class
 		$floatClasses = 'thumbnail nofloat';
 		if (isset($attr ['float'])) {

--- a/fp-plugins/photoswipe/plugin.photoswipe.php
+++ b/fp-plugins/photoswipe/plugin.photoswipe.php
@@ -56,15 +56,52 @@
  * gallery directory. You may edit them with the Gallery captions plugin.
  */
 
-// Include the plugin's PHP files
+// Function to detect if the current request is for an RSS or Atom feed
+function is_rss_feed() {
+	// Check if 'feed' parameter is set and matches valid feed types
+	if (isset($_GET ['feed']) && in_array(strtolower($_GET ['feed']), ['rss2', 'atom'])) {
+		return true;
+	}
+
+	// Check if 'x' parameter starts with 'feed:'
+	if (isset($_GET ['x']) && strpos(strtolower($_GET ['x']), 'feed:') === 0) {
+		return true;
+	}
+
+	// Fallback for REQUEST_URI if it's not available
+	$request_uri = strtolower($_SERVER ['REQUEST_URI'] ?? ($_SERVER ['SCRIPT_NAME'] . ($_SERVER ['QUERY_STRING'] ?? '')));
+
+	// Check if the request URI explicitly matches a feed endpoint
+	if (preg_match('#/(feed/rss2|feed/atom)(/|$)#', $request_uri)) {
+		return true;
+	}
+
+	// Optional: Check if the content type matches RSS/Atom types
+	if (!empty($_SERVER ['HTTP_ACCEPT'])) {
+		if (strpos($_SERVER ['HTTP_ACCEPT'], 'application/rss+xml') !== false) {
+			return true;
+		}
+		if (strpos($_SERVER ['HTTP_ACCEPT'], 'application/atom+xml') !== false) {
+			return true;
+		}
+	}
+
+	// If none of the conditions match, it's not a feed request
+	return false;
+}
+
+// Always load the plugin tag handlers
 include_once dirname(__FILE__) . '/photoswipefunctions.class.php';
 
-// Initialize the BBCode tags of the plugin
+// Always register BBCode tags ([img], [gallery], ...) so galleries also render inside feeds
 add_filter('init', 'PhotoSwipeFunctions::initializePluginTags');
 
-// Inject necessary files into the <head> section
-add_action('wp_head', 'PhotoSwipeFunctions::pswpHead', 2);
+// Do not inject JavaScript/CSS resources into RSS/Atom XML
+if (!is_rss_feed()) {
+	// Inject necessary files into the <head> section
+	add_action('wp_head', 'PhotoSwipeFunctions::pswpHead', 2);
 
-// Inject necessary JavaScript and Overlay-Container into the footer section
-add_action('wp_footer', 'PhotoSwipeFunctions::pswpFooter', 10);
+	// Inject necessary JavaScript and Overlay-Container into the footer section
+	add_action('wp_footer', 'PhotoSwipeFunctions::pswpFooter', 10);
+}
 ?>


### PR DESCRIPTION
- Fixes #805 | Gallery images are displayed again in the RSS feed
- without figcaption in the RSS output.

- `captions.conf` should not be output in the RSS output

This makes the RSS2 output valid.

https://trebicsko.eu/?x=feed:rss2
<img width="470" height="136" alt="image" src="https://github.com/user-attachments/assets/28daa959-c759-4413-bd0a-e3b529b1b5b6" />
