### PR TITLE
Smarty Block Cache

### DIFF
--- a/admin/panels/widgets/admin.widgets.default.php
+++ b/admin/panels/widgets/admin.widgets.default.php
@@ -365,9 +365,56 @@ class admin_widgets_default extends AdminPanelAction {
 		$fp_widgets = isset($_POST ['widgets']) ? $_POST ['widgets'] : array();
 		$success = system_save(CONFIG_DIR . 'widgets.conf.php', compact('fp_widgets'));
 
+		$this->cleartplcache();
+
 		$this->smarty->assign('success', ($success) ? 1 : -1);
 
 		return PANEL_REDIRECT_CURRENT;
+	}
+
+	function cleartplcache() {
+		global $smarty;
+
+		try {
+			$tpl = new tpl_deleter();
+			unset($tpl);
+
+			$smarty->clearAllCache();
+			$smarty->clearCompiledTemplate();
+			$smarty->setCompileCheck(\Smarty\Smarty::COMPILECHECK_ON);
+			$smarty->setForceCompile(true);
+
+			if (!file_exists(CACHE_DIR)) {
+				fs_mkdir(CACHE_DIR);
+			}
+
+			if (!file_exists(COMPILE_DIR)) {
+				fs_mkdir(COMPILE_DIR);
+			}
+
+			return true;
+		} catch (Exception $e) {
+			trigger_error("Error when clearing the cache: " . $e->getMessage(), E_USER_WARNING);
+			return false;
+		}
+	}
+
+}
+
+class tpl_deleter extends fs_filelister {
+
+	function __construct() {
+
+		$this->_directory = CACHE_DIR;
+		parent::__construct();
+	}
+
+	function _checkFile($directory, $file) {
+		if ($file != CACHE_FILE) {
+			array_push($this->_list, $file);
+			fs_delete($directory . "/" . $file);
+		}
+		return 0;
 	}
 
 }

