### PR TITLE
LastComments Feed Slug-Patch

### DIFF
--- a/fp-plugins/lastcomments/tpls/plugin.lastcomments-atom.tpl
+++ b/fp-plugins/lastcomments/tpls/plugin.lastcomments-atom.tpl
@@ -32,6 +32,7 @@ Visit https://aboutfeeds.com to get started with newsreaders and subscribing. It
 	<id>{$smarty.const.BLOG_BASEURL|escape:'html'}</id>
 
 	{if $flatpress.subtitle != ""}
+
 	<subtitle>
 		<![CDATA[
 		{$flatpress.subtitle|wp_specialchars}
@@ -43,8 +44,11 @@ Visit https://aboutfeeds.com to get started with newsreaders and subscribing. It
 
 	<entry>
 		<title>{$comment.subject|plugin_lastcomments_feed_title|escape:"html"}</title>
-		<link href="{$comment.entry|cmnt:comments_link|escape:'html'}#{$comment.id}" />
-		<id>{$comment.entry|cmnt:comments_link|escape:'html'}#{$comment.id}</id>
+		{assign var=comm_link value=$comment.link|default:''}
+		{if $comm_link == ''}{assign var=comm_link value=$comment.entry|cmnt:comments_link}{/if}
+
+		<link href="{$comm_link|escape:'html'}#{$comment.id}" />
+		<id>{$comm_link|escape:'html'}#{$comment.id}</id>
 		<published>{$comment.date|date_format:"%Y-%m-%dT%H:%M:%SZ"}</published>
 		<updated>{$comment.date|date_format:"%Y-%m-%dT%H:%M:%SZ"}</updated>
 		<summary type="xhtml">
@@ -58,10 +62,12 @@ Visit https://aboutfeeds.com to get started with newsreaders and subscribing. It
 			<name>{$comment.name|escape:'html'}</name>
 
 			{if $comment.email != ""}
+
 			<email>{$comment.email|escape:'html'}</email>
 			{/if}
 
 			{if $comment.url != ""}
+
 			<uri>{$comment.url|escape:'html'}</uri>
 			{/if}
 

--- a/fp-plugins/lastcomments/tpls/plugin.lastcomments-feed.tpl
+++ b/fp-plugins/lastcomments/tpls/plugin.lastcomments-feed.tpl
@@ -22,6 +22,7 @@ Visit https://aboutfeeds.com to get started with newsreaders and subscribing. It
 		<link>{$smarty.const.BLOG_BASEURL|escape:'html'}</link>
 
 		{if $flatpress.subtitle != ""}
+
 		<description>
 			<![CDATA[
 			{$flatpress.subtitle|escape:'html'}
@@ -38,10 +39,12 @@ Visit https://aboutfeeds.com to get started with newsreaders and subscribing. It
 			{foreach from=$lastcomments_list item=comment}
 
 			<item>
-			{assign var=comm_link value=$comment.entry|cmnt:comments_link}
+			{assign var=comm_link value=$comment.link|default:''}
+			{if $comm_link == ''}{assign var=comm_link value=$comment.entry|cmnt:comments_link}{/if}
 
 				<title>{$comment.subject|plugin_lastcomments_feed_title|escape:'html'}</title>
 				<link>{$comm_link|escape:'html'}#{$comment.id}</link>
+
 				<description>
 					<![CDATA[
 					{$comment.name|escape:'html'}: {$comment.content|plugin_lastcomments_feed_comment_rss|fix_encoding_issues}


### PR DESCRIPTION
- In the comment feed templates, the link `{$comment.entry|cmnt:comments_link}` has been recalculated. With PrettyURLs, slug generation depends on contextual data; as a result, an outdated or incorrect slug could have been used during rendering.
- The feed templates now use the comment link that has already been correctly prepared, rather than recalculating it at render time, which is prone to errors.