### PR TITLE
Smarty cache fragments in APCu

### DIFF
--- a/docs/FlatPress_APCu_Cache_Overview.md
+++ b/docs/FlatPress_APCu_Cache_Overview.md
@@ -18,8 +18,11 @@ To view and manage user cache entries, [Joe Watkins'](https://github.com/krakjoe
 - Verifies:
   - `apcu_fetch()` exists.
   - APCu is enabled (`apcu_enabled()` or `apc.enabled`).
-  - In CLI/phpdbg, `apc.enable_cli` must be true.
+  - In CLI/phpdbg, `apc.enable_cli` must be true **or** the dedicated test override `FP_APCU_ENABLE_CLI=1` must be present.
 - Result is memoized per request in a static variable.
+
+**Note:**  
+`FP_APCU_ENABLE_CLI=1` exists only so FlatPress can simulate APCu-backed code paths in CLI-based regression tests. It does **not** bypass a genuinely disabled APCu extension.
 
 **Impact:**  
 High. Every APCu-aware function uses this as a guard, so misconfiguration here would disable all caches.
@@ -56,13 +59,15 @@ High. This is the isolation layer between multiple FlatPress instances sharing a
 
 - `apcu_get($key, &$ok = null)`  
 - `apcu_set($key, $val, $ttl = 120)`  
-- `apcu_incr($key, $step = 1, &$success = null)`
+- `apcu_incr($key, $step = 1, &$success = null)`  
+- `apcu_delete_key($key)`
 
-All three:
+These helpers:
 
 - Short-circuit if `is_apcu_on()` is false.
 - Normalize keys through `apcu_key()`, except where raw `apcu_*` functions are used deliberately.
 - Respect TTL (`$ttl`) for `apcu_set`.
+- Give other subsystems a central, instance-safe delete path (`apcu_delete_key`) for invalidation and cleanup.
 
 **Impact:**  
 High. Most APCu usage flows through these helpers.
@@ -312,7 +317,6 @@ Low–Medium. Useful for avoiding repeated disk + parsing cost on high-traffic s
 Low–Medium. Reduces repeated environment probing, especially under reverse proxies.
 
 ---
-
 
 ### 2.9 Base URL Config Cache – `fp:config:settings:*`
 
@@ -701,6 +705,62 @@ Medium–High for repeated social crawler hits and repeated requests to the dyna
 
 ---
 
+### 4.8 Smarty Block Fragment Cache – `fp:smarty:block:<group>:<hash>`
+
+**Files:**
+
+- `fp-includes/fp-smartyplugins/block.cache.php`
+- `fp-interface/themes/leggero/widgetstop.tpl`
+- `fp-interface/themes/leggero/widgetsbottom.tpl`
+- `fp-plugins/categories/tpls/widget.tpl`
+- `fp-interface/sharedtpls/rss.tpl`
+- `fp-interface/sharedtpls/atom.tpl`
+- `fp-interface/sharedtpls/comment-rss.tpl`
+- `fp-interface/sharedtpls/comment-atom.tpl`
+- `fp-plugins/lastcomments/tpls/plugin.lastcomments-feed.tpl`
+- `fp-plugins/lastcomments/tpls/plugin.lastcomments-atom.tpl`
+
+**What is cached:**
+
+FlatPress' custom Smarty `{cache}{/cache}` block stores rendered fragment payloads in APCu **when APCu is available**. The payload mirrors the filesystem fallback and contains:
+
+- creation timestamp
+- TTL
+- template timestamp
+- rendered fragment content
+
+**Logical key format:**
+
+- `smarty:block:<group>:<hash>`
+
+Because all wrapper calls pass through `apcu_key()`, the effective APCu key is:
+
+- `fp:<NS>:smarty:block:<group>:<hash>`
+
+**Current fragment groups:**
+
+- `theme-leggero`
+- `widget-categories`
+- `feeds-main`
+- `feeds-comments`
+- `feeds-lastcomments`
+
+**Invalidation:**
+
+- APCu TTL expiry via `apcu_store(..., $ttl)`
+- template source timestamp changing
+- malformed payloads
+- natural APCu eviction under memory pressure
+
+**Fallback behavior:**
+
+If APCu is not available for the current request, the same fragment cache automatically falls back to the existing file-backed storage below `CACHE_DIR/smarty-block-cache/...`.
+
+**Impact:**  
+Medium–High. For hot widget and feed fragments this removes the filesystem read/write step entirely and replaces it with an in-memory APCu fetch/store round-trip.
+
+---
+
 ## 5. Miscellaneous and Meta Caches
 
 ### 5.1 Instance Namespace Bootstrap – `fp:ns:*`
@@ -825,6 +885,7 @@ The following table summarizes each logical cache group:
 | Language                     | `fp:lang:*`                                                                          | No                       | Language file mtime/size, locale                     | Medium–High              |
 | INI parsing (SEO plugin)     | `fp:ini:*`                                                                           | No                       | INI file mtime/size                                  | Low–Medium               |
 | SEO `og:image` (SEO plugin)  | `fp:seometa:og:imageinfo:*`, `seometa:og:imagebin:*`                                 | No                       | Source path/type/mtime/size, target size, TTL        | Medium–High              |
+| Smarty block fragments       | `fp:smarty:block:*`                                                                  | No                       | TTL, template timestamp, APCu eviction or file fallback | Medium–High           |
 | HTTPS/IP env                 | `fp:https:v2:*`, `fp:net:in_cidrs:*`                                                 | No                       | TTL (≈3600s) and local process                       | Low–Medium               |
 | Plugin discovery             | `fp:plugin:*`, `fp:plugins:*`                                                        | No                       | Plugin dir/config mtimes                             | Medium                   |
 | Smarty plugin index          | `fp:spi:*`                                                                           | No                       | Dir+token hash, TTL 300s                             | Medium                   |
@@ -879,6 +940,7 @@ For completeness, the following logical prefixes are used by FlatPress `1.6.dev`
 - `fp:seometa:og:imageinfo:v1:`
 - `fp:seometa:og:imagebin:v1:`
 - `fp:spi:`
+- `fp:smarty:block:`
 - `fp:statics:list:`
 - `fp:storage:aggregate`
 - `fp:storage:dirsize:`

--- a/docs/FlatPress_Smarty_Cache_Overview.md
+++ b/docs/FlatPress_Smarty_Cache_Overview.md
@@ -30,18 +30,41 @@ In practice, this approach is useful for fragments that are:
 
 ## 2.1 Storage location
 
-Cached fragments are written below:
+FlatPress chooses the storage backend automatically:
+
+1. **APCu**, when APCu is available for the current request
+2. **Filesystem fallback** below `CACHE_DIR`, when APCu is unavailable
+
+### APCu backend
+
+Logical APCu keys look like this:
+
+```text
+smarty:block:<group>:<hash>
+```
+
+Because FlatPress routes APCu calls through `apcu_key()`, the effective key in shared memory is:
+
+```text
+fp:<NS>:smarty:block:<group>:<hash>
+```
+
+### Filesystem fallback
+
+When APCu is unavailable, cached fragments are written below:
 
 ```text
 CACHE_DIR/smarty-block-cache/<group>/<hash-prefix>/<hash>.cache.php
 ```
 
-The cache file stores a serialized payload with:
+The filesystem payload stores:
 
 - creation timestamp,
 - TTL,
 - template timestamp,
 - rendered fragment content.
+
+The APCu payload stores the same logical fields as an array rather than as a serialized file.
 
 ## 2.2 Cache key composition
 
@@ -65,15 +88,15 @@ Template metadata is included so that the cache is invalidated automatically whe
 
 On block open:
 
-1. FlatPress builds the cache state.
-2. It tries to read the fragment from the cache file.
+1. FlatPress builds the cache state, including the fragment backend (`apcu` or `file`).
+2. It tries to read the fragment from APCu first when APCu is available, otherwise from the filesystem fallback.
 3. On a hit, the cached HTML/XML is returned immediately and the inner template code is skipped.
 
 On block close:
 
 1. FlatPress receives the rendered fragment content.
-2. It serializes the payload.
-3. It writes the fragment to the cache file.
+2. It builds the cache payload.
+3. It stores the payload in APCu or writes it to the filesystem fallback, depending on the resolved backend.
 
 ## 2.4 Invalidation
 
@@ -81,7 +104,9 @@ A cached fragment is discarded when:
 
 - the TTL has expired,
 - the template source timestamp no longer matches,
-- the file cannot be decoded as a valid cache payload.
+- the stored payload cannot be decoded as a valid cache payload.
+
+With APCu enabled, expiry is enforced both by APCu's own TTL handling and by FlatPress' payload validation. With the filesystem fallback, FlatPress removes stale cache files on the next read attempt.
 
 ---
 
@@ -132,6 +157,22 @@ This prevents guest/admin output from being mixed by default. It can be set to `
 Boolean-like flag. Default: `false`.
 
 Enable this for fragments whose output depends on the current request path or query string, such as filtered feeds.
+
+
+## 3.1 Backend selection note
+
+The block implementation currently resolves the backend automatically:
+
+- **`apcu`** if `is_apcu_on()` is true
+- **`file`** otherwise
+
+This keeps one template syntax for both environments:
+
+- production hosts with APCu use RAM-backed fragments
+- hosts without APCu keep the proven file-backed fallback
+- CLI regression tests can exercise the APCu code path through the dedicated `FP_APCU_ENABLE_CLI=1` test override
+
+On Windows, APCu is documented as a per-process cache under process-based SAPIs. The feature still works correctly there, but fragment reuse may be limited to requests handled by the same process.
 
 ---
 
@@ -364,17 +405,17 @@ Avoid block caches when the fragment is:
 
 ## 7. Current summary table
 
-| Area | File | id | ttl | group | Extra variance | Why it is cached |
-|---|---|---|---:|---|---|---|
-| Leggero top widgets | `fp-interface/themes/leggero/widgetstop.tpl` | `theme_leggero_widgets_top` | 3600 | `theme-leggero` | `vary_login=false` | Stable top navigation/widget fragment |
-| Leggero bottom widgets | `fp-interface/themes/leggero/widgetsbottom.tpl` | `theme_leggero_widgets_bottom` | 3600 | `theme-leggero` | `vary_login=false` | Stable bottom navigation/widget fragment |
-| Categories widget | `fp-plugins/categories/tpls/widget.tpl` | `plugin_categories_widget` | 1800 | `widget-categories` | `vary=$categories_showcount`, `vary_login=false` | Reused sidebar widget with limited variants |
-| Main RSS feed | `fp-interface/sharedtpls/rss.tpl` | `shared_feed_rss` | 120 | `feeds-main` | `vary_request=true`, `vary_login=false` | Repeated polling by feed readers |
-| Main Atom feed | `fp-interface/sharedtpls/atom.tpl` | `shared_feed_atom` | 120 | `feeds-main` | `vary_request=true`, `vary_login=false` | Repeated polling by feed readers |
-| Comment RSS feed | `fp-interface/sharedtpls/comment-rss.tpl` | `shared_comment_feed_rss` | 60 | `feeds-comments` | `vary_request=true`, `vary_login=false` | Short-lived per-request comment feed cache |
-| Comment Atom feed | `fp-interface/sharedtpls/comment-atom.tpl` | `shared_comment_feed_atom` | 60 | `feeds-comments` | `vary_request=true`, `vary_login=false` | Short-lived per-request comment feed cache |
-| LastComments RSS feed | `fp-plugins/lastcomments/tpls/plugin.lastcomments-feed.tpl` | `plugin_lastcomments_feed_rss` | 60 | `feeds-lastcomments` | `vary_request=true`, `vary_login=false` | Short-lived public plugin feed cache |
-| LastComments Atom feed | `fp-plugins/lastcomments/tpls/plugin.lastcomments-atom.tpl` | `plugin_lastcomments_feed_atom` | 60 | `feeds-lastcomments` | `vary_request=true`, `vary_login=false` | Short-lived public plugin feed cache |
+| Area                     | File                                                           | id                                 | ttl  | group                   | Extra variance                                     | Preferred backend   | Why it is cached                              |
+|--------------------------|----------------------------------------------------------------|------------------------------------|-----:|-------------------------|----------------------------------------------------|---------------------|-----------------------------------------------|
+| Leggero top widgets      | `fp-interface/themes/leggero/widgetstop.tpl`                   | `theme_leggero_widgets_top`        | 3600 | `theme-leggero`         | `vary_login=false`                                 | APCu, file fallback | Stable top navigation/widget fragment         |
+| Leggero bottom widgets   | `fp-interface/themes/leggero/widgetsbottom.tpl`                | `theme_leggero_widgets_bottom`     | 3600 | `theme-leggero`         | `vary_login=false`                                 | APCu, file fallback | Stable bottom navigation/widget fragment      |
+| Categories widget        | `fp-plugins/categories/tpls/widget.tpl`                        | `plugin_categories_widget`         | 1800 | `widget-categories`     | `vary=$categories_showcount`, `vary_login=false`   | APCu, file fallback | Reused sidebar widget with limited variants   |
+| Main RSS feed            | `fp-interface/sharedtpls/rss.tpl`                              | `shared_feed_rss`                  | 120  | `feeds-main`            | `vary_request=true`, `vary_login=false`            | APCu, file fallback | Repeated polling by feed readers              |
+| Main Atom feed           | `fp-interface/sharedtpls/atom.tpl`                             | `shared_feed_atom`                 | 120  | `feeds-main`            | `vary_request=true`, `vary_login=false`            | APCu, file fallback | Repeated polling by feed readers              |
+| Comment RSS feed         | `fp-interface/sharedtpls/comment-rss.tpl`                      | `shared_comment_feed_rss`          | 60   | `feeds-comments`        | `vary_request=true`, `vary_login=false`            | APCu, file fallback | Short-lived per-request comment feed cache    |
+| Comment Atom feed        | `fp-interface/sharedtpls/comment-atom.tpl`                     | `shared_comment_feed_atom`         | 60   | `feeds-comments`        | `vary_request=true`, `vary_login=false`            | APCu, file fallback | Short-lived per-request comment feed cache    |
+| LastComments RSS feed    | `fp-plugins/lastcomments/tpls/plugin.lastcomments-feed.tpl`    | `plugin_lastcomments_feed_rss`     | 60   | `feeds-lastcomments`    | `vary_request=true`, `vary_login=false`            | APCu, file fallback | Short-lived public plugin feed cache          |
+| LastComments Atom feed   | `fp-plugins/lastcomments/tpls/plugin.lastcomments-atom.tpl`    | `plugin_lastcomments_feed_atom`    | 60   | `feeds-lastcomments`    | `vary_request=true`, `vary_login=false`            | APCu, file fallback | Short-lived public plugin feed cache          |
 
 ---
 

--- a/fp-includes/core/core.apcu.php
+++ b/fp-includes/core/core.apcu.php
@@ -1,5 +1,40 @@
 <?php
 /**
+ * Returns whether an environment flag is truthy.
+ *
+ * Accepted truthy values: 1, true, on, yes.
+ *
+ * @param string $name
+ * @param bool $default
+ * @return bool
+ */
+function fp_apcu_env_flag($name, $default = false): bool {
+	$value = getenv((string) $name);
+	if ($value === false && isset($_ENV [(string) $name])) {
+		$value = $_ENV [(string) $name];
+	}
+	if ($value === false || $value === null) {
+		return (bool) $default;
+	}
+	if (is_bool($value)) {
+		return $value;
+	}
+	if (is_int($value) || is_float($value)) {
+		return ((int) $value) !== 0;
+	}
+	if (is_string($value)) {
+		$value = strtolower(trim($value));
+		if ($value === '' || $value === '0' || $value === 'false' || $value === 'off' || $value === 'no') {
+			return false;
+		}
+		if ($value === '1' || $value === 'true' || $value === 'on' || $value === 'yes') {
+			return true;
+		}
+	}
+	return (bool) $default;
+}
+
+/**
  * Returns the FlatPress APCu namespace ID for this instance, or '' if APCu is disabled.
  * Random, stored under deterministic bootstrap key (sha1(ABS_PATH)).
  */
@@ -43,6 +78,11 @@ function apcu_key($key): string {
 
 /**
  * Increment with instance prefix.
+ *
+ * @param string $key
+ * @param int $step
+ * @param bool $success
+ * @return int|false
  */
 function apcu_incr($key, $step = 1, &$success = null) {
 	if (!is_apcu_on()) {
@@ -51,11 +91,31 @@ function apcu_incr($key, $step = 1, &$success = null) {
 		}
 		return false;
 	}
-	return apcu_inc(apcu_key((string)$key), (int)$step, $success);
+	return apcu_inc(apcu_key((string) $key), (int) $step, $success);
 }
 
 /**
- * APCu availability for this request. CLI/phpdbg -> false, except apc.enable_cli=1.
+ * Delete a value from APCu with instance prefix.
+ *
+ * @param string $key
+ * @return bool
+ */
+function apcu_delete_key($key): bool {
+	if (!is_apcu_on()) {
+		return false;
+	}
+	return (bool) apcu_delete(apcu_key((string) $key));
+}
+
+/**
+ * APCu availability for this request.
+ *
+ * In CLI/phpdbg, APCu is considered off unless one of these is true:
+ *   - the runtime enables apc.enable_cli
+ *   - FP_APCU_ENABLE_CLI=1 is present in the environment
+ *
+ * The environment override exists so FlatPress can simulate APCu-backed code
+ * paths in automated CLI tests even on systems without APCu CLI support.
  */
 function is_apcu_on(): bool {
 	static $on = null;
@@ -70,7 +130,7 @@ function is_apcu_on(): bool {
 	} else {
 		$on = (bool) @ini_get('apc.enabled');
 	}
-	if ($on && in_array(PHP_SAPI, ['cli', 'phpdbg'], true) && !((bool) @ini_get('apc.enable_cli'))) {
+	if ($on && in_array(PHP_SAPI, ['cli', 'phpdbg'], true) && !((bool) @ini_get('apc.enable_cli')) && !fp_apcu_env_flag('FP_APCU_ENABLE_CLI', false)) {
 		$on = false;
 	}
 	if ($on) {
@@ -82,6 +142,7 @@ function is_apcu_on(): bool {
 /**
  * Fetch from APCu with instance prefix.
  * 2-Arg form: sets $ok=true on hit; 1-Arg form: same as apcu_fetch($key).
+ *
  * @param string $key
  * @param bool $ok
  * @return mixed|null
@@ -97,17 +158,18 @@ function apcu_get($key, &$ok = null) {
 	if ($ok !== null) {
 		return apcu_fetch(apcu_key((string) $key), $ok);
 	}
-	// One-Arg Form
 	return apcu_fetch(apcu_key((string) $key));
 }
 
 /**
  * Store a value in APCu. TTL=0 means no expiry; no-op if APCu is off.
+ *
  * @param string $key
  * @param mixed $val
  * @param int $ttl
+ * @return bool
  */
-function apcu_set($key, $val, $ttl = 120) {
+function apcu_set($key, $val, $ttl = 120): bool {
 	if (!is_apcu_on()) {
 		return false;
 	}
@@ -115,6 +177,6 @@ function apcu_set($key, $val, $ttl = 120) {
 	if ($ttl < 0) {
 		$ttl = 0;
 	}
-	return apcu_store(apcu_key((string) $key), $val, $ttl);
+	return (bool) apcu_store(apcu_key((string) $key), $val, $ttl);
 }
 ?>

--- a/fp-includes/fp-smartyplugins/block.cache.php
+++ b/fp-includes/fp-smartyplugins/block.cache.php
@@ -3,8 +3,9 @@
  * Smarty {cache}{/cache} block plugin
  *
  * Purpose:
- *   Cache rendered block output in FlatPress' CACHE_DIR even when
- *   global Smarty output caching is disabled.
+ *   Cache rendered block output even when global Smarty output caching is
+ *   disabled. When APCu is available, FlatPress stores fragment payloads in
+ *   RAM first. Otherwise it falls back to CACHE_DIR on the filesystem.
  *
  * Supported attributes:
  *   - id / key      Optional explicit cache key. Recommended for repeated
@@ -34,6 +35,8 @@
  *     vary_logged_in=false) for truly public fragments.
  *   - Request-based variance can be enabled per block via
  *     vary_request=true (or vary_route=true).
+ *   - Storage backend selection is automatic: APCu when available,
+ *     filesystem fallback otherwise.
  */
 
 /**
@@ -310,6 +313,16 @@ function fp_smarty_cache_runtime_vary($template, array $params = []) {
 }
 
 /**
+ * @return string
+ */
+function fp_smarty_cache_backend() {
+	if (function_exists('is_apcu_on') && is_apcu_on()) {
+		return 'apcu';
+	}
+	return 'file';
+}
+
+/**
  * @param mixed $params
  * @param mixed $template
  * @return array<string,mixed>
@@ -353,6 +366,7 @@ function fp_smarty_cache_build_state($params, $template) {
 	$cacheRoot = defined('CACHE_DIR') ? CACHE_DIR : sys_get_temp_dir();
 	$cacheRoot = rtrim((string) $cacheRoot, '/\\');
 	$file = $cacheRoot . DIRECTORY_SEPARATOR . 'smarty-block-cache' . DIRECTORY_SEPARATOR . $group . DIRECTORY_SEPARATOR . substr($hash, 0, 2) . DIRECTORY_SEPARATOR . $hash . '.cache.php';
+	$apcuKey = 'smarty:block:' . $group . ':' . $hash;
 
 	return [
 		'enabled' => $enabled,
@@ -360,27 +374,64 @@ function fp_smarty_cache_build_state($params, $template) {
 		'group' => $group,
 		'slot' => $slot,
 		'hash' => $hash,
+		'backend' => fp_smarty_cache_backend(),
+		'apcu_key' => $apcuKey,
 		'file' => $file,
 		'template_stamp' => (int) $meta ['source_timestamp'],
 	];
 }
 
 /**
+ * @param mixed $raw
+ * @return array<string,mixed>|null
+ */
+function fp_smarty_cache_decode_payload($raw) {
+	if (is_array($raw)) {
+		return $raw;
+	}
+	if (is_string($raw) && $raw !== '') {
+		$payload = @unserialize($raw);
+		if (is_array($payload)) {
+			return $payload;
+		}
+	}
+	return null;
+}
+
+/**
  * @param array<string,mixed> $state
+ * @return void
+ */
+function fp_smarty_cache_delete(array $state) {
+	$backend = isset($state ['backend']) ? (string) $state ['backend'] : 'file';
+	if ($backend === 'apcu') {
+		$key = isset($state ['apcu_key']) ? (string) $state ['apcu_key'] : '';
+		if ($key === '') {
+			return;
+		}
+		if (function_exists('apcu_delete_key')) {
+			apcu_delete_key($key);
+			return;
+		}
+		if (function_exists('apcu_delete') && function_exists('apcu_key') && function_exists('is_apcu_on') && is_apcu_on()) {
+			@apcu_delete(apcu_key($key));
+		}
+		return;
+	}
+
+	$file = isset($state ['file']) ? (string) $state ['file'] : '';
+	if ($file !== '') {
+		@unlink($file);
+	}
+}
+
+/**
+ * @param array<string,mixed> $state
+ * @param mixed $raw
  * @return string|null
  */
-function fp_smarty_cache_read(array $state) {
-	$file = isset($state ['file']) ? (string) $state ['file'] : '';
-	if ($file === '' || !is_file($file)) {
-		return null;
-	}
-
-	$raw = function_exists('io_load_file') ? io_load_file($file) : @file_get_contents($file);
-	if (!is_string($raw) || $raw === '') {
-		return null;
-	}
-
-	$payload = @unserialize($raw);
+function fp_smarty_cache_validate_payload(array $state, $raw) {
+	$payload = fp_smarty_cache_decode_payload($raw);
 	if (!is_array($payload)) {
 		return null;
 	}
@@ -391,16 +442,17 @@ function fp_smarty_cache_read(array $state) {
 	$currentTemplateStamp = isset($state ['template_stamp']) ? (int) $state ['template_stamp'] : 0;
 
 	if ($currentTemplateStamp > 0 && $cachedTemplateStamp > 0 && $cachedTemplateStamp !== $currentTemplateStamp) {
-		@unlink($file);
+		fp_smarty_cache_delete($state);
 		return null;
 	}
 
 	if ($ttl > 0 && $created > 0 && ($created + $ttl) < time()) {
-		@unlink($file);
+		fp_smarty_cache_delete($state);
 		return null;
 	}
 
 	if (!isset($payload ['content']) || !is_string($payload ['content'])) {
+		fp_smarty_cache_delete($state);
 		return null;
 	}
 
@@ -409,24 +461,72 @@ function fp_smarty_cache_read(array $state) {
 
 /**
  * @param array<string,mixed> $state
+ * @return string|null
+ */
+function fp_smarty_cache_read(array $state) {
+	$backend = isset($state ['backend']) ? (string) $state ['backend'] : 'file';
+
+	if ($backend === 'apcu') {
+		$key = isset($state ['apcu_key']) ? (string) $state ['apcu_key'] : '';
+		if ($key === '' || !function_exists('apcu_get')) {
+			return null;
+		}
+		$ok = false;
+		$raw = apcu_get($key, $ok);
+		if (!$ok) {
+			return null;
+		}
+		return fp_smarty_cache_validate_payload($state, $raw);
+	}
+
+	$file = isset($state ['file']) ? (string) $state ['file'] : '';
+	if ($file === '' || !is_file($file)) {
+		return null;
+	}
+
+	$raw = function_exists('io_load_file') ? io_load_file($file) : @file_get_contents($file);
+	if (!is_string($raw) || $raw === '') {
+		return null;
+	}
+
+	return fp_smarty_cache_validate_payload($state, $raw);
+}
+
+/**
+ * @param array<string,mixed> $state
  * @param string $content
  * @return bool
  */
 function fp_smarty_cache_write(array $state, $content) {
+	$payload = [
+		'created' => time(),
+		'ttl' => (int) ($state ['ttl'] ?? 3600),
+		'template_stamp' => (int) ($state ['template_stamp'] ?? 0),
+		'content' => (string) $content,
+	];
+	$backend = isset($state ['backend']) ? (string) $state ['backend'] : 'file';
+
+	if ($backend === 'apcu') {
+		$key = isset($state ['apcu_key']) ? (string) $state ['apcu_key'] : '';
+		if ($key === '' || !function_exists('apcu_set')) {
+			return false;
+		}
+		$ttl = (int) ($state ['ttl'] ?? 3600);
+		if ($ttl < 0) {
+			$ttl = 0;
+		}
+		return (bool) apcu_set($key, $payload, $ttl);
+	}
+
 	$file = isset($state ['file']) ? (string) $state ['file'] : '';
 	if ($file === '') {
 		return false;
 	}
 
-	$payload = serialize([
-		'created' => time(),
-		'ttl' => (int) ($state ['ttl'] ?? 3600),
-		'template_stamp' => (int) ($state ['template_stamp'] ?? 0),
-		'content' => (string) $content,
-	]);
+	$serialized = serialize($payload);
 
 	if (function_exists('io_write_file')) {
-		return (bool) io_write_file($file, $payload);
+		return (bool) io_write_file($file, $serialized);
 	}
 
 	$dir = dirname($file);
@@ -435,7 +535,7 @@ function fp_smarty_cache_write(array $state, $content) {
 			return false;
 		}
 	}
-	return @file_put_contents($file, $payload, LOCK_EX) !== false;
+	return @file_put_contents($file, $serialized, LOCK_EX) !== false;
 }
 
 /**


### PR DESCRIPTION
- If APCu is available, we store the Smarty cache fragments in the APCu cache instead of on disk.

https://github.com/flatpressblog/flatpress/blob/master/docs/FlatPress_Smarty_Cache_Overview.md https://github.com/flatpressblog/flatpress/blob/master/docs/FlatPress_APCu_Cache_Overview.md