--- a/docs/FlatPress_Smarty_Cache_Overview.md
+++ b/docs/FlatPress_Smarty_Cache_Overview.md
@@ -1,0 +1,407 @@
+# FlatPress Smarty Block Cache Overview
+
+This document summarizes FlatPress' custom Smarty `{cache}{/cache}` block, explains how it works, and lists every place where it is currently used in the codebase.
+
+It is intended for core maintainers, theme authors, and plugin developers who want to understand the current fragment-cache layout before adding or changing cache blocks.
+
+---
+
+## 1. Why FlatPress uses a custom Smarty block cache
+
+FlatPress keeps **global Smarty output caching disabled** at CMS level. That is intentional, because whole-page caching would be too coarse for many FlatPress pages and would make it harder to keep admin-only or request-dependent output safe.
+
+To still speed up expensive and frequently repeated fragments, FlatPress ships a custom Smarty block plugin:
+
+- **Implementation:** `fp-includes/fp-smartyplugins/block.cache.php`
+- **Syntax:** `{cache ...}...{/cache}`
+
+This allows FlatPress to cache only selected fragments while the rest of the page stays fully dynamic.
+
+In practice, this approach is useful for fragments that are:
+
+- rendered very often,
+- identical across many requests,
+- expensive enough to justify a file read instead of repeated template/plugin work,
+- safe to share across visitors, or safely separated by cache-key variants.
+
+---
+
+## 2. How the custom block works
+
+## 2.1 Storage location
+
+Cached fragments are written below:
+
+```text
+CACHE_DIR/smarty-block-cache/<group>/<hash-prefix>/<hash>.cache.php
+```
+
+The cache file stores a serialized payload with:
+
+- creation timestamp,
+- TTL,
+- template timestamp,
+- rendered fragment content.
+
+## 2.2 Cache key composition
+
+Each block cache key is based on:
+
+- `group`
+- `id` or `key`
+- `vary`
+- automatic runtime variance
+- current template metadata
+
+Automatic runtime variance currently includes:
+
+- FlatPress locale
+- login state by default
+- request path/query string when `vary_request=true` (or `vary_route=true`)
+
+Template metadata is included so that the cache is invalidated automatically when the underlying template source timestamp changes.
+
+## 2.3 Cache lifecycle
+
+On block open:
+
+1. FlatPress builds the cache state.
+2. It tries to read the fragment from the cache file.
+3. On a hit, the cached HTML/XML is returned immediately and the inner template code is skipped.
+
+On block close:
+
+1. FlatPress receives the rendered fragment content.
+2. It serializes the payload.
+3. It writes the fragment to the cache file.
+
+## 2.4 Invalidation
+
+A cached fragment is discarded when:
+
+- the TTL has expired,
+- the template source timestamp no longer matches,
+- the file cannot be decoded as a valid cache payload.
+
+---
+
+## 3. Supported block attributes
+
+The current block plugin supports these parameters.
+
+### `id` / `key`
+
+Optional explicit block identifier.
+
+Use this whenever the same template may render multiple cache blocks or render a block conditionally. A stable `id` keeps the cache key deterministic.
+
+### `ttl` / `lifetime`
+
+Cache lifetime in seconds.
+
+- Default: `3600`
+- `<= 0` means no time-based expiry  
+  (template timestamp invalidation still applies)
+
+### `group`
+
+Logical namespace used in the cache file path.
+
+It helps separate unrelated fragments and makes the cache directory easier to inspect.
+
+### `vary`
+
+Additional custom value that becomes part of the cache key.
+
+Use it when a fragment changes based on a known variable such as a widget option.
+
+### `enabled`
+
+Boolean-like flag.
+
+When false, the block renders live and no cache file is used.
+
+### `vary_login` / `vary_logged_in`
+
+Boolean-like flag. Default: `true`.
+
+This prevents guest/admin output from being mixed by default. It can be set to `false` for truly public fragments that are identical for both.
+
+### `vary_request` / `vary_route`
+
+Boolean-like flag. Default: `false`.
+
+Enable this for fragments whose output depends on the current request path or query string, such as filtered feeds.
+
+---
+
+## 4. Current deployment map
+
+The current codebase uses the Smarty block cache in **9 template files**.
+
+### 4.1 Theme: top widget area
+
+- **File:** `fp-interface/themes/leggero/widgetstop.tpl`
+- **Block parameters:**
+  - `id='theme_leggero_widgets_top'`
+  - `ttl=3600`
+  - `group='theme-leggero'`
+  - `vary_login=false`
+
+#### Why this helps
+
+This wraps the `widgets pos=top` render path of the active Leggero theme.
+
+The top widget area is usually composed of stable menu-like content. A cache hit avoids re-running the inner widget loop and avoids repeated rendering of the same fragment on every page view.
+
+#### Why `vary_login=false` is safe here
+
+This area is intended for public navigation content. There is no need to create separate guest/admin variants, so disabling login variance reduces duplicate cache files and unnecessary disk I/O.
+
+---
+
+### 4.2 Theme: bottom widget area
+
+- **File:** `fp-interface/themes/leggero/widgetsbottom.tpl`
+- **Block parameters:**
+  - `id='theme_leggero_widgets_bottom'`
+  - `ttl=3600`
+  - `group='theme-leggero'`
+  - `vary_login=false`
+
+#### Why this helps
+
+This is the same optimization pattern as the top widget area, but for the bottom widget region.
+
+Bottom widgets are typically static navigation or informational blocks. Keeping a warm fragment cache here reduces repeated widget rendering and keeps the number of cache files low.
+
+---
+
+### 4.3 Categories widget template
+
+- **File:** `fp-plugins/categories/tpls/widget.tpl`
+- **Block parameters:**
+  - `id='plugin_categories_widget'`
+  - `ttl=1800`
+  - `group='widget-categories'`
+  - `vary=$categories_showcount`
+  - `vary_login=false`
+
+#### Why this helps
+
+The categories widget is often displayed on many pages with the same configuration. Caching it avoids rebuilding the category list for every request.
+
+#### Why `vary=$categories_showcount` is needed
+
+The widget can render either with or without entry counts. That changes the output, so the cache must separate those variants.
+
+#### Why `vary_login=false` is safe here
+
+The output is public and does not contain admin-only controls.
+
+---
+
+### 4.4 Main RSS feed template
+
+- **File:** `fp-interface/sharedtpls/rss.tpl`
+- **Block parameters:**
+  - `id='shared_feed_rss'`
+  - `ttl=120`
+  - `group='feeds-main'`
+  - `vary_request=true`
+  - `vary_login=false`
+
+#### Why this helps
+
+Feed readers and bots often request the same feed repeatedly within short time windows. A short-lived fragment cache avoids rebuilding the whole feed XML on every poll.
+
+#### Why `vary_request=true` is important
+
+Main feeds can be requested in different filtered forms. Request-based variance keeps those feed variants separate so one route does not reuse another route's cached output.
+
+---
+
+### 4.5 Main Atom feed template
+
+- **File:** `fp-interface/sharedtpls/atom.tpl`
+- **Block parameters:**
+  - `id='shared_feed_atom'`
+  - `ttl=120`
+  - `group='feeds-main'`
+  - `vary_request=true`
+  - `vary_login=false`
+
+#### Why this helps
+
+This is the Atom counterpart to the RSS optimization. The benefit is the same: repeated polling requests reuse a recently generated feed body instead of rebuilding it each time.
+
+---
+
+### 4.6 Comment RSS feed template
+
+- **File:** `fp-interface/sharedtpls/comment-rss.tpl`
+- **Block parameters:**
+  - `id='shared_comment_feed_rss'`
+  - `ttl=60`
+  - `group='feeds-comments'`
+  - `vary_request=true`
+  - `vary_login=false`
+
+#### Why this helps
+
+Comment feeds can be requested repeatedly for the same entry. Short caching reduces repeated feed generation while still keeping comment updates reasonably fresh.
+
+#### Why the TTL is shorter
+
+Comment streams are more volatile than navigation widgets, so the cache should refresh sooner.
+
+---
+
+### 4.7 Comment Atom feed template
+
+- **File:** `fp-interface/sharedtpls/comment-atom.tpl`
+- **Block parameters:**
+  - `id='shared_comment_feed_atom'`
+  - `ttl=60`
+  - `group='feeds-comments'`
+  - `vary_request=true`
+  - `vary_login=false`
+
+#### Why this helps
+
+This is the Atom counterpart of the comment RSS feed cache. The rationale and safety constraints are the same.
+
+---
+
+### 4.8 LastComments RSS feed template
+
+- **File:** `fp-plugins/lastcomments/tpls/plugin.lastcomments-feed.tpl`
+- **Block parameters:**
+  - `id='plugin_lastcomments_feed_rss'`
+  - `ttl=60`
+  - `group='feeds-lastcomments'`
+  - `vary_request=true`
+  - `vary_login=false`
+
+#### Why this helps
+
+The LastComments plugin feed is an ideal short-lived feed cache candidate. Many requests ask for the same XML, and the fragment is public.
+
+---
+
+### 4.9 LastComments Atom feed template
+
+- **File:** `fp-plugins/lastcomments/tpls/plugin.lastcomments-atom.tpl`
+- **Block parameters:**
+  - `id='plugin_lastcomments_feed_atom'`
+  - `ttl=60`
+  - `group='feeds-lastcomments'`
+  - `vary_request=true`
+  - `vary_login=false`
+
+#### Why this helps
+
+This is the Atom equivalent of the LastComments RSS feed cache and follows the same strategy.
+
+---
+
+## 5. Why some areas are intentionally not cached
+
+The absence of a cache block is often deliberate.
+
+### 5.1 Right sidebar widgets in `widgets.tpl`
+
+The right sidebar is intentionally rendered live.
+
+Reason:
+
+- it can contain context-sensitive widgets,
+- widgets such as `related` depend on the currently viewed entry,
+- some widgets are only shown in specific contexts,
+- caching the whole sidebar would either risk stale/wrong output or require overly fine-grained cache keys.
+
+### 5.2 Whole-page templates
+
+Templates such as entry pages, search pages, forms, or admin views are not good default candidates for this block cache because they mix many dynamic concerns in a single render path.
+
+The current strategy deliberately prefers **small, stable fragments** over broad page-level fragment caching.
+
+---
+
+## 6. Practical guidance for developers
+
+When deciding whether to add a new `{cache}` block, use this checklist.
+
+### Good candidates
+
+Use a block cache when the fragment is:
+
+- public or safely separated by cache-key variance,
+- stable across many requests,
+- expensive enough to justify a disk read,
+- small enough that the number of cache files stays manageable.
+
+### Bad candidates
+
+Avoid block caches when the fragment is:
+
+- heavily request-dependent,
+- session-dependent,
+- mixed with admin-only controls,
+- already efficiently cached elsewhere,
+- likely to create many low-value cache variants.
+
+### Attribute selection tips
+
+- Prefer an explicit `id`.
+- Use `group` to keep related fragments together.
+- Add `vary` only for real output differences.
+- Disable `vary_login` only when the fragment is truly identical for guests and admins.
+- Enable `vary_request` when the fragment depends on route or query parameters.
+- Choose the shortest TTL that still reduces repeated work.
+
+---
+
+## 7. Current summary table
+
+| Area | File | id | ttl | group | Extra variance | Why it is cached |
+|---|---|---|---:|---|---|---|
+| Leggero top widgets | `fp-interface/themes/leggero/widgetstop.tpl` | `theme_leggero_widgets_top` | 3600 | `theme-leggero` | `vary_login=false` | Stable top navigation/widget fragment |
+| Leggero bottom widgets | `fp-interface/themes/leggero/widgetsbottom.tpl` | `theme_leggero_widgets_bottom` | 3600 | `theme-leggero` | `vary_login=false` | Stable bottom navigation/widget fragment |
+| Categories widget | `fp-plugins/categories/tpls/widget.tpl` | `plugin_categories_widget` | 1800 | `widget-categories` | `vary=$categories_showcount`, `vary_login=false` | Reused sidebar widget with limited variants |
+| Main RSS feed | `fp-interface/sharedtpls/rss.tpl` | `shared_feed_rss` | 120 | `feeds-main` | `vary_request=true`, `vary_login=false` | Repeated polling by feed readers |
+| Main Atom feed | `fp-interface/sharedtpls/atom.tpl` | `shared_feed_atom` | 120 | `feeds-main` | `vary_request=true`, `vary_login=false` | Repeated polling by feed readers |
+| Comment RSS feed | `fp-interface/sharedtpls/comment-rss.tpl` | `shared_comment_feed_rss` | 60 | `feeds-comments` | `vary_request=true`, `vary_login=false` | Short-lived per-request comment feed cache |
+| Comment Atom feed | `fp-interface/sharedtpls/comment-atom.tpl` | `shared_comment_feed_atom` | 60 | `feeds-comments` | `vary_request=true`, `vary_login=false` | Short-lived per-request comment feed cache |
+| LastComments RSS feed | `fp-plugins/lastcomments/tpls/plugin.lastcomments-feed.tpl` | `plugin_lastcomments_feed_rss` | 60 | `feeds-lastcomments` | `vary_request=true`, `vary_login=false` | Short-lived public plugin feed cache |
+| LastComments Atom feed | `fp-plugins/lastcomments/tpls/plugin.lastcomments-atom.tpl` | `plugin_lastcomments_feed_atom` | 60 | `feeds-lastcomments` | `vary_request=true`, `vary_login=false` | Short-lived public plugin feed cache |
+
+---
+
+## 8. File references
+
+### Block implementation
+
+- `fp-includes/fp-smartyplugins/block.cache.php`
+
+### Current template usage
+
+- `fp-interface/themes/leggero/widgetstop.tpl`
+- `fp-interface/themes/leggero/widgetsbottom.tpl`
+- `fp-plugins/categories/tpls/widget.tpl`
+- `fp-interface/sharedtpls/rss.tpl`
+- `fp-interface/sharedtpls/atom.tpl`
+- `fp-interface/sharedtpls/comment-rss.tpl`
+- `fp-interface/sharedtpls/comment-atom.tpl`
+- `fp-plugins/lastcomments/tpls/plugin.lastcomments-feed.tpl`
+- `fp-plugins/lastcomments/tpls/plugin.lastcomments-atom.tpl`
+
+---
+
+## 9. Takeaway
+
+The current FlatPress Smarty block cache is intentionally conservative.
+
+It is not used as a page cache. Instead, it targets a small set of stable, high-reuse fragments where a cache hit can skip repeated template/plugin work without risking wrong output across visitors or routes.
+
+That makes it a useful performance tool for FlatPress developers, especially when they keep cache scope narrow, cache keys explicit, and fragment variance well understood.

