### PR TITLE
Output of Open Graph article:published_time

### DIFF
--- a/fp-includes/core/core.date.php
+++ b/fp-includes/core/core.date.php
@@ -91,15 +91,6 @@ function date_time($offset = null) {
 	return time() + (int)$offset * 3600;
 }
 
-/*
- * function date_now($offset=0) {
- * $timestamp = gmtime();
- * $time_stamp = intval($timestamp) + intval($offset) * 60 * 60;
- * return date($format, $time_stamp);
- *
- * }
- */
-
 /**
  * Takes filename and extension as a parameter, strips
  * alphabetic chars (ascii) from filename and "parses" the date;
@@ -144,6 +135,64 @@ function date_from_id($id) {
 	}
 
 	return $arr;
+}
+
+/**
+ * Formats a FlatPress timestamp as ISO 8601 with the blog's configured offset.
+ *
+ * FlatPress stores entry/comment timestamps in its own "UTC + timeoffset" model
+ * (see date_time()). To preserve the same visible local wall time in machine-
+ * readable metadata, the datetime portion is rendered via gmdate() and the
+ * configured FlatPress offset is appended explicitly.
+ *
+ * @param int|float|string|null $timestamp FlatPress timestamp; null falls back to date_time().
+ * @param int|float|string|null $offset Offset in hours; null uses $fp_config['locale']['timeoffset'].
+ * @return string ISO 8601 datetime or an empty string for invalid input.
+ */
+function date_iso8601($timestamp = null, $offset = null) {
+	global $fp_config;
+
+	if ($timestamp === null || $timestamp === 0 || $timestamp === '0') {
+		$timestamp = date_time($offset);
+	}
+
+	if (!is_numeric($timestamp)) {
+		return '';
+	}
+
+	if (!is_numeric($offset)) {
+		if (isset($fp_config ['locale'] ['timeoffset']) && is_numeric($fp_config ['locale'] ['timeoffset'])) {
+			$offset = $fp_config ['locale'] ['timeoffset'];
+		} else {
+			$offset = 0;
+		}
+	}
+
+	$timestamp = (int) $timestamp;
+
+	// Mirrors date_time(), which stores whole-hour offsets.
+	$offset_hours = (int) $offset;
+	$sign = ($offset_hours < 0) ? '-' : '+';
+	$offset_hours = abs($offset_hours);
+	$offset_string = sprintf('%s%02d:00', $sign, $offset_hours);
+
+	return gmdate('Y-m-d\TH:i:s', $timestamp) . $offset_string;
+}
+
+/**
+ * Formats an entry/comment ID (entryYYMMDD-HHMMSS / commentYYMMDD-HHMMSS) as ISO 8601.
+ *
+ * @param string $id FlatPress entry/comment ID
+ * @param int|float|string|null $offset Offset in hours; null uses the FlatPress config
+ * @return string ISO 8601 datetime or an empty string for invalid IDs
+ */
+function date_id_to_iso8601($id, $offset = null) {
+	$arr = date_from_id($id);
+	if (empty($arr) || !isset($arr ['time']) || $arr ['time'] === false) {
+		return '';
+	}
+
+	return date_iso8601($arr ['time'], $offset);
 }
 
 /**

--- a/fp-interface/themes/leggero/header.tpl
+++ b/fp-interface/themes/leggero/header.tpl
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="{$fp_config.locale.lang}"{if function_exists('plugin_seometataginfo_head')} prefix="og: https://ogp.me/ns#"{/if}>
+{$lang_parts = $fp_config.locale.lang|split:'-'}
+<html lang="{$lang_parts[0]|lower}-{$lang_parts[1]|upper}"{if function_exists('plugin_seometataginfo_head')} prefix="og: https://ogp.me/ns#"{else} xmlns="http://www.w3.org/1999/xhtml"{/if}>
 <head>
 	<title>{$flatpress.title|tag:wp_title:'&laquo;'}</title>
 	<meta http-equiv="Content-Type" content="text/html; charset={$fp_config.locale.charset}">

--- a/fp-plugins/seometataginfo/plugin.seometataginfo.php
+++ b/fp-plugins/seometataginfo/plugin.seometataginfo.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: SEO Meta Tag Info
- * Version: 2.2.5
+ * Version: 2.3.0
  * Plugin URI: https://www.flatpress.org
  * Description: This plugin allows editing of SEO meta tags description, keywords and robots for Entries, Statics and Categories. Part of the standard distribution. <a href="./fp-plugins/seometataginfo/doc_seometataginfo.txt" title="Anleitung" target="_blank">[Instructions]</a>
  * Author: FlatPress
@@ -395,10 +395,15 @@ function output_metatags($seo_desc, $seo_keywords, $seo_noindex, $seo_nofollow, 
 	if (SEOMETA_GEN_OPEN_GRAPH) {
 		echo '		<meta property="og:description" content="' . $encoded_description . '">' . "\n";
 	}
+	$article_published_time = '';
 	if (is_single()) {
+		$article_published_time = seometataginfo_get_article_published_time();
 		echo '		<meta name="author" content="' . $fp_config ['general'] ['author'] . '">' . "\n";
 		if (SEOMETA_GEN_OPEN_GRAPH) {
 			echo '		<meta property="og:type" content="article">' . "\n";
+			if ($article_published_time !== '') {
+				echo '		<meta property="article:published_time" content="' . htmlspecialchars($article_published_time, ENT_QUOTES, $charset) . '">' . "\n";
+			}
 		}
 	} else {
 		if (SEOMETA_GEN_OPEN_GRAPH) {
@@ -480,6 +485,58 @@ function seometataginfo_build_public_url($baseUrl) {
 	}
 
 	return seometataginfo_strip_tracking_params($url);
+}
+
+/**
+ * Returns the published time of the current single entry/comments view in ISO 8601.
+ *
+ * Prefer the explicit DATE field stored with the entry; fall back to the entry ID
+ * timestamp if needed so older or incomplete content still gets valid metadata.
+ */
+function seometataginfo_get_article_published_time() {
+	global $fpdb, $fp_params;
+
+	if (!is_single()) {
+		return '';
+	}
+
+	$entry_id = '';
+	$entry = array();
+
+	if (isset($fpdb) && is_object($fpdb) && method_exists($fpdb, 'getQuery')) {
+		$q = &$fpdb->getQuery();
+		if (is_object($q) && method_exists($q, 'peekEntry')) {
+			$peek = @$q->peekEntry();
+			if (is_array($peek) && isset($peek [0])) {
+				$entry_id = is_string($peek [0]) ? $peek [0] : '';
+				$entry = (isset($peek [1]) && is_array($peek [1])) ? $peek [1] : array();
+			}
+		}
+	}
+
+	if ($entry_id === '' && !empty($fp_params ['entry']) && is_string($fp_params ['entry'])) {
+		$entry_id = $fp_params ['entry'];
+	}
+
+	if (empty($entry) && $entry_id !== '' && function_exists('entry_parse')) {
+		$parsed = entry_parse($entry_id);
+		if (is_array($parsed)) {
+			$entry = $parsed;
+		}
+	}
+
+	if (isset($entry ['date']) && is_numeric($entry ['date']) && function_exists('date_iso8601')) {
+		$published = date_iso8601($entry ['date']);
+		if ($published !== '') {
+			return $published;
+		}
+	}
+
+	if ($entry_id !== '' && function_exists('date_id_to_iso8601')) {
+		return date_id_to_iso8601($entry_id);
+	}
+
+	return '';
 }
 
 /**


### PR DESCRIPTION
SEO Meta Tag Info plugin update to version 2.3.0
- Two new core functions: date_iso8601() and date_id_to_iso8601()
- Taking into account FlatPress's own timeoffset logic