### PR TITLE
Fixes #821 | No empty output in nextpage and prevpage

### DIFF
--- a/fp-interface/themes/leggero/comments.tpl
+++ b/fp-interface/themes/leggero/comments.tpl
@@ -37,9 +37,13 @@
 
 		{/entry}
 
+		{capture assign='fp_nextpage'}{strip}{nextpage}{/strip}{/capture}
+		{capture assign='fp_prevpage'}{strip}{prevpage}{/strip}{/capture}
+		{if $fp_nextpage != '' || $fp_prevpage != ''}
 			<div class="navigation">
-				{nextpage}{prevpage}
+				{$fp_nextpage nofilter}{$fp_prevpage nofilter}
 			</div>
+		{/if}
 
 		{/entry_block}
 

--- a/fp-interface/themes/leggero/index.tpl
+++ b/fp-interface/themes/leggero/index.tpl
@@ -1,23 +1,25 @@
 {include file="header.tpl"}
 
 		<div id="main">
-		
-		
+
 		{entry_block}
-		
+
 			{entry}
 			{include file='entry-default.tpl'}
 			{/entry}
-		
+
+			{capture assign='fp_nextpage'}{strip}{nextpage}{/strip}{/capture}
+			{capture assign='fp_prevpage'}{strip}{prevpage}{/strip}{/capture}
+			{if $fp_nextpage != '' || $fp_prevpage != ''}
 			<div class="navigation">
-				{nextpage}{prevpage}
+				{$fp_nextpage nofilter}{$fp_prevpage nofilter}
 			</div>
-			
+			{/if}
+
 		{/entry_block}
 
 		</div>
-			
 
 		{include file="widgets.tpl"}
-				
+
 {include file="footer.tpl"}


### PR DESCRIPTION
- Additionally, the tag plugin requires a correct bail-out if no Next/Prev exists.

Proof of concept already working