--- a/fp-includes/fp-smartyplugins/block.cache.php
+++ b/fp-includes/fp-smartyplugins/block.cache.php
@@ -1,0 +1,477 @@
+<?php
+/**
+ * Smarty {cache}{/cache} block plugin
+ *
+ * Purpose:
+ *   Cache rendered block output in FlatPress' CACHE_DIR even when
+ *   global Smarty output caching is disabled.
+ *
+ * Supported attributes:
+ *   - id / key      Optional explicit cache key. Recommended for repeated
+ *                   or conditionally rendered cache blocks.
+ *   - ttl / lifetime
+ *                   Lifetime in seconds. Default: 3600. Values <= 0 mean
+ *                   "no time-based expiry" (the cache is still invalidated
+ *                   when the template source changes).
+ *   - enabled       Boolean-ish flag. If false, the block is rendered live.
+ *   - vary          Optional extra value that becomes part of the cache key.
+ *   - group         Optional logical namespace for the cache file path.
+ *   - vary_login / vary_logged_in
+ *                   Boolean-ish flag. Default: true. Set to false for
+ *                   fragments that are identical for guests and admins.
+ *   - vary_request / vary_route
+ *                   Boolean-ish flag. Default: false. Set to true for
+ *                   fragments whose output depends on the current request
+ *                   path or query string, e.g. filtered feeds.
+ *
+ * Notes:
+ *   - Anonymous blocks are supported. Their cache key is derived from the
+ *     current template plus a per-render slot number. For repeated or
+ *     conditionally rendered blocks, use id=... to guarantee a stable key.
+ *   - The cache varies automatically by current FlatPress locale.
+ *   - By default it also varies by login state to avoid leaking admin-only
+ *     output. This can be disabled per block via vary_login=false (or
+ *     vary_logged_in=false) for truly public fragments.
+ *   - Request-based variance can be enabled per block via
+ *     vary_request=true (or vary_route=true).
+ */
+
+/**
+ * @return array<string,mixed>
+ */
+function &fp_smarty_cache_runtime_store() {
+	static $store = [
+		'stacks' => [],
+		'slots' => [],
+		'callback_registered' => [],
+	];
+	return $store;
+}
+
+/**
+ * @param mixed $value
+ * @param bool $default
+ * @return bool
+ */
+function fp_smarty_cache_bool($value, $default = true) {
+	if ($value === null) {
+		return (bool) $default;
+	}
+	if (is_bool($value)) {
+		return $value;
+	}
+	if (is_int($value) || is_float($value)) {
+		return ((int) $value) !== 0;
+	}
+	if (is_string($value)) {
+		$v = strtolower(trim($value));
+		if ($v === '' || $v === '0' || $v === 'false' || $v === 'off' || $v === 'no') {
+			return false;
+		}
+		if ($v === '1' || $v === 'true' || $v === 'on' || $v === 'yes') {
+			return true;
+		}
+	}
+	return (bool) $default;
+}
+
+/**
+ * @param mixed $value
+ * @param int $default
+ * @return int
+ */
+function fp_smarty_cache_ttl($value, $default = 3600) {
+	if ($value === null || $value === '') {
+		return (int) $default;
+	}
+	if (is_int($value)) {
+		return $value;
+	}
+	if (is_float($value)) {
+		return (int) $value;
+	}
+	if (is_string($value) && preg_match('/^-?\d+$/', trim($value))) {
+		return (int) trim($value);
+	}
+	return (int) $default;
+}
+
+/**
+ * @param mixed $value
+ * @return string
+ */
+function fp_smarty_cache_stringify($value) {
+	if (is_scalar($value) || $value === null) {
+		return (string) $value;
+	}
+	return serialize($value);
+}
+
+/**
+ * @param object|null $template
+ * @return string
+ */
+function fp_smarty_cache_template_handle($template) {
+	if (!is_object($template)) {
+		return 'template:none';
+	}
+	if (function_exists('spl_object_id')) {
+		return 'template:' . (string) spl_object_id($template);
+	}
+	return 'template:' . spl_object_hash($template);
+}
+
+/**
+ * @param object|null $template
+ * @return void
+ */
+function fp_smarty_cache_reset_template_state($template) {
+	$store = &fp_smarty_cache_runtime_store();
+	$key = fp_smarty_cache_template_handle($template);
+	unset($store ['slots'] [$key], $store ['stacks'] [$key]);
+}
+
+/**
+ * @param object|null $template
+ * @return void
+ */
+function fp_smarty_cache_register_render_callbacks($template) {
+	if (!is_object($template)) {
+		return;
+	}
+	if (!isset($template->startRenderCallbacks) || !is_array($template->startRenderCallbacks)) {
+		return;
+	}
+	if (!isset($template->endRenderCallbacks) || !is_array($template->endRenderCallbacks)) {
+		return;
+	}
+
+	$store = &fp_smarty_cache_runtime_store();
+	$key = fp_smarty_cache_template_handle($template);
+	if (!empty($store ['callback_registered'] [$key])) {
+		return;
+	}
+
+	$template->startRenderCallbacks [] = static function($tpl): void {
+		fp_smarty_cache_reset_template_state($tpl);
+	};
+	$template->endRenderCallbacks [] = static function($tpl): void {
+		fp_smarty_cache_reset_template_state($tpl);
+	};
+
+	$store ['callback_registered'] [$key] = true;
+}
+
+/**
+ * @param object|null $template
+ * @return int
+ */
+function fp_smarty_cache_next_slot($template) {
+	$store = &fp_smarty_cache_runtime_store();
+	$key = fp_smarty_cache_template_handle($template);
+	if (!isset($store ['slots'] [$key])) {
+		$store ['slots'] [$key] = 0;
+	}
+	$store ['slots'] [$key]++;
+	return (int) $store ['slots'] [$key];
+}
+
+/**
+ * @param object|null $template
+ * @param array<string,mixed> $state
+ * @return void
+ */
+function fp_smarty_cache_push_state($template, array $state) {
+	$store = &fp_smarty_cache_runtime_store();
+	$key = fp_smarty_cache_template_handle($template);
+	if (!isset($store ['stacks'] [$key]) || !is_array($store ['stacks'] [$key])) {
+		$store ['stacks'] [$key] = [];
+	}
+	$store ['stacks'] [$key] [] = $state;
+}
+
+/**
+ * @param object|null $template
+ * @return array<string,mixed>|null
+ */
+function fp_smarty_cache_pop_state($template) {
+	$store = &fp_smarty_cache_runtime_store();
+	$key = fp_smarty_cache_template_handle($template);
+	if (empty($store ['stacks'] [$key]) || !is_array($store ['stacks'] [$key])) {
+		return null;
+	}
+	$state = array_pop($store ['stacks'] [$key]);
+	if (empty($store ['stacks'] [$key])) {
+		unset($store ['stacks'] [$key]);
+	}
+	return is_array($state) ? $state : null;
+}
+
+/**
+ * @param mixed $template
+ * @return array<string,mixed>
+ */
+function fp_smarty_cache_template_meta($template) {
+	$meta = [
+		'resource' => '',
+		'source_uid' => '',
+		'source_name' => '',
+		'source_type' => '',
+		'source_timestamp' => 0,
+		'compile_id' => '',
+	];
+
+	if (!is_object($template)) {
+		return $meta;
+	}
+
+	if (isset($template->template_resource) && is_scalar($template->template_resource)) {
+		$meta ['resource'] = (string) $template->template_resource;
+	}
+	if (isset($template->compile_id) && is_scalar($template->compile_id)) {
+		$meta ['compile_id'] = (string) $template->compile_id;
+	}
+
+	$source = null;
+	if (method_exists($template, 'getSource')) {
+		$source = $template->getSource();
+	} elseif (isset($template->source)) {
+		$source = $template->source;
+	}
+
+	if (is_object($source)) {
+		if (isset($source->uid) && is_scalar($source->uid)) {
+			$meta ['source_uid'] = (string) $source->uid;
+		}
+		if (isset($source->name) && is_scalar($source->name)) {
+			$meta ['source_name'] = (string) $source->name;
+		}
+		if (isset($source->type) && is_scalar($source->type)) {
+			$meta ['source_type'] = (string) $source->type;
+		}
+		if (isset($source->timestamp) && is_numeric($source->timestamp)) {
+			$meta ['source_timestamp'] = (int) $source->timestamp;
+		}
+	}
+
+	return $meta;
+}
+
+/**
+ * @param mixed $template
+ * @return array<string,mixed>
+ */
+function fp_smarty_cache_runtime_vary($template, array $params = []) {
+	$locale = '';
+	if (isset($GLOBALS ['fp_config']) && is_array($GLOBALS ['fp_config'])) {
+		if (isset($GLOBALS ['fp_config'] ['locale']) && is_array($GLOBALS ['fp_config'] ['locale'])) {
+			$locale = (string) ($GLOBALS ['fp_config'] ['locale'] ['lang'] ?? '');
+		}
+	}
+
+	$varyLogin = true;
+	if (array_key_exists('vary_login', $params)) {
+		$varyLogin = fp_smarty_cache_bool($params ['vary_login'], true);
+	} elseif (array_key_exists('vary_logged_in', $params)) {
+		$varyLogin = fp_smarty_cache_bool($params ['vary_logged_in'], true);
+	}
+
+	$vary = [
+		'locale' => $locale,
+		'compile_id' => is_object($template) && isset($template->compile_id) ? (string) $template->compile_id : '',
+	];
+
+	$varyRequest = false;
+	if (array_key_exists('vary_request', $params)) {
+		$varyRequest = fp_smarty_cache_bool($params ['vary_request'], false);
+	} elseif (array_key_exists('vary_route', $params)) {
+		$varyRequest = fp_smarty_cache_bool($params ['vary_route'], false);
+	}
+
+	if ($varyRequest) {
+		$requestUri = '';
+		if (isset($_SERVER ['REQUEST_URI']) && is_string($_SERVER ['REQUEST_URI'])) {
+			$requestUri = (string) $_SERVER ['REQUEST_URI'];
+		} elseif (isset($_SERVER ['QUERY_STRING']) && is_string($_SERVER ['QUERY_STRING']) && $_SERVER ['QUERY_STRING'] !== '') {
+			$requestUri = '?' . (string) $_SERVER ['QUERY_STRING'];
+		}
+		$vary ['request_uri'] = $requestUri;
+	}
+
+	if ($varyLogin) {
+		$loggedIn = false;
+		if (function_exists('user_loggedin')) {
+			$loggedIn = (bool) user_loggedin();
+		}
+		$vary ['logged_in'] = $loggedIn ? '1' : '0';
+	}
+
+	return $vary;
+}
+
+/**
+ * @param mixed $params
+ * @param mixed $template
+ * @return array<string,mixed>
+ */
+function fp_smarty_cache_build_state($params, $template) {
+	$params = is_array($params) ? $params : [];
+	fp_smarty_cache_register_render_callbacks($template);
+
+	$enabled = fp_smarty_cache_bool($params ['enabled'] ?? true, true);
+	$ttl = fp_smarty_cache_ttl($params ['ttl'] ?? ($params ['lifetime'] ?? null), 3600);
+	$group = isset($params ['group']) ? preg_replace('/[^A-Za-z0-9_.-]+/', '-', fp_smarty_cache_stringify($params ['group'])) : 'default';
+	if (!is_string($group) || $group === '') {
+		$group = 'default';
+	}
+
+	$meta = fp_smarty_cache_template_meta($template);
+
+	if (isset($params ['id']) && $params ['id'] !== '') {
+		$slot = 'id:' . fp_smarty_cache_stringify($params ['id']);
+	} elseif (isset($params ['key']) && $params ['key'] !== '') {
+		$slot = 'key:' . fp_smarty_cache_stringify($params ['key']);
+	} else {
+		$slot = 'slot:' . (string) fp_smarty_cache_next_slot($template);
+	}
+
+	$keyPayload = [
+		'group' => $group,
+		'slot' => $slot,
+		'vary' => isset($params ['vary']) ? $params ['vary'] : null,
+		'auto_vary' => fp_smarty_cache_runtime_vary($template, $params),
+		'template' => [
+			'resource' => $meta ['resource'],
+			'source_name' => $meta ['source_name'],
+			'source_type' => $meta ['source_type'],
+			'source_timestamp' => $meta ['source_timestamp'],
+			'compile_id' => $meta ['compile_id'],
+		],
+	];
+	$hash = sha1(serialize($keyPayload));
+
+	$cacheRoot = defined('CACHE_DIR') ? CACHE_DIR : sys_get_temp_dir();
+	$cacheRoot = rtrim((string) $cacheRoot, '/\\');
+	$file = $cacheRoot . DIRECTORY_SEPARATOR . 'smarty-block-cache' . DIRECTORY_SEPARATOR . $group . DIRECTORY_SEPARATOR . substr($hash, 0, 2) . DIRECTORY_SEPARATOR . $hash . '.cache.php';
+
+	return [
+		'enabled' => $enabled,
+		'ttl' => $ttl,
+		'group' => $group,
+		'slot' => $slot,
+		'hash' => $hash,
+		'file' => $file,
+		'template_stamp' => (int) $meta ['source_timestamp'],
+	];
+}
+
+/**
+ * @param array<string,mixed> $state
+ * @return string|null
+ */
+function fp_smarty_cache_read(array $state) {
+	$file = isset($state ['file']) ? (string) $state ['file'] : '';
+	if ($file === '' || !is_file($file)) {
+		return null;
+	}
+
+	$raw = function_exists('io_load_file') ? io_load_file($file) : @file_get_contents($file);
+	if (!is_string($raw) || $raw === '') {
+		return null;
+	}
+
+	$payload = @unserialize($raw);
+	if (!is_array($payload)) {
+		return null;
+	}
+
+	$created = isset($payload ['created']) ? (int) $payload ['created'] : 0;
+	$ttl = isset($payload ['ttl']) ? (int) $payload ['ttl'] : (int) ($state ['ttl'] ?? 3600);
+	$cachedTemplateStamp = isset($payload ['template_stamp']) ? (int) $payload ['template_stamp'] : 0;
+	$currentTemplateStamp = isset($state ['template_stamp']) ? (int) $state ['template_stamp'] : 0;
+
+	if ($currentTemplateStamp > 0 && $cachedTemplateStamp > 0 && $cachedTemplateStamp !== $currentTemplateStamp) {
+		@unlink($file);
+		return null;
+	}
+
+	if ($ttl > 0 && $created > 0 && ($created + $ttl) < time()) {
+		@unlink($file);
+		return null;
+	}
+
+	if (!isset($payload ['content']) || !is_string($payload ['content'])) {
+		return null;
+	}
+
+	return $payload ['content'];
+}
+
+/**
+ * @param array<string,mixed> $state
+ * @param string $content
+ * @return bool
+ */
+function fp_smarty_cache_write(array $state, $content) {
+	$file = isset($state ['file']) ? (string) $state ['file'] : '';
+	if ($file === '') {
+		return false;
+	}
+
+	$payload = serialize([
+		'created' => time(),
+		'ttl' => (int) ($state ['ttl'] ?? 3600),
+		'template_stamp' => (int) ($state ['template_stamp'] ?? 0),
+		'content' => (string) $content,
+	]);
+
+	if (function_exists('io_write_file')) {
+		return (bool) io_write_file($file, $payload);
+	}
+
+	$dir = dirname($file);
+	if (!is_dir($dir) && function_exists('fs_mkdir')) {
+		if (!fs_mkdir($dir)) {
+			return false;
+		}
+	}
+	return @file_put_contents($file, $payload, LOCK_EX) !== false;
+}
+
+/**
+ * Smarty block handler for {cache}{/cache}
+ *
+ * @param array<string,mixed> $params
+ * @param string|null $content
+ * @param mixed $template
+ * @param bool $repeat
+ * @return string
+ */
+function smarty_block_cache($params, $content, $template, &$repeat) {
+	if ($content === null) {
+		$state = fp_smarty_cache_build_state($params, $template);
+
+		if (empty($state ['enabled'])) {
+			return '';
+		}
+
+		$cached = fp_smarty_cache_read($state);
+		if (is_string($cached)) {
+			$repeat = false;
+			return $cached;
+		}
+
+		fp_smarty_cache_push_state($template, $state);
+		return '';
+	}
+
+	$state = fp_smarty_cache_pop_state($template);
+	if (!is_array($state) || empty($state ['enabled'])) {
+		return (string) $content;
+	}
+
+	$content = (string) $content;
+	fp_smarty_cache_write($state, $content);
+	return $content;
+}
+?>

