### PR TITLE
Stringendo-Stil | Nice to have

### DIFF
--- a/fp-interface/themes/leggero/stringendo/res/common.css
+++ b/fp-interface/themes/leggero/stringendo/res/common.css
@@ -921,3 +921,13 @@ ol#comments pre code {
 		height: 180px !IMPORTANT;
 	}
 }
+
+/**
+ * widgets-under-main.js may move #columnbottom out of #outer-container so that
+ * overflow sidebar widgets can render above it (under-main grid -> columnbottom).
+ * In that case, re-create the normal vertical spacing that is otherwise provided
+ * by the flex gap inside #outer-container.
+ */
+html.stringendo-columnbottom-moved #columnbottom {
+	margin-top: var(--fp-space-5, 1.25rem);
+}


### PR DESCRIPTION
- Nice to have: the arrangement of widgets from the right widget bar (`#column`) takes into account any existing bottom widget bar (`#columnbottom`).

    - The fix prevents both bars from overlapping.