### PR TITLE
Fix for crash when BBCode is disabled

### DIFF
--- a/admin/panels/entry/admin.entry.commedit.php
+++ b/admin/panels/entry/admin.entry.commedit.php
@@ -4,7 +4,7 @@
  *
  * Type:
  * Name:
- * Date: 30.12.2024
+ * Date: 18.04.2026
  * Purpose: Provides the option to edit comments
  * Input:
  *
@@ -133,10 +133,16 @@ class admin_entry_commedit extends AdminPanelActionValidated {
 
 		$comment = comment_parse($_REQUEST ['entry'], $_REQUEST ['comment']);
 
-		if (isset($comment ['loggedin']) || user_loggedin()) {
-			$content ['loggedin'] = $comment ['loggedin'];
-			$content ['ip-address'] = $comment ['ip-address'];
-			$content ['date'] = $comment ['date'];
+		if (is_array($comment) && (array_key_exists('loggedin', $comment) || user_loggedin())) {
+			if (array_key_exists('loggedin', $comment)) {
+				$content ['loggedin'] = $comment ['loggedin'];
+			}
+			if (array_key_exists('ip-address', $comment)) {
+				$content ['ip-address'] = $comment ['ip-address'];
+			}
+			if (array_key_exists('date', $comment)) {
+				$content ['date'] = $comment ['date'];
+			}
 			$success = comment_save($_REQUEST ['entry'], $content);
 			$this->smarty->assign('success', $success ? 1 : -1);
 		}

--- a/fp-plugins/tag/inc/entry.php
+++ b/fp-plugins/tag/inc/entry.php
@@ -114,14 +114,42 @@ class plugin_tag_entry {
 	}
 
 	/**
+	 * Ensures the BBCode parser class is available without activating the BBCode plugin.
+	 *
+	 * @return bool True if the parser class can be used, false otherwise.
+	 */
+	function ensure_bbcode_parser() {
+		if (class_exists('StringParser_BBCode', false)) {
+			return true;
+		}
+
+		if (!function_exists('plugin_tag_get_bbcode_parser_file')) {
+			return false;
+		}
+
+		$parserFile = plugin_tag_get_bbcode_parser_file();
+		if ($parserFile === false) {
+			return false;
+		}
+
+		require_once $parserFile;
+
+		return class_exists('StringParser_BBCode', false);
+	}
+
+	/**
 	 * load_bbcode
 	 *
 	 * This function create a new instance of StringParser_BBCode
 	 * and add to it the 'tag' tag.
 	 *
-	 * returns object: the StringParser_BBCode instance
+	 * @return StringParser_BBCode|false The parser instance or false when unavailable.
 	 */
 	function load_bbcode() {
+		if (!$this->ensure_bbcode_parser()) {
+			return false;
+		}
+
 		$tag_bbcode = new StringParser_BBCode();
 		$tag_bbcode->addCode('tag', 'callback_replace', array(
 			$this,
@@ -154,7 +182,7 @@ class plugin_tag_entry {
 		$this->merge = true;
 		# Load the tag parser and parse them
 		$tag_bbcode = $this->load_bbcode();
-		if (false !== $post = $tag_bbcode->parse($content)) {
+		if ($tag_bbcode && false !== $post = $tag_bbcode->parse($content)) {
 			$content = $post;
 		}
 		# Disable tag merge

--- a/fp-plugins/tag/plugin.tag.php
+++ b/fp-plugins/tag/plugin.tag.php
@@ -27,8 +27,44 @@ define('PLUGIN_TAG_ALLOW_NOT', false);
 // Never create the cache
 define('PLUGIN_TAG_NOCACHE', false);
 
+function plugin_tag_get_bbcode_parser_file() {
+	static $parserFile = null;
+
+	if ($parserFile !== null) {
+		return $parserFile;
+	}
+
+	$candidates = array();
+
+	if (function_exists('plugin_getdir')) {
+		$candidates[] = plugin_getdir('bbcode') . '/inc/stringparser_bbcode.class.php';
+	}
+
+	$candidates[] = dirname(__FILE__) . '/../bbcode/inc/stringparser_bbcode.class.php';
+
+	foreach ($candidates as $candidate) {
+		$dependency = is_string($candidate) ? dirname($candidate) . '/stringparser.class.php' : '';
+
+		if (is_string($candidate) && $candidate !== '' && is_file($candidate) && is_file($dependency)) {
+			$parserFile = $candidate;
+			return $parserFile;
+		}
+	}
+
+	$parserFile = false;
+	return $parserFile;
+}
+
+function plugin_tag_has_bbcode_parser() {
+	if (function_exists('plugin_bbcode_init') || class_exists('StringParser_BBCode', false)) {
+		return true;
+	}
+
+	return plugin_tag_get_bbcode_parser_file() !== false;
+}
+
 function plugin_tag_setup() {
-	return function_exists('plugin_bbcode_init') ? 1 : -1;
+	return plugin_tag_has_bbcode_parser() ? 1 : -1;
 }
 
 class plugin_tag {

--- a/fp-plugins/tag/plugin.tag.php
+++ b/fp-plugins/tag/plugin.tag.php
@@ -43,9 +43,9 @@ function plugin_tag_get_bbcode_parser_file() {
 	$candidates[] = dirname(__FILE__) . '/../bbcode/inc/stringparser_bbcode.class.php';
 
 	foreach ($candidates as $candidate) {
-		$dependency = is_string($candidate) ? dirname($candidate) . '/stringparser.class.php' : '';
+		$dependency = dirname($candidate) . '/stringparser.class.php';
 
-		if (is_string($candidate) && $candidate !== '' && is_file($candidate) && is_file($dependency)) {
+		if (is_file($candidate) && is_file($dependency)) {
 			$parserFile = $candidate;
 			return $parserFile;
 		}


### PR DESCRIPTION
- Fixes the issue where the tag plugin crashes when the BBCode parser is not active.
- The tag plugin now loads the BBCode parser class only when necessary if the BBCode plugin is disabled.
- The comment editor continues to save existing metadata but no longer accesses missing keys without protection.