--- a/fp-interface/sharedtpls/atom.tpl
+++ b/fp-interface/sharedtpls/atom.tpl
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="{$fp_config.locale.charset}"?>
+{cache id='shared_feed_atom' ttl=120 group='feeds-main' vary_request=true vary_login=false}
 <!--
 
              _                                  ______                     _ 
@@ -21,6 +22,7 @@ Visit https://aboutfeeds.com to get started with newsreaders and subscribing. It
 	<title>{$flatpress.title|escape:'html'} » {$lang.main.entries|escape:'html'}</title>
 
 	{if $flatpress.subtitle!=""}
+
 	<subtitle>{$flatpress.subtitle|escape:'html'}</subtitle>
 	{/if}
 
@@ -38,6 +40,7 @@ Visit https://aboutfeeds.com to get started with newsreaders and subscribing. It
 
 	{entry_block}
 	{entry}
+
 	<entry>
 
 		<title>{$subject|tag:the_title|escape:'html'}</title>
@@ -45,6 +48,7 @@ Visit https://aboutfeeds.com to get started with newsreaders and subscribing. It
 
 		<id>{$id|link:post_link|escape:'html'}</id>
 		{assign var=the_date value=$date|date_rfc3339}
+
 		<published>{$the_date}</published>
 		<updated>{$the_date}</updated>
 		<content type="xhtml">
@@ -56,13 +60,17 @@ Visit https://aboutfeeds.com to get started with newsreaders and subscribing. It
 		</content>
 
 		{if isset($enclosure)}
+
 			{foreach from=$enclosure item=encl}
+
 			<link rel="enclosure" href="{$encl.url|escape:'html'}" title="{$encl.title|escape:'html'}" length="{$encl.length|escape:'html'}" type="{$encl.type|escape:'html'}" />
 			{/foreach}
 		{/if}
 
 	</entry>
+
 	{/entry}
 	{/entry_block}
 
 </feed>
+{/cache}

--- a/fp-interface/sharedtpls/comment-atom.tpl
+++ b/fp-interface/sharedtpls/comment-atom.tpl
@@ -3,6 +3,8 @@
 	{entry}
 	{assign var=the_comment_link value=$id|link:comments_link}
 
+	{cache id='shared_comment_feed_atom' ttl=60 group='feeds-comments' vary_request=true vary_login=false}
+
 <!--
 
              _                                  ______                     _ 
@@ -25,14 +27,13 @@ Visit https://aboutfeeds.com to get started with newsreaders and subscribing. It
 	<title>{$flatpress.title|tag:wp_title:':'|escape:'html'} » {$subject|tag:the_title|escape:'html'} » {$lang.main.comments|escape:'html'}</title>
 
 	{if $flatpress.subtitle != ""}
+
 	<subtitle>{$flatpress.subtitle|escape:'html'}</subtitle>
 	{/if}
 
 	<link href="{$smarty.const.BLOG_BASEURL|escape:'html'}" />
 	<link rel="self" href="{'atom'|theme_comments_feed_link:$id|escape:'html'}" type="application/atom+xml" />
-	<generator uri="https://www.flatpress.org/" version="{$smarty.const.SYSTEM_VER}">
-		FlatPress
-	</generator>
+	<generator uri="https://www.flatpress.org/" version="{$smarty.const.SYSTEM_VER}">FlatPress</generator>
 	<rights>{$flatpress.author|escape:'html'} {$smarty.now|date_format:'%Y'}</rights>
 
 	<updated>{$date|date_rfc3339}</updated>
@@ -43,31 +44,35 @@ Visit https://aboutfeeds.com to get started with newsreaders and subscribing. It
 
 		{comment_block}
 			{comment}
-			<entry>
 
-				<title>{$name|escape:'html'}</title>
-				<author>
-					<name>{$name|escape:'html'}</name>
-					{if isset($www) && $www != ""}
-					<uri>{$www|escape:'html'}</uri>
-					{/if}
-				</author>
-				<link href="{$the_comment_link|escape:'html'}#{$id}" />
-				<id>{$the_comment_link|escape:'html'}#{$id}</id>
-				{assign var=the_date value=$date|date_rfc3339}
-				<published>{$the_date}</published>
-				<updated>{$the_date}</updated>
-				<content type="xhtml">
-					<div xmlns="http://www.w3.org/1999/xhtml">
-						<![CDATA[
-						{$content|tag:the_content|strip_tags|strip|escape|fix_encoding_issues}
-						]]>
-					</div>
-				</content>
+		<entry>
 
-			</entry>
+			<title>{$name|escape:'html'}</title>
+			<author>
+				<name>{$name|escape:'html'}</name>
+				{if isset($www) && $www != ""}
+
+				<uri>{$www|escape:'html'}</uri>
+				{/if}
+			</author>
+			<link href="{$the_comment_link|escape:'html'}#{$id}" />
+			<id>{$the_comment_link|escape:'html'}#{$id}</id>
+			{assign var=the_date value=$date|date_rfc3339}
+			<published>{$the_date}</published>
+			<updated>{$the_date}</updated>
+			<content type="xhtml">
+				<div xmlns="http://www.w3.org/1999/xhtml">
+					<![CDATA[
+					{$content|tag:the_content|strip_tags|strip|escape|fix_encoding_issues}
+					]]>
+				</div>
+			</content>
+
+		</entry>
 			{/comment}
 		{/comment_block}
+
+	{/cache}
 
 	{/entry}
 {/entry_block}

--- a/fp-interface/sharedtpls/comment-rss.tpl
+++ b/fp-interface/sharedtpls/comment-rss.tpl
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="{$fp_config.locale.charset}"?>
-	{entry_block}
-		{entry}
-		{assign var=the_comment_link value=$id|link:comments_link}
+{entry_block}
+	{entry}
+	{assign var=the_comment_link value=$id|link:comments_link}
+
+	{cache id='shared_comment_feed_rss' ttl=60 group='feeds-comments' vary_request=true vary_login=false}
 
 <!--
 
@@ -31,6 +33,7 @@ Visit https://aboutfeeds.com to get started with newsreaders and subscribing. It
 		<link>{$the_comment_link|escape:'html'}</link>
 
 		{if $flatpress.subtitle!=""}
+
 		<description>
 			<![CDATA[
 			{$flatpress.subtitle|escape:'html'}
@@ -47,27 +50,31 @@ Visit https://aboutfeeds.com to get started with newsreaders and subscribing. It
 
 		{comment_block}
 			{comment}
-			<item>
 
-				<title>{$name|escape:'html'}</title>
-				<link>{$the_comment_link|escape:'html'}#{$id}</link>
-				<description>
-					<![CDATA[
-					{$content|tag:the_content}
-					]]>
-				</description>
+		<item>
 
-				<guid isPermaLink="true">{$the_comment_link|escape:'html'}#{$id}</guid>
+			<title>{$name|escape:'html'}</title>
+			<link>{$the_comment_link|escape:'html'}#{$id}</link>
 
-				<dc:creator>{$name|escape:'html'}</dc:creator>
-				<pubDate>{'r'|date:$date}</pubDate>
+			<description>
+				<![CDATA[
+				{$content|tag:the_content}
+				]]>
+			</description>
 
-			</item>
+			<guid isPermaLink="true">{$the_comment_link|escape:'html'}#{$id}</guid>
+
+			<dc:creator>{$name|escape:'html'}</dc:creator>
+			<pubDate>{'r'|date:$date}</pubDate>
+
+		</item>
 			{/comment}
 		{/comment_block}
 
-		{/entry}
-	{/entry_block}
+	{/cache}
+
+	{/entry}
+{/entry_block}
 
 	</channel>
 </rss>

--- a/fp-interface/sharedtpls/rss.tpl
+++ b/fp-interface/sharedtpls/rss.tpl
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="{$fp_config.locale.charset}"?>
+{cache id='shared_feed_rss' ttl=120 group='feeds-main' vary_request=true vary_login=false}
 <!--
 
   _____     _____    _____   ___             ______                     _ 
@@ -23,6 +24,7 @@ Visit https://aboutfeeds.com to get started with newsreaders and subscribing. It
 		<link>{$flatpress.www|escape:'html'}</link>
 
 		{if $flatpress.subtitle!=""}
+
 		<description>
 			<![CDATA[
 			{$flatpress.subtitle|escape:'html'}
@@ -38,6 +40,7 @@ Visit https://aboutfeeds.com to get started with newsreaders and subscribing. It
 
 		{entry_block}
 			{entry}
+
 			<item>
 
 				<title>{$subject|tag:the_title|wp_specialchars}</title>
@@ -48,27 +51,35 @@ Visit https://aboutfeeds.com to get started with newsreaders and subscribing. It
 					]]>
 				</description>
 				{if ($categories)}
+
 				<category>
 					<![CDATA[
 					{$categories|@filed:false}
 					]]>
 				</category>
 				{/if}
+
 				<guid isPermaLink="true">{$id|link:post_link|escape:'html'}</guid>
 
 				{*<author>{$flatpress.email} ({$flatpress.author})</author>*}
+
 				<pubDate>{'r'|date:$date}</pubDate>
 				<comments>{$id|link:comments_link|escape:'html'}</comments>
 
 				{if isset($enclosure)}
-					{foreach from=$enclosure item=encl} 
+
+					{foreach from=$enclosure item=encl}
+
 					<enclosure url="{$encl.url|escape:'html'}" length="{$encl.length|escape:'html'}" type="{$encl.type|escape:'html'}" />
 					{/foreach}
 				{/if}
 
 			</item>
+
 			{/entry}
 		{/entry_block}
 
 	</channel>
 </rss>
+
+{/cache}

--- a/fp-plugins/categories/tpls/widget.tpl
+++ b/fp-plugins/categories/tpls/widget.tpl
@@ -1,1 +1,3 @@
-{list_categories type=linked count=$categories_showcount} 
+{cache id='plugin_categories_widget' ttl=1800 group='widget-categories' vary=$categories_showcount vary_login=false}
+{list_categories type=linked count=$categories_showcount}
+{/cache}

--- a/fp-plugins/lastcomments/tpls/plugin.lastcomments-atom.tpl
+++ b/fp-plugins/lastcomments/tpls/plugin.lastcomments-atom.tpl
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="{$fp_config.locale.charset}"?>
+{cache id='plugin_lastcomments_feed_atom' ttl=60 group='feeds-lastcomments' vary_request=true vary_login=false}
 <!--
 
              _                                  ______                     _ 
@@ -20,9 +21,7 @@ Visit https://aboutfeeds.com to get started with newsreaders and subscribing. It
 	<title>{$flatpress.title|escape:'html'} » {$dynamic_title|escape:'html'}</title>
 	<link href="{$smarty.const.BLOG_BASEURL|escape:'html'}" rel="alternate" />
 	<link href="{$atom_link|escape:'html'}" rel="self" type="application/atom+xml" />
-	<generator uri="https://www.flatpress.org" version="{$smarty.const.SYSTEM_VER}">
-		FlatPress
-	</generator>
+	<generator uri="https://www.flatpress.org" version="{$smarty.const.SYSTEM_VER}">FlatPress</generator>
 	<rights>{$flatpress.author|escape:'html'} {'Y'|date}</rights>
 	<updated>{$smarty.now|date_rfc3339}</updated>
 	<author>
@@ -76,3 +75,5 @@ Visit https://aboutfeeds.com to get started with newsreaders and subscribing. It
 
 	{/foreach}
 </feed>
+
+{/cache}

--- a/fp-plugins/lastcomments/tpls/plugin.lastcomments-feed.tpl
+++ b/fp-plugins/lastcomments/tpls/plugin.lastcomments-feed.tpl
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="{$fp_config.locale.charset}"?>
+{cache id='plugin_lastcomments_feed_rss' ttl=60 group='feeds-lastcomments' vary_request=true vary_login=false}
 <!--
 
   _____     _____    _____   ___             ______                     _ 
@@ -61,3 +62,5 @@ Visit https://aboutfeeds.com to get started with newsreaders and subscribing. It
 			{/foreach}
 	</channel>
 </rss>
+
+{/cache}


### PR DESCRIPTION
- FlatPress now features a Smarty block cache. The goal is to avoid running stable templates through the compiler with every request, but instead to retrieve them from the block cache where appropriate.

- So far, the top and bottom widget bars and the feed templates have proven to be suitable. The right widget bar is not placed in the block cache, as the bar may contain widgets with highly dynamic content.

- All other templates are either highly request- or context-dependent or contain hooks, form states, nonces, selection states, or actual content—and are therefore unsuitable for the Smarty block cache.