### PR TITLE
Update Mastodon to version 2.2.2

### DIFF
--- a/docs/FlatPress_APCu_Cache_Overview.md
+++ b/docs/FlatPress_APCu_Cache_Overview.md
@@ -821,6 +821,65 @@ Low–Medium. This cache does not affect every request, but it avoids repeated `
 
 ---
 
+### 4.10 Mastodon State Fallback and Synchronization Guards – `mastodon:state:*`, `mastodon:sync_guard:*`
+
+**File:** `fp-plugins/mastodon/plugin.mastodon.php`  
+
+The Mastodon plugin also uses APCu for short-lived resilience around scheduled synchronization state.
+
+**Logical keys:**
+
+- `mastodon:state:last_known_good`
+- `mastodon:sync_guard:content:v1`
+- `mastodon:sync_guard:deletion:v1`
+
+**Effective APCu keys:**
+
+All three keys are stored through the Mastodon APCu wrapper, which calls the FlatPress APCu wrappers. With APCu enabled, the runtime keys therefore become:
+
+- `fp:<NS>:mastodon:state:last_known_good`
+- `fp:<NS>:mastodon:sync_guard:content:v1`
+- `fp:<NS>:mastodon:sync_guard:deletion:v1`
+
+**What is cached:**
+
+- `mastodon:state:last_known_good`
+  - the most recently normalized valid Mastodon synchronization state,
+  - wrapped with a `stored_at` timestamp,
+  - used only as a short-lived "last known good" fallback when `fp-content/plugin_mastodon/state.json` is missing, empty, unreadable, or invalid.
+- `mastodon:sync_guard:content:v1`
+  - a small guard payload for non-forced scheduled content synchronization.
+- `mastodon:sync_guard:deletion:v1`
+  - a small guard payload for non-forced scheduled deletion synchronization.
+
+**TTL / invalidation:**
+
+- State fallback TTL: `PLUGIN_MASTODON_STATE_FALLBACK_TTL`, currently `300` seconds (5 minutes).
+- Synchronization guard TTL: `PLUGIN_MASTODON_COOLDOWN_TTL`, currently `300` seconds (5 minutes).
+- The state fallback is refreshed after valid state reads and after state writes, including cases where the durable file write fails.
+- Guard entries expire naturally after the cooldown window.
+- Guard entries can also be cleared explicitly by `plugin_mastodon_sync_guard_clear()`.
+- All entries are naturally invalidated by APCu eviction/reset and FlatPress namespace rotation.
+
+**File-backed companion layer:**
+
+- Durable state remains `fp-content/plugin_mastodon/state.json`.
+- The cooldown guard also has a file companion: `fp-content/plugin_mastodon/sync.guard.json`.
+- The file guard is intentionally tiny and TTL-based. It protects hosts where APCu is unavailable or where PHP workers do not share the same APCu pool.
+
+**Runtime behavior:**
+
+- Forced/manual synchronization bypasses the cooldown guards.
+- Non-forced scheduled content and deletion synchronization check the APCu guard first.
+- If APCu misses, the plugin checks `sync.guard.json`.
+- If the file guard is still active, it is seeded back into APCu for the remaining TTL.
+- This prevents repeated expensive Mastodon synchronization attempts on every or every second web request when `state.json` cannot be persisted reliably.
+
+**Impact:**  
+Medium for Mastodon-enabled sites under unfavorable hosting conditions. The APCu entries are small, but they stabilize request-time synchronization and prevent repeated media/status work when the durable state file is temporarily unavailable.
+
+---
+
 ## 5. Miscellaneous and Meta Caches
 
 ### 5.1 Instance Namespace Bootstrap – `fp:ns:*`
@@ -869,7 +928,7 @@ Admin-only, but critical for debugging and manual cache reset.
 
 ---
 
-### 5.4 File Fallback Layers (Calendar, Storage)
+### 5.4 File Fallback Layers (Calendar, Storage, Mastodon)
 
 Some features use a **dual-layer cache** (APCu + file fallback) to stay fast even when APCu is unavailable.
 
@@ -882,6 +941,13 @@ Some features use a **dual-layer cache** (APCu + file fallback) to stay fast eve
   - Additional JSON fallbacks:
     - `storage.dirsize.*.json`, `storage.quota.json`, `storage.dirsize.json`  
       (TTL-based; refreshed on demand; not globally purged on version bumps).
+
+- **Mastodon** (`fp-plugins/mastodon/plugin.mastodon.php`)
+  - Durable state: `fp-content/plugin_mastodon/state.json`.
+  - Last-known-good APCu fallback: `mastodon:state:last_known_good` with TTL 300s.
+  - File cooldown guard: `fp-content/plugin_mastodon/sync.guard.json`.
+  - APCu cooldown guards: `mastodon:sync_guard:content:v1` and `mastodon:sync_guard:deletion:v1`, each with TTL 300s.
+  - The file guard is used as a small shared fallback when APCu is unavailable or not shared between workers.
 
 ---
 
@@ -955,6 +1021,8 @@ The following table summarizes each logical cache group:
 | Calendar                     | `fp:calendar:v`, `calendar:*:vN`                                                     | **Yes**                  | `plugin_calendar_cache_bump()` + PrettyURLs bump     | Medium–High              |
 | Storage plugin               | `fp:storage:v`, `fp:storage:aggregate*`, `fp:storage:dirsize*`, `fp:storage:quota*`  | No                       | Storage rescan + TTL                                 | Low–Medium               |
 | Mastodon instance snapshot   | `fp:mastodon:instance_document:<sha1(instance_url)>`                                 | No                       | TTL 900s, `instance_url` change, snapshot refresh    | Low–Medium               |
+| Mastodon state fallback      | `fp:mastodon:state:last_known_good`                                                  | No                       | TTL 300s, refreshed after valid state read/write      | Medium                   |
+| Mastodon sync guards         | `fp:mastodon:sync_guard:content:v1`, `fp:mastodon:sync_guard:deletion:v1`            | No                       | TTL 300s + file guard `sync.guard.json`               | Medium                   |
 | Admin setup hide             | `fp:admin:setup_hide_report`                                                         | No                       | TTL (ok 86400s, fail 300s) + manual APCu clear       | Low–Medium (admin only)  |
 | PrettyURLs auto-detection    | `prettyurls:*`, `prettyurls:auto:v3:g*:*`                                            | No (but influences URLs) | `apcu_gen` bump on mode/.htaccess changes            | Medium                   |
 | Maintain panel tools         | Uses APCu to clear and inspect all keys, no own namespace                            | No                       | Manual admin action                                  | N/A (admin only)         |
@@ -989,6 +1057,9 @@ For completeness, the following logical prefixes are used by FlatPress `1.6.dev`
 - `fp:lang:`
 - `fp:net:in_cidrs:`
 - `fp:mastodon:instance_document:`
+- `fp:mastodon:state:last_known_good`
+- `fp:mastodon:sync_guard:content:v1`
+- `fp:mastodon:sync_guard:deletion:v1`
 - `fp:ns:`
 - `fp:plugin:dir:v2:`
 - `fp:plugin:exists:v2:`

--- a/fp-plugins/mastodon/Function-Organigram.md
+++ b/fp-plugins/mastodon/Function-Organigram.md
@@ -10,10 +10,10 @@ The layout is intentionally hierarchical so responsibilities, call paths, and im
 
 - The focus is the Mastodon plugin PHP code.
 - The document is organized by responsibility and call path.
-- Recently added FlatPress configuration reuse, centralized plugin-state detection, and FlatPress I/O helpers are reflected explicitly.
+- Recently added FlatPress configuration reuse, centralized plugin-state detection, FlatPress I/O helpers, explicit `FILE_PERMISSIONS` handling for Mastodon runtime files, APCu-backed last-known-good state fallback, and file-backed synchronization cooldown guards are reflected explicitly.
 - The companion-plugin diagnostics for BBCode, PhotoSwipe, AudioVideo, Tag, and Emoticons are covered.
 - The admin-side Mastodon instance-information snapshot, manual refresh button, exact-version display, and reuse of cached instance capabilities for later sync runs are covered.
-- Mastodon instance-dependent URL budgeting, bounded PHP execution-budget refreshes, OAuth scope discovery with a strict `profile`-scope preference and an older-instance fallback to `read:accounts`, media-type-aware asynchronous media-upload readiness polling for longer AudioVideo processing, AudioVideo optional endtag descriptions for local export and remote import, best-effort cleanup of unattached uploaded Mastodon media before a failed final posting finishes, follow-up deletion synchronization, the admin toggle that can disable deletion synchronization, comment tombstones that block stale re-imports of deleted remote replies, early protection of locally deleted exported FlatPress comments before the next content sync, local reattachment of surviving descendant replies to the synchronized entry status during deletion follow-up, targeted descendant-recheck queues with a dedicated `comment_rechecks` follow-up scope, and the separate persistence of content-sync and deletion-sync counters are reflected explicitly.
+- Mastodon instance-dependent URL budgeting, bounded PHP execution-budget refreshes, central per-run Mastodon API rate-limit guards with request/media-upload/delete budgets, OAuth scope discovery with a strict `profile`-scope preference and an older-instance fallback to `read:accounts`, media-type-aware asynchronous media-upload readiness polling for longer AudioVideo processing, AudioVideo optional endtag descriptions for local export and remote import, best-effort cleanup of unattached uploaded Mastodon media before a failed final posting finishes, follow-up deletion synchronization, the admin toggle that can disable deletion synchronization, comment tombstones that block stale re-imports of deleted remote replies, early protection of locally deleted exported FlatPress comments before the next content sync, local reattachment of surviving descendant replies to the synchronized entry status during deletion follow-up, targeted descendant-recheck queues with a dedicated `comment_rechecks` follow-up scope, 5-minute scheduled-sync cooldown guards, state-write failure reporting, and the separate persistence of content-sync and deletion-sync counters are reflected explicitly.
 - FlatPress timeoffset-aware remote import timestamps for Mastodon statuses and replies are reflected explicitly.
 - FlatPress-local admin time display for the daily synchronization time, last content sync, and last deletion sync is reflected explicitly while keeping the stored synchronization time in UTC.
 - Friendly deletion-sync guards for normalized comment mapping metadata are reflected explicitly.
@@ -35,6 +35,7 @@ The layout is intentionally hierarchical so responsibilities, call paths, and im
 - `GET /api/v1/statuses/:id`
 - `POST /api/v1/statuses`
 - `PUT /api/v1/statuses/:id`
+- `DELETE /api/v1/statuses/:id`
 - `GET /api/v2/instance`
 - `POST /api/v2/media`
 - `GET /api/v1/media/:id`
@@ -47,11 +48,12 @@ Current export behavior uses these endpoints in a version-aware way:
 - Remote media import retries alternate direct media URLs (`url`, `remote_url`, and for images `preview_url`) and uses longer transfer timeouts for downloaded media, so temporary object-storage or CDN failures do not immediately lose AudioVideo imports.
 - Current Mastodon media entities can be `image`, `gifv`, `video`, or `audio`; `audio` was added after early Mastodon media APIs, so import/export code must tolerate older payloads and unknown attachment types.
 - Instance-provided limits from `/api/v2/instance` are authoritative when available: `statuses.max_media_attachments`, `media_attachments.supported_mime_types`, `image_size_limit`, `video_size_limit`, `audio_size_limit`, and description limits. Public defaults still commonly include 4 media per status, one video/audio per status, and server-specific size/transcoding limits.
+- Official Mastodon API rate limits are protected locally by a per-run guard: the plugin reserves a conservative general request budget, a media-upload budget, and a status-delete budget, and also observes `X-RateLimit-*` / `429` responses so a single large synchronization run stops before it repeatedly hammers the instance.
 
 ## Function count
 
-The plugin file currently contains **261** callable functions/methods documented in this organigram:
-- **258** top-level plugin functions
+The plugin file currently contains **288** callable functions/methods documented in this organigram:
+- **285** top-level plugin functions
 - **3** admin panel class methods (`setup()`, `main()`, `onsubmit()`)
 
 ## High-level call flow
@@ -72,10 +74,10 @@ The plugin file currently contains **261** callable functions/methods documented
   Refreshes the shared-request PHP execution budget through `plugin_mastodon_extend_time_limit()`, protects locally deleted exported FlatPress comment mappings through `plugin_mastodon_protect_locally_deleted_exported_comments()` so stale Mastodon thread context cannot resurrect them during the same request, and then executes the two main directions in order:
   1. `plugin_mastodon_sync_remote_to_local()`
   2. `plugin_mastodon_sync_local_to_remote()`
-  If both directions finish successfully, the function marks a follow-up deletion pass as pending for a later web request.
+  Non-forced scheduled runs are gated by `plugin_mastodon_sync_guard_active()` and mark a 5-minute `content` cooldown through `plugin_mastodon_sync_guard_mark()` before network work starts. After acquiring the sync lock, the function starts a per-run Mastodon API guard through `plugin_mastodon_rate_limit_guard_start()`, so general requests, media uploads, and status deletions stay inside conservative budgets and Mastodon `X-RateLimit-*` headers can stop the run cleanly. If both directions finish successfully, the function marks a follow-up deletion pass as pending for a later web request. A completed sync is reported as failed if `plugin_mastodon_state_write()` cannot persist the updated state; the updated state is still placed in the short APCu fallback cache when APCu is available.
 
 - `plugin_mastodon_run_deletion_sync()`  
-  Runs the real deletion synchronization in a separate follow-up request. It first checks `plugin_mastodon_should_run_deletion_sync()` so the user-controlled admin toggle can disable the delete pass, resets only `deletion_stats` while preserving `content_stats` from the last content sync, gates mapped items through `plugin_mastodon_mapping_matches_sync_start()` so the delete pass stays inside the configured sync-start window, then either runs the full reconciliation pass or a targeted `comment_rechecks` follow-up scope via `plugin_mastodon_state_has_comment_recheck_scope()`. Direct descendants of newly deleted replies are queued with `plugin_mastodon_queue_comment_descendant_remote_rechecks()`, surviving direct child replies can be reattached to the synchronized entry status through `plugin_mastodon_reattach_local_comment_to_entry_status()`, and pending deep-thread cleanup is processed breadth-first through `plugin_mastodon_process_pending_comment_remote_rechecks()`.
+  Runs the real deletion synchronization in a separate follow-up request. It first checks `plugin_mastodon_should_run_deletion_sync()` so the user-controlled admin toggle can disable the delete pass, applies the same 5-minute cooldown guard with the `deletion` kind for non-forced scheduled runs, starts the per-run Mastodon API guard after acquiring the sync lock, resets only `deletion_stats` while preserving `content_stats` from the last content sync, gates mapped items through `plugin_mastodon_mapping_matches_sync_start()` so the delete pass stays inside the configured sync-start window, then either runs the full reconciliation pass or a targeted `comment_rechecks` follow-up scope via `plugin_mastodon_state_has_comment_recheck_scope()`. Direct descendants of newly deleted replies are queued with `plugin_mastodon_queue_comment_descendant_remote_rechecks()`, surviving direct child replies can be reattached to the synchronized entry status through `plugin_mastodon_reattach_local_comment_to_entry_status()`, and pending deep-thread cleanup is processed breadth-first through `plugin_mastodon_process_pending_comment_remote_rechecks()`. A successful delete pass is reported as failed if the resulting state cannot be persisted.
 
 ### Local → remote export path
 
@@ -90,7 +92,7 @@ The plugin file currently contains **261** callable functions/methods documented
   - collects local images, galleries, AudioVideo `[audioplayer]` tags, and AudioVideo `[videoplayer]` tags with `plugin_mastodon_collect_local_entry_media()`, including optional text between AudioVideo opening and closing tags
   - normalizes media items and computes attachment/description signatures with `plugin_mastodon_prepare_entry_media_items()`, `plugin_mastodon_entry_media_attachment_signature_from_items()`, and `plugin_mastodon_entry_media_description_signature_from_items()`
   - prepares a per-entry sync strategy with `plugin_mastodon_prepare_entry_media_sync_plan()`
-  - uploads media through `plugin_mastodon_upload_media_items()` only when attachments really changed or when an older/unknown Mastodon version cannot edit descriptions in place
+  - uploads media through `plugin_mastodon_upload_media_items()` only when attachments really changed or when an older/unknown Mastodon version cannot edit descriptions in place, and each upload must pass the per-run media-upload budget enforced by `plugin_mastodon_rate_limit_acquire()`
   - sends initial descriptions in `POST /api/v2/media`, including image alt text, AudioVideo optional endtag text, and legacy AudioVideo description/title/alt attributes; video posters become Mastodon thumbnails when the local poster file is usable
   - reuses stored remote `media_ids` for text-only edits, and on Mastodon 4.1+ forwards changed descriptions through `plugin_mastodon_status_media_attributes()` and `plugin_mastodon_update_status()`
   - waits for asynchronously processed media through `plugin_mastodon_fetch_media_attachment()` and `plugin_mastodon_wait_for_media_attachment()` when required; `plugin_mastodon_media_processing_attempts()` gives audio, video, and GIFV uploads a longer bounded polling window than images
@@ -117,6 +119,7 @@ The plugin file currently contains **261** callable functions/methods documented
   - blocks stale re-imports of deleted remote replies via `plugin_mastodon_state_has_comment_tombstone()`
   - optionally prepends a BBCode quote of the replied-to Mastodon comment (or the previously exported FlatPress comment) so FlatPress readers can see who was answered and what was answered to
   - refreshes known older threads with `plugin_mastodon_collect_known_entry_context_targets()`
+  - aborts the import direction with the rate-limit reason when the central per-run guard has blocked further API work
 
 ### Admin panel flow
 
@@ -133,286 +136,313 @@ The plugin file currently contains **261** callable functions/methods documented
 
 ## A. Entry points and admin integration
 
-- `plugin_mastodon_head()` — line 1262 — Print Mastodon profile metadata into the HTML head.
-- `plugin_mastodon_maybe_sync()` — line 7161 — Run the scheduled synchronization when the current request is due.
-- `plugin_mastodon_run_sync()` — line 7096 — Run a full synchronization cycle.
-- `plugin_mastodon_run_deletion_sync()` — line 6875 — Run the deferred deletion synchronization in a follow-up request after content sync completed.
-- `plugin_mastodon_sync_due()` — line 7074 — Determine whether the scheduled synchronization is currently due.
-- `plugin_mastodon_admin_assign()` — line 7323 — Assign plugin data to Smarty for the admin panel, including cached instance-information rows.
-- `setup()` — line 7362 — Register the Mastodon admin panel template and assign plugin data to Smarty.
-- `main()` — line 7367 — Keep the admin panel lifecycle compatible with FlatPress without extra processing.
-- `onsubmit()` — line 7371 — Process configuration saves, OAuth actions, authorization-code exchange, manual instance-information refreshes, and the manual synchronization trigger.
+- `plugin_mastodon_head()` — line 1864 — Print Mastodon profile metadata into the HTML head.
+- `plugin_mastodon_maybe_sync()` — line 8513 — Run the scheduled synchronization when the current request is due.
+- `plugin_mastodon_run_sync()` — line 8434 — Run a full synchronization cycle.
+- `plugin_mastodon_run_deletion_sync()` — line 8192 — Run the deferred deletion synchronization in a follow-up request after content sync completed.
+- `plugin_mastodon_sync_due()` — line 8412 — Determine whether the scheduled synchronization is currently due.
+- `plugin_mastodon_admin_assign()` — line 8675 — Assign plugin data to Smarty for the admin panel, including cached instance-information rows.
+- `setup()` — line 8720 — Register the Mastodon admin panel template and assign plugin data to Smarty.
+- `main()` — line 8725 — Keep the admin panel lifecycle compatible with FlatPress without extra processing.
+- `onsubmit()` — line 8729 — Process configuration saves, OAuth actions, authorization-code exchange, manual instance-information refreshes, and the manual synchronization trigger.
 
 ## B. Defaults, configuration, secrets, and centralized FlatPress feature toggles
 
-- `plugin_mastodon_default_options()` — line 56 — Return the default plugin option values.
-- `plugin_mastodon_clear_saved_instance_info()` — line 86 — Remove persisted instance-information snapshots and related admin refresh errors from an option array.
-- `plugin_mastodon_compact_instance_document()` — line 105 — Reduce `/api/v2/instance` responses to the stable subset reused by the plugin and admin table.
-- `plugin_mastodon_saved_instance_document()` — line 310 — Decode the persisted compact instance snapshot from the saved plugin configuration.
-- `plugin_mastodon_store_instance_document()` — line 355 — Persist a compact instance-information snapshot in the FlatPress plugin configuration and warm request/APCu caches.
-- `plugin_mastodon_store_instance_error()` — line 401 — Persist the latest instance-information refresh failure for the admin diagnostics view.
-- `plugin_mastodon_refresh_instance_information()` — line 417 — Force a live `/api/v2/instance` refresh, compact the response, and store it for later requests.
-- `plugin_mastodon_default_content_stats()` — line 437 — Return the default counters for the last content synchronization.
-- `plugin_mastodon_default_deletion_stats()` — line 454 — Return the default counters for the last deletion synchronization.
-- `plugin_mastodon_default_state()` — line 467 — Return the default runtime state structure, including the targeted deletion-follow-up scope marker.
-- `plugin_mastodon_oauth_legacy_scopes()` — line 491 — Return the legacy OAuth scope string used before scope discovery was added.
-- `plugin_mastodon_oauth_profile_scopes()` — line 499 — Return the stricter OAuth scope string that uses `profile` for `verify_credentials`.
-- `plugin_mastodon_oauth_server_metadata()` — line 508 — Discover and cache OAuth authorization-server metadata from `/.well-known/oauth-authorization-server`.
-- `plugin_mastodon_oauth_supported_scopes()` — line 527 — Parse the discoverable OAuth scopes supported by the configured Mastodon instance.
-- `plugin_mastodon_oauth_scope_supported()` — line 564 — Check whether the configured Mastodon instance advertises support for a specific OAuth scope.
-- `plugin_mastodon_oauth_preferred_scopes()` — line 585 — Prefer the narrow `profile` scope on current instances and fall back to `read:accounts` on older ones.
-- `plugin_mastodon_oauth_scopes()` — line 602 — Return the OAuth scopes that the currently registered app may safely request.
-- `plugin_mastodon_fp_config()` — line 679 — Return the FlatPress configuration, preferring the early-loaded core cache.
-- `plugin_mastodon_fp_config_value()` — line 715 — Read a nested FlatPress configuration value.
-- `plugin_mastodon_fp_timeoffset_seconds()` — line 731 — Return the configured FlatPress time offset in seconds for exact local admin-time conversion.
-- `plugin_mastodon_fp_timeoffset_label()` — line 751 — Format the configured FlatPress time offset as a UTC label for admin users.
-- `plugin_mastodon_sync_time_to_minutes()` — line 781 — Convert a normalized `HH:MM` sync-time value into minutes after midnight.
-- `plugin_mastodon_minutes_to_sync_time()` — line 792 — Convert minutes after midnight back into a normalized `HH:MM` sync-time value.
-- `plugin_mastodon_sync_time_utc_to_local()` — line 808 — Convert the stored UTC synchronization time to the FlatPress-local admin time.
-- `plugin_mastodon_sync_time_local_to_utc()` — line 819 — Convert the FlatPress-local admin synchronization time back to stored UTC.
-- `plugin_mastodon_format_admin_datetime()` — line 830 — Format stored UTC timestamps for the admin panel using FlatPress `timeoffset`, date format, and time format.
-- `plugin_mastodon_fp_timeoffset_hours()` — line 731 — Return the configured FlatPress time offset in whole hours.
-- `plugin_mastodon_get_options()` — line 915 — Load the saved plugin options and merge them with defaults.
-- `plugin_mastodon_save_options()` — line 970 — Persist plugin options, invalidate mismatching instance snapshots on URL changes, and keep matching refreshed snapshots.
-- `plugin_mastodon_secret_key()` — line 1055 — Build the encryption key used for stored secrets.
-- `plugin_mastodon_secret_encode()` — line 1072 — Encode a secret value before storing it in the configuration.
-- `plugin_mastodon_secret_decode()` — line 1095 — Decode a previously stored secret value.
-- `plugin_mastodon_normalize_instance_url()` — line 1126 — Normalize the configured Mastodon instance URL.
-- `plugin_mastodon_normalize_head_username()` — line 1159 — Normalize the configured Mastodon username for HTML head metadata.
-- `plugin_mastodon_instance_authority()` — line 1198 — Return the Mastodon instance authority used in fediverse creator metadata.
-- `plugin_mastodon_profile_url()` — line 1228 — Build the public Mastodon profile URL used for the rel-me link.
-- `plugin_mastodon_fediverse_creator_value()` — line 1244 — Build the fediverse creator meta value.
-- `plugin_mastodon_normalize_status_language()` — line 1302 — Normalize a FlatPress locale string to a Mastodon-compatible ISO 639-1 code.
-- `plugin_mastodon_configured_status_language()` — line 1324 — Read the configured FlatPress locale and return the Mastodon language code.
-- `plugin_mastodon_normalize_sync_time()` — line 1344 — Normalize the configured daily sync time.
-- `plugin_mastodon_normalize_sync_start_date()` — line 1361 — Normalize the configured sync start date.
-- `plugin_mastodon_normalize_boolean_option()` — line 1387 — Normalize a boolean-like option value to the stored string representation.
-- `plugin_mastodon_normalize_update_local_from_remote()` — line 1403 — Normalize the toggle that controls whether existing local content may be updated from remote Mastodon data.
-- `plugin_mastodon_should_update_local_from_remote()` — line 1412 — Check whether remote Mastodon updates may overwrite already existing local FlatPress content.
-- `plugin_mastodon_normalize_import_synced_comments_as_entries()` — line 1421 — Normalize the toggle that allows importing already synchronized local comments as entries.
-- `plugin_mastodon_should_import_synced_comments_as_entries()` — line 1430 — Check whether a remote Mastodon status that is already mapped to a local FlatPress comment may also be imported as an entry.
-- `plugin_mastodon_normalize_quote_imported_reply_parent()` — line 1439 — Normalize the toggle that controls whether imported Mastodon replies should quote the replied-to comment.
-- `plugin_mastodon_should_quote_imported_reply_parent()` — line 1448 — Check whether imported Mastodon replies should include a quote of the replied-to comment.
-- `plugin_mastodon_normalize_delete_sync_enabled()` — line 1457 — Normalize the toggle that enables or disables the follow-up deletion synchronization.
-- `plugin_mastodon_should_run_deletion_sync()` — line 1466 — Check whether the follow-up deletion synchronization is enabled.
-- `plugin_mastodon_enabled_plugin_state()` — line 2802 — Determine whether a FlatPress plugin is enabled in the centralized plugin configuration.
-- `plugin_mastodon_tag_plugin_active()` — line 2867 — Determine whether the Tag plugin is active for the current FlatPress request.
-- `plugin_mastodon_bbcode_plugin_active()` — line 2884 — Determine whether the BBCode plugin is active for the current FlatPress request.
-- `plugin_mastodon_photoswipe_plugin_active()` — line 2901 — Determine whether the PhotoSwipe plugin is active for the current FlatPress request.
-- `plugin_mastodon_audiovideo_plugin_active()` — current source — Determine whether the AudioVideo plugin is active for the current FlatPress request.
-- `plugin_mastodon_emoticons_plugin_active()` — line 2918 — Determine whether the Emoticons plugin is active for the current FlatPress request.
-- `plugin_mastodon_companion_plugins_status()` — line 2933 — Return the status of companion FlatPress plugins used for the full Mastodon feature set.
+- `plugin_mastodon_default_options()` — line 77 — Return the default plugin option values.
+- `plugin_mastodon_clear_saved_instance_info()` — line 107 — Remove persisted instance-information snapshots and related admin refresh errors from an option array.
+- `plugin_mastodon_compact_instance_document()` — line 126 — Reduce `/api/v2/instance` responses to the stable subset reused by the plugin and admin table.
+- `plugin_mastodon_saved_instance_document()` — line 331 — Decode the persisted compact instance snapshot from the saved plugin configuration.
+- `plugin_mastodon_store_instance_document()` — line 376 — Persist a compact instance-information snapshot in the FlatPress plugin configuration and warm request/APCu caches.
+- `plugin_mastodon_store_instance_error()` — line 422 — Persist the latest instance-information refresh failure for the admin diagnostics view.
+- `plugin_mastodon_refresh_instance_information()` — line 438 — Force a live `/api/v2/instance` refresh, compact the response, and store it for later requests.
+- `plugin_mastodon_default_content_stats()` — line 458 — Return the default counters for the last content synchronization.
+- `plugin_mastodon_default_deletion_stats()` — line 475 — Return the default counters for the last deletion synchronization.
+- `plugin_mastodon_default_state()` — line 488 — Return the default runtime state structure, including the targeted deletion-follow-up scope marker.
+- `plugin_mastodon_oauth_legacy_scopes()` — line 512 — Return the legacy OAuth scope string used before scope discovery was added.
+- `plugin_mastodon_oauth_profile_scopes()` — line 520 — Return the stricter OAuth scope string that uses `profile` for `verify_credentials`.
+- `plugin_mastodon_oauth_server_metadata()` — line 529 — Discover and cache OAuth authorization-server metadata from `/.well-known/oauth-authorization-server`.
+- `plugin_mastodon_oauth_supported_scopes()` — line 548 — Parse the discoverable OAuth scopes supported by the configured Mastodon instance.
+- `plugin_mastodon_oauth_scope_supported()` — line 585 — Check whether the configured Mastodon instance advertises support for a specific OAuth scope.
+- `plugin_mastodon_oauth_preferred_scopes()` — line 606 — Prefer the narrow `profile` scope on current instances and fall back to `read:accounts` on older ones.
+- `plugin_mastodon_oauth_scopes()` — line 623 — Return the OAuth scopes that the currently registered app may safely request.
+- `plugin_mastodon_fp_config()` — line 700 — Return the FlatPress configuration, preferring the early-loaded core cache.
+- `plugin_mastodon_fp_config_value()` — line 736 — Read a nested FlatPress configuration value.
+- `plugin_mastodon_fp_timeoffset_seconds()` — line 752 — Return the configured FlatPress time offset in seconds for exact local admin-time conversion.
+- `plugin_mastodon_fp_timeoffset_label()` — line 772 — Format the configured FlatPress time offset as a UTC label for admin users.
+- `plugin_mastodon_sync_time_to_minutes()` — line 802 — Convert a normalized `HH:MM` sync-time value into minutes after midnight.
+- `plugin_mastodon_minutes_to_sync_time()` — line 813 — Convert minutes after midnight back into a normalized `HH:MM` sync-time value.
+- `plugin_mastodon_sync_time_utc_to_local()` — line 829 — Convert the stored UTC synchronization time to the FlatPress-local admin time.
+- `plugin_mastodon_sync_time_local_to_utc()` — line 840 — Convert the FlatPress-local admin synchronization time back to stored UTC.
+- `plugin_mastodon_format_admin_datetime()` — line 851 — Format stored UTC timestamps for the admin panel using FlatPress `timeoffset`, date format, and time format.
+- `plugin_mastodon_fp_timeoffset_hours()` — line 764 — Return the configured FlatPress time offset in whole hours.
+- `plugin_mastodon_get_options()` — line 1517 — Load the saved plugin options and merge them with defaults.
+- `plugin_mastodon_save_options()` — line 1572 — Persist plugin options, invalidate mismatching instance snapshots on URL changes, and keep matching refreshed snapshots.
+- `plugin_mastodon_secret_key()` — line 1657 — Build the encryption key used for stored secrets.
+- `plugin_mastodon_secret_encode()` — line 1674 — Encode a secret value before storing it in the configuration.
+- `plugin_mastodon_secret_decode()` — line 1697 — Decode a previously stored secret value.
+- `plugin_mastodon_normalize_instance_url()` — line 1728 — Normalize the configured Mastodon instance URL.
+- `plugin_mastodon_normalize_head_username()` — line 1761 — Normalize the configured Mastodon username for HTML head metadata.
+- `plugin_mastodon_instance_authority()` — line 1800 — Return the Mastodon instance authority used in fediverse creator metadata.
+- `plugin_mastodon_profile_url()` — line 1830 — Build the public Mastodon profile URL used for the rel-me link.
+- `plugin_mastodon_fediverse_creator_value()` — line 1846 — Build the fediverse creator meta value.
+- `plugin_mastodon_normalize_status_language()` — line 1904 — Normalize a FlatPress locale string to a Mastodon-compatible ISO 639-1 code.
+- `plugin_mastodon_configured_status_language()` — line 1926 — Read the configured FlatPress locale and return the Mastodon language code.
+- `plugin_mastodon_normalize_sync_time()` — line 1946 — Normalize the configured daily sync time.
+- `plugin_mastodon_normalize_sync_start_date()` — line 1963 — Normalize the configured sync start date.
+- `plugin_mastodon_normalize_boolean_option()` — line 1989 — Normalize a boolean-like option value to the stored string representation.
+- `plugin_mastodon_normalize_update_local_from_remote()` — line 2005 — Normalize the toggle that controls whether existing local content may be updated from remote Mastodon data.
+- `plugin_mastodon_should_update_local_from_remote()` — line 2014 — Check whether remote Mastodon updates may overwrite already existing local FlatPress content.
+- `plugin_mastodon_normalize_import_synced_comments_as_entries()` — line 2023 — Normalize the toggle that allows importing already synchronized local comments as entries.
+- `plugin_mastodon_should_import_synced_comments_as_entries()` — line 2032 — Check whether a remote Mastodon status that is already mapped to a local FlatPress comment may also be imported as an entry.
+- `plugin_mastodon_normalize_quote_imported_reply_parent()` — line 2041 — Normalize the toggle that controls whether imported Mastodon replies should quote the replied-to comment.
+- `plugin_mastodon_should_quote_imported_reply_parent()` — line 2050 — Check whether imported Mastodon replies should include a quote of the replied-to comment.
+- `plugin_mastodon_normalize_delete_sync_enabled()` — line 2059 — Normalize the toggle that enables or disables the follow-up deletion synchronization.
+- `plugin_mastodon_should_run_deletion_sync()` — line 2068 — Check whether the follow-up deletion synchronization is enabled.
+- `plugin_mastodon_enabled_plugin_state()` — line 3418 — Determine whether a FlatPress plugin is enabled in the centralized plugin configuration.
+- `plugin_mastodon_tag_plugin_active()` — line 3483 — Determine whether the Tag plugin is active for the current FlatPress request.
+- `plugin_mastodon_bbcode_plugin_active()` — line 3500 — Determine whether the BBCode plugin is active for the current FlatPress request.
+- `plugin_mastodon_photoswipe_plugin_active()` — line 3517 — Determine whether the PhotoSwipe plugin is active for the current FlatPress request.
+- `plugin_mastodon_audiovideo_plugin_active()` — line 3534 — Determine whether the AudioVideo plugin is active for the current FlatPress request.
+- `plugin_mastodon_emoticons_plugin_active()` — line 3551 — Determine whether the Emoticons plugin is active for the current FlatPress request.
+- `plugin_mastodon_companion_plugins_status()` — line 3566 — Return the status of companion FlatPress plugins used for the full Mastodon feature set.
 
 ## C. Caching, filesystem helpers, logging, and persisted state
 
-- `plugin_mastodon_runtime_cache_get()` — line 622 — Return a value from the request-local plugin cache.
-- `plugin_mastodon_runtime_cache_set()` — line 646 — Store a value in the request-local plugin cache.
-- `plugin_mastodon_runtime_cache_clear()` — line 664 — Clear one request-local plugin cache bucket or the complete cache.
-- `plugin_mastodon_io_read_file()` — line 761 — Read a file through the FlatPress I/O layer when available.
-- `plugin_mastodon_io_read_file_uncached()` — line 774 — Read a file without FlatPress request-local caches.
-- `plugin_mastodon_io_write_file()` — line 791 — Write a file through the FlatPress I/O layer when available.
-- `plugin_mastodon_io_append_file()` — line 804 — Append to a file via the FlatPress I/O layer.
-- `plugin_mastodon_apcu_enabled()` — line 820 — Check whether shared APCu caching is available for the plugin.
-- `plugin_mastodon_apcu_cache_key()` — line 829 — Build the namespaced APCu key used by this plugin.
-- `plugin_mastodon_apcu_fetch()` — line 843 — Fetch a value from APCu through the FlatPress namespace helper.
-- `plugin_mastodon_apcu_store()` — line 858 — Store a value in APCu through the FlatPress namespace helper.
-- `plugin_mastodon_apcu_delete()` — line 871 — Delete a value from APCu using the FlatPress namespace key builder.
-- `plugin_mastodon_file_prestat()` — line 884 — Read a cheap file metadata snapshot for cache validation.
-- `plugin_mastodon_file_prestat_signature()` — line 904 — Convert a file metadata snapshot into a stable cache signature.
-- `plugin_mastodon_ensure_state_dir()` — line 1639 — Ensure that the plugin runtime directory exists.
-- `plugin_mastodon_log()` — line 1648 — Append a line to the plugin sync log.
-- `plugin_mastodon_state_read()` — line 1658 — Load the persisted runtime state from disk.
-- `plugin_mastodon_state_write()` — line 1697 — Persist the runtime state to disk.
-- `plugin_mastodon_normalize_deletions_pending_scope()` — line 1721 — Normalize the targeted deletion-follow-up scope marker.
-- `plugin_mastodon_state_normalize()` — line 1734 — Normalize a runtime state array and fill in missing keys.
-- `plugin_mastodon_state_comment_key()` — line 1781 — Build the compound state key used for comment mappings.
-- `plugin_mastodon_state_set_entry_mapping()` — line 1796 — Store the mapping between a local entry and a remote status.
-- `plugin_mastodon_state_set_comment_mapping()` — line 1834 — Store the mapping between a local comment and a remote status.
-- `plugin_mastodon_state_remove_entry_mapping()` — line 1869 — Remove the mapping between a local entry and a remote status.
-- `plugin_mastodon_state_remove_comment_mapping()` — line 1888 — Remove the mapping between a local comment and a remote status.
-- `plugin_mastodon_state_get_entry_meta()` — line 1909 — Return mapping metadata for a local entry.
-- `plugin_mastodon_state_set_entry_media_meta()` — line 1923 — Persist cached remote media IDs plus local attachment/description signatures for a synchronized entry.
-- `plugin_mastodon_state_get_comment_meta()` — line 2004 — Return mapping metadata for a local comment.
-- `plugin_mastodon_state_set_comment_tombstone()` — line 2018 — Store a tombstone that blocks stale re-imports of one deleted remote comment.
-- `plugin_mastodon_state_has_comment_tombstone()` — line 2038 — Check whether one remote Mastodon comment status was tombstoned locally.
-- `plugin_mastodon_protect_locally_deleted_exported_comments()` — line 2050 — Tombstone locally deleted exported FlatPress comment mappings before the next content sync can stale-reimport them from Mastodon thread context.
-- `plugin_mastodon_reattach_local_comment_to_entry_status()` — line 2096 — Remove a local imported reply parent link and reattach the surviving reply to the synchronized entry status after its remote parent reply disappeared.
-- `plugin_mastodon_state_remove_pending_comment_remote_recheck()` — line 2156 — Remove one pending descendant recheck marker.
-- `plugin_mastodon_state_get_pending_comment_remote_recheck()` — line 2170 — Return one pending descendant recheck marker.
-- `plugin_mastodon_state_set_pending_comment_remote_recheck()` — line 2185 — Mark one local comment for follow-up verification after an ancestor disappeared remotely.
-- `plugin_mastodon_state_set_deletions_pending()` — line 2210 — Persist whether another deletion follow-up request is pending and which scope it should run.
-- `plugin_mastodon_state_has_comment_recheck_scope()` — line 2222 — Check whether the next deletion follow-up request should run only the targeted descendant recheck scope.
-- `plugin_mastodon_build_comment_remote_child_index()` — line 2231 — Build a direct-child index for mapped remote reply trees.
-- `plugin_mastodon_queue_comment_descendant_remote_rechecks()` — line 2259 — Queue only the direct mapped local children of one deleted remote comment for additional verification passes.
-- `plugin_mastodon_process_pending_comment_remote_rechecks()` — line 2298 — Process pending descendant rechecks breadth-first so deeper reply chains can converge within the same targeted follow-up request.
+- `plugin_mastodon_runtime_cache_get()` — line 643 — Return a value from the request-local plugin cache.
+- `plugin_mastodon_runtime_cache_set()` — line 667 — Store a value in the request-local plugin cache.
+- `plugin_mastodon_runtime_cache_clear()` — line 685 — Clear one request-local plugin cache bucket or the complete cache.
+- `plugin_mastodon_io_read_file()` — line 885 — Read a file through the FlatPress I/O layer when available.
+- `plugin_mastodon_io_read_file_uncached()` — line 898 — Read a file without FlatPress request-local caches.
+- `plugin_mastodon_file_permissions_mode()` — line 913 — Return the FlatPress `FILE_PERMISSIONS` mode used for plugin runtime files.
+- `plugin_mastodon_apply_file_permissions()` — line 922 — Apply FlatPress `FILE_PERMISSIONS` to a plugin runtime file.
+- `plugin_mastodon_io_write_file()` — line 935 — Write a file through the FlatPress I/O layer when available and enforce `FILE_PERMISSIONS` after successful writes.
+- `plugin_mastodon_io_append_file()` — line 956 — Append to a file via the FlatPress I/O layer.
+- `plugin_mastodon_apcu_enabled()` — line 972 — Check whether shared APCu caching is available for the plugin.
+- `plugin_mastodon_apcu_cache_key()` — line 981 — Build the namespaced APCu key used by this plugin.
+- `plugin_mastodon_apcu_fetch()` — line 995 — Fetch a value from APCu through the FlatPress namespace helper.
+- `plugin_mastodon_apcu_store()` — line 1010 — Store a value in APCu through the FlatPress namespace helper.
+- `plugin_mastodon_apcu_delete()` — line 1023 — Delete a value from APCu using the FlatPress namespace key builder.
+- `plugin_mastodon_state_fallback_key()` — line 1035 — Return the APCu key used for the short-lived last-known-good state fallback.
+- `plugin_mastodon_state_fallback_store()` — line 1044 — Store a normalized runtime state in APCu for a 5-minute emergency fallback window.
+- `plugin_mastodon_state_fallback_read()` — line 1056 — Fetch the short-lived last-known-good state fallback from APCu.
+- `plugin_mastodon_sync_guard_kind()` — line 1074 — Normalize the cooldown guard kind.
+- `plugin_mastodon_sync_guard_apcu_key()` — line 1084 — Return the APCu key used for one sync cooldown guard.
+- `plugin_mastodon_sync_guard_entry_active()` — line 1094 — Check whether one cooldown guard entry is still active.
+- `plugin_mastodon_sync_guard_apcu_store()` — line 1105 — Store one cooldown guard in APCu.
+- `plugin_mastodon_sync_guard_file_read()` — line 1118 — Read and prune the file-backed cooldown guard.
+- `plugin_mastodon_sync_guard_file_write()` — line 1145 — Write the file-backed cooldown guard.
+- `plugin_mastodon_sync_guard_active()` — line 1166 — Check whether a recent scheduled content/deletion pass is still cooling down.
+- `plugin_mastodon_sync_guard_mark()` — line 1191 — Mark a 5-minute cooldown guard for a scheduled sync/deletion pass.
+- `plugin_mastodon_sync_guard_clear()` — line 1212 — Clear one sync cooldown guard.
+- `plugin_mastodon_rate_limit_default_budgets()` — line 1227 — Return conservative per-run Mastodon API budgets.
+- `plugin_mastodon_rate_limit_guard_start()` — line 1252 — Start the per-run Mastodon API rate-limit guard.
+- `plugin_mastodon_rate_limit_guard_stop()` — line 1276 — Stop the per-run Mastodon API rate-limit guard while keeping its summary inspectable.
+- `plugin_mastodon_rate_limit_guard_active()` — line 1287 — Check whether the per-run Mastodon API guard is active.
+- `plugin_mastodon_rate_limit_guard_summary()` — line 1295 — Return the current per-run rate-limit guard summary.
+- `plugin_mastodon_rate_limit_headers()` — line 1304 — Normalize response headers for rate-limit checks.
+- `plugin_mastodon_rate_limit_request_kind()` — line 1325 — Classify Mastodon API requests as general, media upload, or status deletion.
+- `plugin_mastodon_rate_limit_block()` — line 1347 — Mark the current run as blocked by a rate-limit budget or Mastodon response and log the stop reason with budget counters once per run.
+- `plugin_mastodon_rate_limit_acquire()` — line 1383 — Reserve request/media/delete budget before a Mastodon API request proceeds.
+- `plugin_mastodon_rate_limit_observe_response()` — line 1424 — Update the guard from `X-RateLimit-*` headers and `429` responses.
+- `plugin_mastodon_rate_limit_blocked_reason()` — line 1448 — Return the current rate-limit block reason.
+- `plugin_mastodon_rate_limit_blocked_response()` — line 1460 — Build the synthetic `429` response used for locally blocked requests.
+- `plugin_mastodon_rate_limit_state_error()` — line 1476 — Return the rate-limit reason that should be written to synchronization state.
+- `plugin_mastodon_file_prestat()` — line 1486 — Read a cheap file metadata snapshot for cache validation.
+- `plugin_mastodon_file_prestat_signature()` — line 1506 — Convert a file metadata snapshot into a stable cache signature.
+- `plugin_mastodon_ensure_state_dir()` — line 2241 — Ensure that the plugin runtime directory exists.
+- `plugin_mastodon_log()` — line 2250 — Append a line to the plugin sync log.
+- `plugin_mastodon_state_read()` — line 2260 — Load the persisted runtime state from disk and fall back to the short-lived APCu state if the file is temporarily missing, empty, or invalid.
+- `plugin_mastodon_state_write()` — line 2314 — Persist the runtime state to disk and always refresh the short-lived APCu last-known-good state when possible.
+- `plugin_mastodon_normalize_deletions_pending_scope()` — line 2339 — Normalize the targeted deletion-follow-up scope marker.
+- `plugin_mastodon_state_normalize()` — line 2352 — Normalize a runtime state array and fill in missing keys.
+- `plugin_mastodon_state_comment_key()` — line 2399 — Build the compound state key used for comment mappings.
+- `plugin_mastodon_state_set_entry_mapping()` — line 2414 — Store the mapping between a local entry and a remote status.
+- `plugin_mastodon_state_set_comment_mapping()` — line 2452 — Store the mapping between a local comment and a remote status.
+- `plugin_mastodon_state_remove_entry_mapping()` — line 2487 — Remove the mapping between a local entry and a remote status.
+- `plugin_mastodon_state_remove_comment_mapping()` — line 2506 — Remove the mapping between a local comment and a remote status.
+- `plugin_mastodon_state_get_entry_meta()` — line 2527 — Return mapping metadata for a local entry.
+- `plugin_mastodon_state_set_entry_media_meta()` — line 2541 — Persist cached remote media IDs plus local attachment/description signatures for a synchronized entry.
+- `plugin_mastodon_state_get_comment_meta()` — line 2622 — Return mapping metadata for a local comment.
+- `plugin_mastodon_state_set_comment_tombstone()` — line 2636 — Store a tombstone that blocks stale re-imports of one deleted remote comment.
+- `plugin_mastodon_state_has_comment_tombstone()` — line 2656 — Check whether one remote Mastodon comment status was tombstoned locally.
+- `plugin_mastodon_protect_locally_deleted_exported_comments()` — line 2667 — Tombstone locally deleted exported FlatPress comment mappings before the next content sync can stale-reimport them from Mastodon thread context.
+- `plugin_mastodon_reattach_local_comment_to_entry_status()` — line 2713 — Remove a local imported reply parent link and reattach the surviving reply to the synchronized entry status after its remote parent reply disappeared.
+- `plugin_mastodon_state_remove_pending_comment_remote_recheck()` — line 2773 — Remove one pending descendant recheck marker.
+- `plugin_mastodon_state_get_pending_comment_remote_recheck()` — line 2787 — Return one pending descendant recheck marker.
+- `plugin_mastodon_state_set_pending_comment_remote_recheck()` — line 2802 — Mark one local comment for follow-up verification after an ancestor disappeared remotely.
+- `plugin_mastodon_state_set_deletions_pending()` — line 2827 — Persist whether another deletion follow-up request is pending and which scope it should run.
+- `plugin_mastodon_state_has_comment_recheck_scope()` — line 2839 — Check whether the next deletion follow-up request should run only the targeted descendant recheck scope.
+- `plugin_mastodon_build_comment_remote_child_index()` — line 2848 — Build a direct-child index for mapped remote reply trees.
+- `plugin_mastodon_queue_comment_descendant_remote_rechecks()` — line 2876 — Queue only the direct mapped local children of one deleted remote comment for additional verification passes.
+- `plugin_mastodon_process_pending_comment_remote_rechecks()` — line 2915 — Process pending descendant rechecks breadth-first so deeper reply chains can converge within the same targeted follow-up request.
 
 ## D. Date, timestamp, visibility, and threading helpers
 
-- `plugin_mastodon_timestamp_to_flatpress_time()` — line 744 — Convert a real Unix timestamp into FlatPress's offset-adjusted timestamp model.
-- `plugin_mastodon_timestamp_date_key()` — line 1475 — Convert a FlatPress-adjusted timestamp into a stable date key.
-- `plugin_mastodon_local_item_date_key()` — line 1489 — Determine the date key of a local FlatPress entry or comment.
-- `plugin_mastodon_remote_status_date_key()` — line 1509 — Determine the date key of a remote Mastodon status.
-- `plugin_mastodon_datetime_date_key()` — line 1535 — Normalize a stored date/datetime string to the sync-start date-key format.
-- `plugin_mastodon_date_matches_sync_start()` — line 1559 — Determine whether a content date passes the configured sync start date.
-- `plugin_mastodon_local_item_matches_sync_start()` — line 1578 — Determine whether a local FlatPress item should be synchronized.
-- `plugin_mastodon_remote_status_matches_sync_start()` — line 1588 — Determine whether a remote Mastodon status should be synchronized.
-- `plugin_mastodon_mapping_matches_sync_start()` — line 1599 — Determine whether a stored synchronization mapping still belongs to the active sync-start window.
-- `plugin_mastodon_parse_iso_datetime()` — line 2403 — Parse an ISO date/time string into FlatPress date format.
-- `plugin_mastodon_parse_iso_timestamp()` — line 2421 — Parse an ISO date/time value into a Unix timestamp.
-- `plugin_mastodon_remote_status_timestamp()` — line 2443 — Resolve the best FlatPress-adjusted timestamp for a remote Mastodon status.
-- `plugin_mastodon_remote_status_visibility()` — line 2462 — Return the normalized visibility of a remote Mastodon status.
-- `plugin_mastodon_remote_status_is_importable()` — line 2475 — Determine whether a remote Mastodon status may be imported.
-- `plugin_mastodon_comment_parent_fields()` — line 2487 — Return the comment fields that may contain a parent reference.
-- `plugin_mastodon_normalize_boolean_option()` — line 1387 — Normalize a boolean-like option value to the stored string representation.
-- `plugin_mastodon_normalize_comment_parent_id()` — line 2496 — Normalize a stored local comment parent identifier.
-- `plugin_mastodon_detect_local_comment_parent_id()` — line 2513 — Detect the local parent comment identifier from comment data.
-- `plugin_mastodon_resolve_comment_reply_target()` — line 2535 — Resolve the remote reply target for a local comment export.
-- `plugin_mastodon_list_local_comment_ids()` — line 2589 — Scan the FlatPress comment directory directly so local reply export is not blocked by stale comment-list caches.
+- `plugin_mastodon_timestamp_to_flatpress_time()` — line 786 — Convert a real Unix timestamp into FlatPress's offset-adjusted timestamp model.
+- `plugin_mastodon_timestamp_date_key()` — line 2077 — Convert a FlatPress-adjusted timestamp into a stable date key.
+- `plugin_mastodon_local_item_date_key()` — line 2091 — Determine the date key of a local FlatPress entry or comment.
+- `plugin_mastodon_remote_status_date_key()` — line 2111 — Determine the date key of a remote Mastodon status.
+- `plugin_mastodon_datetime_date_key()` — line 2137 — Normalize a stored date/datetime string to the sync-start date-key format.
+- `plugin_mastodon_date_matches_sync_start()` — line 2161 — Determine whether a content date passes the configured sync start date.
+- `plugin_mastodon_local_item_matches_sync_start()` — line 2180 — Determine whether a local FlatPress item should be synchronized.
+- `plugin_mastodon_remote_status_matches_sync_start()` — line 2190 — Determine whether a remote Mastodon status should be synchronized.
+- `plugin_mastodon_mapping_matches_sync_start()` — line 2201 — Determine whether a stored synchronization mapping still belongs to the active sync-start window.
+- `plugin_mastodon_parse_iso_datetime()` — line 3020 — Parse an ISO date/time string into FlatPress date format.
+- `plugin_mastodon_parse_iso_timestamp()` — line 3038 — Parse an ISO date/time value into a Unix timestamp.
+- `plugin_mastodon_remote_status_timestamp()` — line 3060 — Resolve the best FlatPress-adjusted timestamp for a remote Mastodon status.
+- `plugin_mastodon_remote_status_visibility()` — line 3079 — Return the normalized visibility of a remote Mastodon status.
+- `plugin_mastodon_remote_status_is_importable()` — line 3092 — Determine whether a remote Mastodon status may be imported.
+- `plugin_mastodon_comment_parent_fields()` — line 3104 — Return the comment fields that may contain a parent reference.
+- `plugin_mastodon_normalize_boolean_option()` — line 1989 — Normalize a boolean-like option value to the stored string representation.
+- `plugin_mastodon_normalize_comment_parent_id()` — line 3113 — Normalize a stored local comment parent identifier.
+- `plugin_mastodon_detect_local_comment_parent_id()` — line 3130 — Detect the local parent comment identifier from comment data.
+- `plugin_mastodon_resolve_comment_reply_target()` — line 3152 — Resolve the remote reply target for a local comment export.
+- `plugin_mastodon_list_local_comment_ids()` — line 3205 — Scan the FlatPress comment directory directly so local reply export is not blocked by stale comment-list caches.
 
 ## E. Text, URLs, language strings, tags, emojis, and BBCode/HTML conversion
 
-- `plugin_mastodon_guess_subject()` — line 2626 — Guess a subject line from imported plain text.
-- `plugin_mastodon_html_entity_decode()` — line 2668 — Decode HTML entities using the plugin defaults.
-- `plugin_mastodon_blog_base_url()` — line 2677 — Return the absolute base URL of the current FlatPress installation.
-- `plugin_mastodon_extract_url_token()` — line 2713 — Extract the URL token from a BBCode or attribute fragment.
-- `plugin_mastodon_absolute_url()` — line 2730 — Convert a URL or path into an absolute URL when possible.
-- `plugin_mastodon_lang_string()` — line 2772 — Return a localized plugin string or a provided fallback.
-- `plugin_mastodon_normalize_tag_list()` — line 2974 — Normalize a list of tag labels.
-- `plugin_mastodon_extend_time_limit()` — line 4614 — Refresh or raise the PHP execution time budget for long-running Mastodon work without lowering an existing higher or unlimited limit.
-- `plugin_mastodon_extract_flatpress_tags()` — line 3005 — Extract FlatPress Tag plugin labels from an entry body.
-- `plugin_mastodon_strip_flatpress_tag_bbcode()` — line 3030 — Remove Tag plugin BBCode blocks from entry content.
-- `plugin_mastodon_mastodon_hashtag_footer()` — line 3047 — Convert FlatPress tag labels into a Mastodon hashtag footer line.
-- `plugin_mastodon_remote_status_tags()` — line 3068 — Collect remote Mastodon tags from a status entity.
-- `plugin_mastodon_strip_trailing_mastodon_hashtag_footer()` — line 3095 — Remove a trailing Mastodon hashtag footer from imported plain text.
-- `plugin_mastodon_build_flatpress_tag_bbcode()` — line 3158 — Build Tag plugin BBCode from a list of remote Mastodon tags.
-- `plugin_mastodon_emoticon_entity_to_unicode()` — line 3171 — Convert an emoticon HTML entity into a Unicode character.
-- `plugin_mastodon_emoticon_map()` — line 3184 — Return the FlatPress emoticon-to-Unicode lookup map.
-- `plugin_mastodon_replace_emoticon_shortcodes_with_unicode()` — line 3238 — Replace FlatPress emoticon shortcodes with Unicode glyphs.
-- `plugin_mastodon_prepare_emoticons_for_mastodon()` — line 3253 — Convert active FlatPress emoticon shortcodes to standard Unicode emoji before Mastodon export.
-- `plugin_mastodon_replace_unicode_emoticons_with_shortcodes()` — line 3266 — Replace Unicode emoticons with FlatPress shortcodes.
-- `plugin_mastodon_is_public_host()` — line 3288 — Determine whether a host name resolves to a public endpoint.
-- `plugin_mastodon_public_url_for_mastodon()` — line 3311 — Return a Mastodon-safe public URL or an empty string.
-- `plugin_mastodon_plain_text_from_bbcode()` — line 3455 — Convert FlatPress BBCode into plain text for Mastodon export, removing complete AudioVideo player tags including optional description endtag content.
-- `plugin_mastodon_subject_line_is_noise()` — line 3372 — Determine whether an extracted line should be ignored as a subject.
-- `plugin_mastodon_domains_match()` — line 3400 — Determine whether two host names belong to the same domain family.
-- `plugin_mastodon_cleanup_imported_text()` — line 3414 — Clean imported text before saving it to FlatPress.
-- `plugin_mastodon_dom_children_to_flatpress()` — line 3468 — Convert DOM child nodes into FlatPress BBCode text.
-- `plugin_mastodon_dom_node_to_flatpress()` — line 3486 — Convert a single DOM node into FlatPress BBCode text.
-- `plugin_mastodon_public_entry_url()` — line 3595 — Return the public URL for a FlatPress entry.
-- `plugin_mastodon_public_comments_url()` — line 3622 — Return the public comments URL for a FlatPress entry.
-- `plugin_mastodon_public_comment_url()` — line 3650 — Return the public URL for a specific FlatPress comment.
-- `plugin_mastodon_mastodon_html_to_flatpress()` — line 3665 — Convert Mastodon HTML content into FlatPress BBCode.
-- `plugin_mastodon_flatpress_to_mastodon()` — line 3767 — Convert FlatPress content into Mastodon-ready plain text.
-- `plugin_mastodon_limit_text()` — line 3882 — Limit text to a maximum number of characters.
+- `plugin_mastodon_guess_subject()` — line 3242 — Guess a subject line from imported plain text.
+- `plugin_mastodon_html_entity_decode()` — line 3284 — Decode HTML entities using the plugin defaults.
+- `plugin_mastodon_blog_base_url()` — line 3293 — Return the absolute base URL of the current FlatPress installation.
+- `plugin_mastodon_extract_url_token()` — line 3329 — Extract the URL token from a BBCode or attribute fragment.
+- `plugin_mastodon_absolute_url()` — line 3346 — Convert a URL or path into an absolute URL when possible.
+- `plugin_mastodon_lang_string()` — line 3388 — Return a localized plugin string or a provided fallback.
+- `plugin_mastodon_normalize_tag_list()` — line 3614 — Normalize a list of tag labels.
+- `plugin_mastodon_extend_time_limit()` — line 5842 — Refresh or raise the PHP execution time budget for long-running Mastodon work without lowering an existing higher or unlimited limit.
+- `plugin_mastodon_extract_flatpress_tags()` — line 3645 — Extract FlatPress Tag plugin labels from an entry body.
+- `plugin_mastodon_strip_flatpress_tag_bbcode()` — line 3670 — Remove Tag plugin BBCode blocks from entry content.
+- `plugin_mastodon_mastodon_hashtag_footer()` — line 3687 — Convert FlatPress tag labels into a Mastodon hashtag footer line.
+- `plugin_mastodon_remote_status_tags()` — line 3708 — Collect remote Mastodon tags from a status entity.
+- `plugin_mastodon_strip_trailing_mastodon_hashtag_footer()` — line 3735 — Remove a trailing Mastodon hashtag footer from imported plain text.
+- `plugin_mastodon_build_flatpress_tag_bbcode()` — line 3798 — Build Tag plugin BBCode from a list of remote Mastodon tags.
+- `plugin_mastodon_emoticon_entity_to_unicode()` — line 3811 — Convert an emoticon HTML entity into a Unicode character.
+- `plugin_mastodon_emoticon_map()` — line 3824 — Return the FlatPress emoticon-to-Unicode lookup map.
+- `plugin_mastodon_replace_emoticon_shortcodes_with_unicode()` — line 3878 — Replace FlatPress emoticon shortcodes with Unicode glyphs.
+- `plugin_mastodon_prepare_emoticons_for_mastodon()` — line 3893 — Convert active FlatPress emoticon shortcodes to standard Unicode emoji before Mastodon export.
+- `plugin_mastodon_replace_unicode_emoticons_with_shortcodes()` — line 3906 — Replace Unicode emoticons with FlatPress shortcodes.
+- `plugin_mastodon_is_public_host()` — line 3928 — Determine whether a host name resolves to a public endpoint.
+- `plugin_mastodon_public_url_for_mastodon()` — line 3951 — Return a Mastodon-safe public URL or an empty string.
+- `plugin_mastodon_plain_text_from_bbcode()` — line 3970 — Convert FlatPress BBCode into plain text for Mastodon export, removing complete AudioVideo player tags including optional description endtag content.
+- `plugin_mastodon_subject_line_is_noise()` — line 4014 — Determine whether an extracted line should be ignored as a subject.
+- `plugin_mastodon_domains_match()` — line 4042 — Determine whether two host names belong to the same domain family.
+- `plugin_mastodon_cleanup_imported_text()` — line 4056 — Clean imported text before saving it to FlatPress.
+- `plugin_mastodon_dom_children_to_flatpress()` — line 4110 — Convert DOM child nodes into FlatPress BBCode text.
+- `plugin_mastodon_dom_node_to_flatpress()` — line 4128 — Convert a single DOM node into FlatPress BBCode text.
+- `plugin_mastodon_public_entry_url()` — line 4237 — Return the public URL for a FlatPress entry.
+- `plugin_mastodon_public_comments_url()` — line 4264 — Return the public comments URL for a FlatPress entry.
+- `plugin_mastodon_public_comment_url()` — line 4292 — Return the public URL for a specific FlatPress comment.
+- `plugin_mastodon_mastodon_html_to_flatpress()` — line 4307 — Convert Mastodon HTML content into FlatPress BBCode.
+- `plugin_mastodon_flatpress_to_mastodon()` — line 4409 — Convert FlatPress content into Mastodon-ready plain text.
+- `plugin_mastodon_limit_text()` — line 4526 — Limit text to a maximum number of characters.
 
 ## F. Local content access, media processing, hashing, and export ordering
 
-- `plugin_mastodon_entry_hash()` — line 3904 — Build a change-detection hash for a FlatPress entry.
-- `plugin_mastodon_comment_hash()` — line 3916 — Build a change-detection hash for a FlatPress comment.
-- `plugin_mastodon_remote_status_author_label()` — line 6245 — Build a readable author label for quoted Mastodon replies.
-- `plugin_mastodon_strip_leading_quote_block()` — line 6278 — Remove one leading BBCode quote block so imported reply quotes do not compound indefinitely.
-- `plugin_mastodon_imported_reply_quote_payload()` — line 6311 — Resolve the author and body that should be quoted for an imported Mastodon reply.
-- `plugin_mastodon_build_imported_reply_quote()` — line 6354 — Build the optional BBCode quote block for an imported Mastodon reply.
-- `plugin_mastodon_safe_path_component()` — line 3934 — Sanitize a string so it can be used as a path component.
-- `plugin_mastodon_safe_filename()` — line 3949 — Sanitize a file name for local storage.
-- `plugin_mastodon_media_relative_to_absolute()` — line 3962 — Resolve a FlatPress media path to an absolute file path.
-- `plugin_mastodon_media_prepare_directory()` — line 3975 — Ensure that a media directory exists.
-- `plugin_mastodon_media_delete_tree()` — line 3991 — Delete a directory tree used for imported media.
-- `plugin_mastodon_media_copy_tree()` — line 4018 — Copy a directory tree used for media synchronization.
-- `plugin_mastodon_bbcode_attr_escape()` — line 4208 — Escape a value for safe BBCode attribute usage.
-- `plugin_mastodon_bbcode_text_escape()` — line 4220 — Escape plain text embedded between BBCode tags, used for imported AudioVideo media descriptions.
-- `plugin_mastodon_media_guess_mime_type()` — line 4068 — Guess the MIME type of a local media file.
-- `plugin_mastodon_media_parse_tag_attributes()` — line 4464 — Parse key/value attributes from a FlatPress media tag.
-- `plugin_mastodon_media_description_from_bbcode_content()` — line 4495 — Normalize optional AudioVideo BBCode content into a Mastodon media description.
-- `plugin_mastodon_instance_supported_media_mime_types()` — current source — Return the MIME types advertised by the configured Mastodon instance.
-- `plugin_mastodon_instance_media_size_limit()` — current source — Return the configured byte-size limit for an image, video/GIFV, or audio upload.
-- `plugin_mastodon_validate_local_media_item()` — current source — Validate one local media file against available instance MIME and byte-size limits before upload.
-- `plugin_mastodon_media_extract_default_path()` — current source — Extract the default path parameter from FlatPress media BBCode such as `[img=...]`, `[gallery=...]`, `[audioplayer="..."]`, and `[videoplayer="..."]`.
-- `plugin_mastodon_add_local_media_item()` — current source — Add one normalized local media item while deduplicating and enforcing an expected media family.
-- `plugin_mastodon_collect_local_entry_media()` — line 4599 — Collect local images, galleries, audio, video, optional AudioVideo endtag descriptions, and video poster thumbnails referenced by an entry.
-- `plugin_mastodon_prepare_entry_media_items()` — line 4259 — Normalize collected local media items into reusable path/description tuples.
-- `plugin_mastodon_entry_media_attachment_signature_from_items()` — line 4282 — Hash only the attachment identity of normalized media items.
-- `plugin_mastodon_entry_media_description_signature_from_items()` — line 4305 — Hash only the alt-text portion of normalized media items.
-- `plugin_mastodon_entry_media_signature()` — line 4324 — Build a combined attachment+description signature for media references contained in entry content.
-- `plugin_mastodon_remote_media_attachment_type()` — current source — Normalize a Mastodon attachment type, including extension-based fallbacks for older or incomplete payloads.
-- `plugin_mastodon_remote_status_media_attachments()` — current source — Extract supported image, audio, video, and GIFV attachments from a remote Mastodon status.
-- `plugin_mastodon_remote_status_image_attachments()` — line 4341 — Extract image attachments from a remote Mastodon status.
-- `plugin_mastodon_remote_media_source_url()` — line 4364 — Resolve the best downloadable source URL for a remote attachment.
-- `plugin_mastodon_remote_media_source_urls()` — current source — Resolve direct-download fallback candidates for a remote attachment; audio/video/GIFV avoid `preview_url` as a file-source fallback, while images may use it.
-- `plugin_mastodon_remote_media_description()` — line 4378 — Resolve the best description for a remote attachment.
-- `plugin_mastodon_remote_media_focus()` — line 4392 — Normalize a Mastodon media focus string when present.
-- `plugin_mastodon_remote_media_descriptors_from_status()` — line 4409 — Extract reusable media descriptors (`id`, `description`, `focus`) from a Mastodon status payload.
-- `plugin_mastodon_remote_media_descriptors_from_media_ids()` — line 4436 — Build fallback reusable media descriptors from already-known IDs and local media items.
-- `plugin_mastodon_media_download()` — line 4499 — Download a remote media asset with an extended media-transfer timeout.
-- `plugin_mastodon_remote_download_basename()` — current source — Build a safe local basename for a downloaded remote image, audio, video, GIFV, or poster.
-- `plugin_mastodon_store_remote_media_url()` — current source — Download and persist one remote media URL.
-- `plugin_mastodon_build_imported_media_bbcode()` — line 5128 — Build FlatPress BBCode for imported remote media attachments: images become `[img]`/`[gallery]`, audio becomes `[audioplayer]`, and video/GIFV becomes `[videoplayer]` with imported optional description endtag text and an imported poster when available; alternate direct media URLs are retried before an attachment is skipped.
-- `plugin_mastodon_collect_entry_files()` — line 5314 — Collect entry files recursively from the FlatPress content tree.
-- `plugin_mastodon_local_item_timestamp()` — line 5341 — Resolve the best timestamp for a local FlatPress item.
-- `plugin_mastodon_compare_local_entries_for_export()` — line 5367 — Compare local FlatPress entries for Mastodon export order.
-- `plugin_mastodon_list_local_entries()` — line 5385 — List local FlatPress entry identifiers.
+- `plugin_mastodon_entry_hash()` — line 4548 — Build a change-detection hash for a FlatPress entry.
+- `plugin_mastodon_comment_hash()` — line 4560 — Build a change-detection hash for a FlatPress comment.
+- `plugin_mastodon_remote_status_author_label()` — line 7552 — Build a readable author label for quoted Mastodon replies.
+- `plugin_mastodon_strip_leading_quote_block()` — line 7585 — Remove one leading BBCode quote block so imported reply quotes do not compound indefinitely.
+- `plugin_mastodon_imported_reply_quote_payload()` — line 7618 — Resolve the author and body that should be quoted for an imported Mastodon reply.
+- `plugin_mastodon_build_imported_reply_quote()` — line 7661 — Build the optional BBCode quote block for an imported Mastodon reply.
+- `plugin_mastodon_safe_path_component()` — line 4578 — Sanitize a string so it can be used as a path component.
+- `plugin_mastodon_safe_filename()` — line 4593 — Sanitize a file name for local storage.
+- `plugin_mastodon_media_relative_to_absolute()` — line 4629 — Resolve a FlatPress media path to an absolute file path.
+- `plugin_mastodon_media_prepare_directory()` — line 4642 — Ensure that a media directory exists.
+- `plugin_mastodon_media_delete_tree()` — line 4658 — Delete a directory tree used for imported media.
+- `plugin_mastodon_media_copy_tree()` — line 4685 — Copy a directory tree used for media synchronization.
+- `plugin_mastodon_bbcode_attr_escape()` — line 4723 — Escape a value for safe BBCode attribute usage.
+- `plugin_mastodon_bbcode_text_escape()` — line 4735 — Escape plain text embedded between BBCode tags, used for imported AudioVideo media descriptions.
+- `plugin_mastodon_media_guess_mime_type()` — line 4757 — Guess the MIME type of a local media file.
+- `plugin_mastodon_media_parse_tag_attributes()` — line 4979 — Parse key/value attributes from a FlatPress media tag.
+- `plugin_mastodon_media_description_from_bbcode_content()` — line 5010 — Normalize optional AudioVideo BBCode content into a Mastodon media description.
+- `plugin_mastodon_instance_supported_media_mime_types()` — line 4905 — Return the MIME types advertised by the configured Mastodon instance.
+- `plugin_mastodon_instance_media_size_limit()` — line 4925 — Return the configured byte-size limit for an image, video/GIFV, or audio upload.
+- `plugin_mastodon_validate_local_media_item()` — line 4952 — Validate one local media file against available instance MIME and byte-size limits before upload.
+- `plugin_mastodon_media_extract_default_path()` — line 5036 — Extract the default path parameter from FlatPress media BBCode such as `[img=...]`, `[gallery=...]`, `[audioplayer="..."]`, and `[videoplayer="..."]`.
+- `plugin_mastodon_add_local_media_item()` — line 5065 — Add one normalized local media item while deduplicating and enforcing an expected media family.
+- `plugin_mastodon_collect_local_entry_media()` — line 5114 — Collect local images, galleries, audio, video, optional AudioVideo endtag descriptions, and video poster thumbnails referenced by an entry.
+- `plugin_mastodon_prepare_entry_media_items()` — line 5252 — Normalize collected local media items into reusable path/description tuples.
+- `plugin_mastodon_entry_media_attachment_signature_from_items()` — line 5283 — Hash only the attachment identity of normalized media items.
+- `plugin_mastodon_entry_media_description_signature_from_items()` — line 5306 — Hash only the alt-text portion of normalized media items.
+- `plugin_mastodon_entry_media_signature()` — line 5325 — Build a combined attachment+description signature for media references contained in entry content.
+- `plugin_mastodon_remote_media_attachment_type()` — line 5342 — Normalize a Mastodon attachment type, including extension-based fallbacks for older or incomplete payloads.
+- `plugin_mastodon_remote_status_media_attachments()` — line 5369 — Extract supported image, audio, video, and GIFV attachments from a remote Mastodon status.
+- `plugin_mastodon_remote_status_image_attachments()` — line 5399 — Extract image attachments from a remote Mastodon status.
+- `plugin_mastodon_remote_media_source_url()` — line 5408 — Resolve the best downloadable source URL for a remote attachment.
+- `plugin_mastodon_remote_media_source_urls()` — line 5426 — Resolve direct-download fallback candidates for a remote attachment; audio/video/GIFV avoid `preview_url` as a file-source fallback, while images may use it.
+- `plugin_mastodon_remote_media_description()` — line 5448 — Resolve the best description for a remote attachment.
+- `plugin_mastodon_remote_media_focus()` — line 5462 — Normalize a Mastodon media focus string when present.
+- `plugin_mastodon_remote_media_descriptors_from_status()` — line 5479 — Extract reusable media descriptors (`id`, `description`, `focus`) from a Mastodon status payload.
+- `plugin_mastodon_remote_media_descriptors_from_media_ids()` — line 5510 — Build fallback reusable media descriptors from already-known IDs and local media items.
+- `plugin_mastodon_media_download()` — line 5577 — Download a remote media asset with an extended media-transfer timeout.
+- `plugin_mastodon_remote_download_basename()` — line 5591 — Build a safe local basename for a downloaded remote image, audio, video, GIFV, or poster.
+- `plugin_mastodon_store_remote_media_url()` — line 5621 — Download and persist one remote media URL.
+- `plugin_mastodon_build_imported_media_bbcode()` — line 5643 — Build FlatPress BBCode for imported remote media attachments: images become `[img]`/`[gallery]`, audio becomes `[audioplayer]`, and video/GIFV becomes `[videoplayer]` with imported optional description endtag text and an imported poster when available; alternate direct media URLs are retried before an attachment is skipped.
+- `plugin_mastodon_collect_entry_files()` — line 6610 — Collect entry files recursively from the FlatPress content tree.
+- `plugin_mastodon_local_item_timestamp()` — line 6637 — Resolve the best timestamp for a local FlatPress item.
+- `plugin_mastodon_compare_local_entries_for_export()` — line 6663 — Compare local FlatPress entries for Mastodon export order.
+- `plugin_mastodon_list_local_entries()` — line 6681 — List local FlatPress entry identifiers.
 
 ## G. HTTP transport, PHP timeout budgeting, instance capability lookup, status-length budgeting, OAuth, Mastodon API calls, and media upload
 
-- `plugin_mastodon_extend_time_limit()` — line 4614 — Refresh or raise the PHP execution time budget for long-running Mastodon work without lowering an existing higher or unlimited limit.
-- `plugin_mastodon_instance_document()` — line 4645 — Load and cache the compact Mastodon instance document, preferring the saved FlatPress snapshot before APCu and live network fetches.
-- `plugin_mastodon_instance_version()` — line 4689 — Extract the human-readable Mastodon server version from the cached instance document.
-- `plugin_mastodon_instance_supports_status_media_attributes()` — line 4707 — Decide whether `PUT /api/v1/statuses/:id` may safely use `media_attributes` for in-place alt-text edits.
-- `plugin_mastodon_instance_configuration()` — line 4724 — Return the normalized `configuration` subtree from the cached Mastodon instance document.
-- `plugin_mastodon_instance_media_limit()` — line 4734 — Return the media attachment limit of the configured instance.
-- `plugin_mastodon_instance_media_description_limit()` — line 4747 — Return the media description length limit of the configured instance.
-- `plugin_mastodon_instance_url_reserved_length()` — line 4760 — Return the reserved Mastodon character budget used for each URL.
-- `plugin_mastodon_instance_registration_summary()` — line 7225 — Summarize the cached registration policy advertised by the instance for the admin diagnostics table.
-- `plugin_mastodon_admin_instance_info_rows()` — line 7251 — Build the localized admin-table rows from the cached instance-information snapshot without forcing another live request.
-- `plugin_mastodon_status_text_length()` — line 4774 — Calculate the Mastodon-visible status length with instance URL budgeting.
-- `plugin_mastodon_limit_status_text()` — line 4806 — Truncate status text using Mastodon URL-budget rules.
-- `plugin_mastodon_http_request_multipart()` — line 4884 — Perform a multipart HTTP request.
-- `plugin_mastodon_fetch_media_attachment()` — line 5016 — Fetch a single Mastodon media attachment by ID.
-- `plugin_mastodon_media_processing_attempts()` — current source — Calculate media-type- and size-aware polling attempts for asynchronous Mastodon media processing.
-- `plugin_mastodon_media_transfer_timeout()` — current source — Calculate longer upload transfer timeouts for audio/video/GIFV while keeping image uploads lighter.
-- `plugin_mastodon_wait_for_media_attachment()` — line 5082 — Poll an asynchronously processed Mastodon media attachment until it is ready or times out, including pending audio/video responses without `preview_url`.
-- `plugin_mastodon_upload_media_items()` — line 5128 — Upload local media items to Mastodon and collect the created media IDs; AudioVideo posters are sent as Mastodon `thumbnail` multipart fields for video uploads.
-- `plugin_mastodon_parse_http_response_headers()` — line 5422 — Parse raw HTTP response headers.
-- `plugin_mastodon_stream_context_request()` — line 5452 — Perform an HTTP request through a stream context fallback.
-- `plugin_mastodon_status_media_attributes()` — line 4466 — Build the `media_attributes` array used for in-place status edits of already attached media.
-- `plugin_mastodon_prepare_entry_media_sync_plan()` — line 5225 — Decide whether an entry should upload fresh media, reuse stored IDs, or reuse IDs plus `media_attributes`.
-- `plugin_mastodon_array_is_list()` — line 5492 — Detect whether a PHP array is a zero-based list that should use `[]` form-field notation.
-- `plugin_mastodon_array_contains_only_form_scalars()` — line 5512 — Detect whether a list can be serialized as repeated scalar `[]` fields.
-- `plugin_mastodon_http_build_query()` — line 5530 — Build an application/x-www-form-urlencoded query string, emitting Rack-compatible Mastodon array fields such as `media_ids[]` and nested `media_attributes[][description]`.
-- `plugin_mastodon_http_request()` — line 5585 — Perform an HTTP request using cURL or the stream fallback.
-- `plugin_mastodon_mastodon_api()` — line 5702 — Call the Mastodon API and return the raw HTTP response.
-- `plugin_mastodon_mastodon_json()` — line 5746 — Call the Mastodon API and decode a JSON response.
-- `plugin_mastodon_response_error_message()` — line 5761 — Extract the most useful error message from an API response.
-- `plugin_mastodon_oauth_legacy_scopes()` — line 491 — Return the legacy OAuth scope string used by older registrations.
-- `plugin_mastodon_oauth_profile_scopes()` — line 499 — Return the stricter scope string that uses `profile` for `verify_credentials`.
-- `plugin_mastodon_oauth_server_metadata()` — line 508 — Discover OAuth server metadata from `/.well-known/oauth-authorization-server`.
-- `plugin_mastodon_oauth_supported_scopes()` — line 527 — Extract the discoverable scope list from OAuth server metadata.
-- `plugin_mastodon_oauth_scope_supported()` — line 564 — Check whether the configured Mastodon instance supports a given OAuth scope.
-- `plugin_mastodon_oauth_preferred_scopes()` — line 585 — Prefer `profile` on current instances and fall back to `read:accounts` on older ones.
-- `plugin_mastodon_register_app()` — line 5790 — Register the FlatPress application on the configured Mastodon instance with the preferred discoverable scope set.
-- `plugin_mastodon_build_authorize_url()` — line 5813 — Build the OAuth authorization URL using the scopes that the registered app may safely request.
-- `plugin_mastodon_exchange_code_for_token()` — line 5833 — Exchange an OAuth authorization code for an access token using the same negotiated scope string.
-- `plugin_mastodon_verify_credentials()` — line 5863 — Verify the currently configured access token.
-- `plugin_mastodon_instance_character_limit()` — line 5880 — Return the status character limit of the configured instance.
-- `plugin_mastodon_fetch_account_statuses()` — line 5895 — Fetch statuses for the authenticated Mastodon account.
-- `plugin_mastodon_fetch_status_context()` — line 5942 — Fetch the conversation context for a Mastodon status.
-- `plugin_mastodon_fetch_status()` — line 5953 — Fetch a single Mastodon status.
-- `plugin_mastodon_delete_status()` — line 5964 — Delete a Mastodon status, including media when requested.
-- `plugin_mastodon_status_missing_response()` — line 5977 — Check whether an API response means that the referenced Mastodon status no longer exists.
-- `plugin_mastodon_create_status()` — line 5990 — Create a Mastodon status.
-- `plugin_mastodon_update_status()` — line 6015 — Update an existing Mastodon status.
+- `plugin_mastodon_extend_time_limit()` — line 5842 — Refresh or raise the PHP execution time budget for long-running Mastodon work without lowering an existing higher or unlimited limit.
+- `plugin_mastodon_instance_document()` — line 5873 — Load and cache the compact Mastodon instance document, preferring the saved FlatPress snapshot before APCu and live network fetches.
+- `plugin_mastodon_instance_version()` — line 5917 — Extract the human-readable Mastodon server version from the cached instance document.
+- `plugin_mastodon_instance_supports_status_media_attributes()` — line 5935 — Decide whether `PUT /api/v1/statuses/:id` may safely use `media_attributes` for in-place alt-text edits.
+- `plugin_mastodon_instance_configuration()` — line 5952 — Return the normalized `configuration` subtree from the cached Mastodon instance document.
+- `plugin_mastodon_instance_media_limit()` — line 5962 — Return the media attachment limit of the configured instance.
+- `plugin_mastodon_instance_media_description_limit()` — line 5975 — Return the media description length limit of the configured instance.
+- `plugin_mastodon_instance_url_reserved_length()` — line 5988 — Return the reserved Mastodon character budget used for each URL.
+- `plugin_mastodon_instance_registration_summary()` — line 8577 — Summarize the cached registration policy advertised by the instance for the admin diagnostics table.
+- `plugin_mastodon_admin_instance_info_rows()` — line 8603 — Build the localized admin-table rows from the cached instance-information snapshot without forcing another live request.
+- `plugin_mastodon_status_text_length()` — line 6002 — Calculate the Mastodon-visible status length with instance URL budgeting.
+- `plugin_mastodon_limit_status_text()` — line 6034 — Truncate status text using Mastodon URL-budget rules.
+- `plugin_mastodon_http_request_multipart()` — line 6113 — Perform a multipart HTTP request.
+- `plugin_mastodon_fetch_media_attachment()` — line 6246 — Fetch a single Mastodon media attachment by ID.
+- `plugin_mastodon_media_processing_attempts()` — line 6311 — Calculate media-type- and size-aware polling attempts for asynchronous Mastodon media processing.
+- `plugin_mastodon_media_transfer_timeout()` — line 6335 — Calculate longer upload transfer timeouts for audio/video/GIFV while keeping image uploads lighter.
+- `plugin_mastodon_wait_for_media_attachment()` — line 6355 — Poll an asynchronously processed Mastodon media attachment until it is ready or times out, including pending audio/video responses without `preview_url`.
+- `plugin_mastodon_upload_media_items()` — line 6404 — Upload local media items to Mastodon and collect the created media IDs; AudioVideo posters are sent as Mastodon `thumbnail` multipart fields for video uploads.
+- `plugin_mastodon_parse_http_response_headers()` — line 6718 — Parse raw HTTP response headers.
+- `plugin_mastodon_stream_context_request()` — line 6748 — Perform an HTTP request through a stream context fallback.
+- `plugin_mastodon_status_media_attributes()` — line 5544 — Build the `media_attributes` array used for in-place status edits of already attached media.
+- `plugin_mastodon_prepare_entry_media_sync_plan()` — line 6521 — Decide whether an entry should upload fresh media, reuse stored IDs, or reuse IDs plus `media_attributes`.
+- `plugin_mastodon_array_is_list()` — line 6788 — Detect whether a PHP array is a zero-based list that should use `[]` form-field notation.
+- `plugin_mastodon_array_contains_only_form_scalars()` — line 6808 — Detect whether a list can be serialized as repeated scalar `[]` fields.
+- `plugin_mastodon_http_build_query()` — line 6826 — Build an application/x-www-form-urlencoded query string, emitting Rack-compatible Mastodon array fields such as `media_ids[]` and nested `media_attributes[][description]`.
+- `plugin_mastodon_http_request()` — line 6882 — Perform an HTTP request using cURL or the stream fallback.
+- `plugin_mastodon_mastodon_api()` — line 7000 — Call the Mastodon API and return the raw HTTP response.
+- `plugin_mastodon_mastodon_json()` — line 7049 — Call the Mastodon API and decode a JSON response.
+- `plugin_mastodon_response_error_message()` — line 7064 — Extract the most useful error message from an API response.
+- `plugin_mastodon_oauth_legacy_scopes()` — line 512 — Return the legacy OAuth scope string used by older registrations.
+- `plugin_mastodon_oauth_profile_scopes()` — line 520 — Return the stricter scope string that uses `profile` for `verify_credentials`.
+- `plugin_mastodon_oauth_server_metadata()` — line 529 — Discover OAuth server metadata from `/.well-known/oauth-authorization-server`.
+- `plugin_mastodon_oauth_supported_scopes()` — line 548 — Extract the discoverable scope list from OAuth server metadata.
+- `plugin_mastodon_oauth_scope_supported()` — line 585 — Check whether the configured Mastodon instance supports a given OAuth scope.
+- `plugin_mastodon_oauth_preferred_scopes()` — line 606 — Prefer `profile` on current instances and fall back to `read:accounts` on older ones.
+- `plugin_mastodon_register_app()` — line 7093 — Register the FlatPress application on the configured Mastodon instance with the preferred discoverable scope set.
+- `plugin_mastodon_build_authorize_url()` — line 7116 — Build the OAuth authorization URL using the scopes that the registered app may safely request.
+- `plugin_mastodon_exchange_code_for_token()` — line 7136 — Exchange an OAuth authorization code for an access token using the same negotiated scope string.
+- `plugin_mastodon_verify_credentials()` — line 7166 — Verify the currently configured access token.
+- `plugin_mastodon_instance_character_limit()` — line 7183 — Return the status character limit of the configured instance.
+- `plugin_mastodon_fetch_account_statuses()` — line 7198 — Fetch statuses for the authenticated Mastodon account.
+- `plugin_mastodon_fetch_status_context()` — line 7245 — Fetch the conversation context for a Mastodon status.
+- `plugin_mastodon_fetch_status()` — line 7256 — Fetch a single Mastodon status.
+- `plugin_mastodon_delete_status()` — line 7267 — Delete a Mastodon status, including media when requested.
+- `plugin_mastodon_status_missing_response()` — line 7280 — Check whether an API response means that the referenced Mastodon status no longer exists.
+- `plugin_mastodon_create_status()` — line 7293 — Create a Mastodon status.
+- `plugin_mastodon_update_status()` — line 7320 — Update an existing Mastodon status.
 
 ## H. Import/export builders and synchronization orchestration
 
-- `plugin_mastodon_build_entry_status_text()` — line 6039 — Build the status body used when exporting a FlatPress entry.
-- `plugin_mastodon_build_comment_status_text()` — line 6107 — Build the status body used when exporting a FlatPress comment.
-- `plugin_mastodon_import_remote_entry()` — line 6145 — Import a remote Mastodon status into FlatPress as an entry.
-- `plugin_mastodon_import_remote_comment()` — line 6396 — Import a remote Mastodon reply into FlatPress as a comment while respecting comment tombstones, including early tombstones for locally deleted exported comments.
-- `plugin_mastodon_import_remote_context_descendants()` — line 6480 — Import remote Mastodon replies from a fetched thread context while blocking tombstoned parent/child replies.
-- `plugin_mastodon_collect_known_entry_context_targets()` — line 6583 — Collect known synchronized entry threads that should have their Mastodon reply context refreshed.
-- `plugin_mastodon_sync_remote_to_local()` — line 6617 — Synchronize remote Mastodon content into FlatPress.
-- `plugin_mastodon_sync_local_to_remote()` — line 6676 — Synchronize local FlatPress content to Mastodon, including remote-sourced entry comment export, media-plan reuse of stored `media_ids`, and version-aware in-place alt-text updates.
-- `plugin_mastodon_run_deletion_sync()` — line 6875 — Reconcile mapped deletions between FlatPress and Mastodon in a separate follow-up request.
+- `plugin_mastodon_build_entry_status_text()` — line 7346 — Build the status body used when exporting a FlatPress entry.
+- `plugin_mastodon_build_comment_status_text()` — line 7414 — Build the status body used when exporting a FlatPress comment.
+- `plugin_mastodon_import_remote_entry()` — line 7452 — Import a remote Mastodon status into FlatPress as an entry.
+- `plugin_mastodon_import_remote_comment()` — line 7703 — Import a remote Mastodon reply into FlatPress as a comment while respecting comment tombstones, including early tombstones for locally deleted exported comments.
+- `plugin_mastodon_import_remote_context_descendants()` — line 7787 — Import remote Mastodon replies from a fetched thread context while blocking tombstoned parent/child replies.
+- `plugin_mastodon_collect_known_entry_context_targets()` — line 7890 — Collect known synchronized entry threads that should have their Mastodon reply context refreshed.
+- `plugin_mastodon_sync_remote_to_local()` — line 7924 — Synchronize remote Mastodon content into FlatPress.
+- `plugin_mastodon_sync_local_to_remote()` — line 7989 — Synchronize local FlatPress content to Mastodon, including remote-sourced entry comment export, media-plan reuse of stored `media_ids`, and version-aware in-place alt-text updates.
+- `plugin_mastodon_run_deletion_sync()` — line 8192 — Reconcile mapped deletions between FlatPress and Mastodon in a separate follow-up request.
 
 ## Recommended reading order for new developers
 
@@ -480,213 +510,240 @@ When changing the plugin, these clusters usually need to stay in sync:
 A change in one of these areas often requires corresponding updates in the simulation script.
 
 ## Alphabetical appendix
-- `main()` — line 7367 — Keep the admin panel lifecycle compatible with FlatPress without extra processing.
-- `onsubmit()` — line 7371 — Process configuration saves, OAuth actions, including app registration and authorization-code exchange, and the manual synchronization trigger.
-- `plugin_mastodon_absolute_url()` — line 2730 — Convert a URL or path into an absolute URL when possible.
-- `plugin_mastodon_admin_assign()` — line 7323 — Assign plugin data to Smarty for the admin panel.
-- `plugin_mastodon_apcu_cache_key()` — line 829 — Build the namespaced APCu key used by this plugin.
-- `plugin_mastodon_apcu_delete()` — line 871 — Delete a value from APCu using the FlatPress namespace key builder.
-- `plugin_mastodon_apcu_enabled()` — line 820 — Check whether shared APCu caching is available for the plugin.
-- `plugin_mastodon_apcu_fetch()` — line 843 — Fetch a value from APCu through the FlatPress namespace helper.
-- `plugin_mastodon_apcu_store()` — line 858 — Store a value in APCu through the FlatPress namespace helper.
-- `plugin_mastodon_bbcode_attr_escape()` — line 4208 — Escape a value for safe BBCode attribute usage.
-- `plugin_mastodon_bbcode_text_escape()` — line 4220 — Escape plain text embedded between BBCode tags.
-- `plugin_mastodon_bbcode_plugin_active()` — line 2884 — Determine whether the BBCode plugin is active for the current FlatPress request.
-- `plugin_mastodon_blog_base_url()` — line 2677 — Return the absolute base URL of the current FlatPress installation.
-- `plugin_mastodon_build_authorize_url()` — line 5813 — Build the OAuth authorization URL using the scopes that the registered app may safely request.
-- `plugin_mastodon_build_comment_status_text()` — line 6107 — Build the status body used when exporting a FlatPress comment.
-- `plugin_mastodon_build_entry_status_text()` — line 6039 — Build the status body used when exporting a FlatPress entry.
-- `plugin_mastodon_build_flatpress_tag_bbcode()` — line 3158 — Build Tag plugin BBCode from a list of remote Mastodon tags.
-- `plugin_mastodon_build_imported_media_bbcode()` — line 5128 — Build FlatPress BBCode for imported remote media attachments, including AudioVideo optional description endtag text.
-- `plugin_mastodon_cleanup_imported_text()` — line 3414 — Clean imported text before saving it to FlatPress.
-- `plugin_mastodon_cleanup_uploaded_media()` — line 5045 — Best-effort cleanup for uploaded Mastodon media that never reached a final status request.
-- `plugin_mastodon_collect_entry_files()` — line 5314 — Collect entry files recursively from the FlatPress content tree.
-- `plugin_mastodon_collect_known_entry_context_targets()` — line 6583 — Collect known synchronized entry threads that should have their Mastodon reply context refreshed.
-- `plugin_mastodon_collect_local_entry_media()` — line 4599 — Collect local images, galleries, AudioVideo media, optional AudioVideo endtag descriptions, and video poster thumbnails referenced by an entry.
-- `plugin_mastodon_comment_hash()` — line 3916 — Build a change-detection hash for a FlatPress comment.
-- `plugin_mastodon_comment_parent_fields()` — line 2487 — Return the comment fields that may contain a parent reference.
-- `plugin_mastodon_companion_plugins_status()` — line 2933 — Return the status of companion FlatPress plugins used for the full Mastodon feature set.
-- `plugin_mastodon_compare_local_entries_for_export()` — line 5367 — Compare local FlatPress entries for Mastodon export order.
-- `plugin_mastodon_configured_status_language()` — line 1324 — Read the configured FlatPress locale and return the Mastodon language code.
-- `plugin_mastodon_create_status()` — line 5990 — Create a Mastodon status.
-- `plugin_mastodon_date_matches_sync_start()` — line 1559 — Determine whether a content date passes the configured sync start date.
-- `plugin_mastodon_datetime_date_key()` — line 1535 — Normalize a stored date/datetime string to the sync-start date-key format.
-- `plugin_mastodon_default_content_stats()` — line 437 — Return the default counters for the last content synchronization.
-- `plugin_mastodon_default_deletion_stats()` — line 454 — Return the default counters for the last deletion synchronization.
-- `plugin_mastodon_default_options()` — line 56 — Return the default plugin option values.
-- `plugin_mastodon_default_state()` — line 467 — Return the default runtime state structure, including the targeted deletion-follow-up scope marker.
-- `plugin_mastodon_delete_media_attachment()` — line 5026 — Delete an uploaded Mastodon media attachment before it is attached to a final status.
-- `plugin_mastodon_delete_status()` — line 5964 — Delete a Mastodon status, including media when requested.
-- `plugin_mastodon_detect_local_comment_parent_id()` — line 2513 — Detect the local parent comment identifier from comment data.
-- `plugin_mastodon_dom_children_to_flatpress()` — line 3468 — Convert DOM child nodes into FlatPress BBCode text.
-- `plugin_mastodon_dom_node_to_flatpress()` — line 3486 — Convert a single DOM node into FlatPress BBCode text.
-- `plugin_mastodon_domains_match()` — line 3400 — Determine whether two host names belong to the same domain family.
-- `plugin_mastodon_emoticon_entity_to_unicode()` — line 3171 — Convert an emoticon HTML entity into a Unicode character.
-- `plugin_mastodon_emoticon_map()` — line 3184 — Return the FlatPress emoticon-to-Unicode lookup map.
-- `plugin_mastodon_emoticons_plugin_active()` — line 2918 — Determine whether the Emoticons plugin is active for the current FlatPress request.
-- `plugin_mastodon_enabled_plugin_state()` — line 2802 — Determine whether a FlatPress plugin is enabled in the centralized plugin configuration.
-- `plugin_mastodon_ensure_state_dir()` — line 1639 — Ensure that the plugin runtime directory exists.
-- `plugin_mastodon_entry_hash()` — line 3904 — Build a change-detection hash for a FlatPress entry.
-- `plugin_mastodon_entry_media_signature()` — line 4324 — Build a signature for media references contained in entry content.
-- `plugin_mastodon_exchange_code_for_token()` — line 5833 — Exchange an OAuth authorization code for an access token using the same negotiated scope string.
-- `plugin_mastodon_extend_time_limit()` — line 4614 — Refresh or raise the PHP execution time budget for long-running Mastodon work without lowering an existing higher or unlimited limit.
-- `plugin_mastodon_extract_flatpress_tags()` — line 3005 — Extract FlatPress Tag plugin labels from an entry body.
-- `plugin_mastodon_extract_url_token()` — line 2713 — Extract the URL token from a BBCode or attribute fragment.
-- `plugin_mastodon_fediverse_creator_value()` — line 1244 — Build the fediverse creator meta value.
-- `plugin_mastodon_fetch_account_statuses()` — line 5895 — Fetch statuses for the authenticated Mastodon account.
-- `plugin_mastodon_fetch_media_attachment()` — line 5016 — Fetch a single Mastodon media attachment by ID.
-- `plugin_mastodon_fetch_status()` — line 5953 — Fetch a single Mastodon status.
-- `plugin_mastodon_fetch_status_context()` — line 5942 — Fetch the conversation context for a Mastodon status.
-- `plugin_mastodon_file_prestat()` — line 884 — Read a cheap file metadata snapshot for cache validation.
-- `plugin_mastodon_file_prestat_signature()` — line 904 — Convert a file metadata snapshot into a stable cache signature.
-- `plugin_mastodon_flatpress_to_mastodon()` — line 3767 — Convert FlatPress content into Mastodon-ready plain text.
-- `plugin_mastodon_fp_config()` — line 679 — Return the FlatPress configuration, preferring the early-loaded core cache.
-- `plugin_mastodon_fp_config_value()` — line 715 — Read a nested FlatPress configuration value.
-- `plugin_mastodon_fp_timeoffset_seconds()` — line 731 — Return the configured FlatPress time offset in seconds for exact local admin-time conversion.
-- `plugin_mastodon_fp_timeoffset_label()` — line 751 — Format the configured FlatPress time offset as a UTC label for admin users.
-- `plugin_mastodon_sync_time_to_minutes()` — line 781 — Convert a normalized `HH:MM` sync-time value into minutes after midnight.
-- `plugin_mastodon_minutes_to_sync_time()` — line 792 — Convert minutes after midnight back into a normalized `HH:MM` sync-time value.
-- `plugin_mastodon_sync_time_utc_to_local()` — line 808 — Convert the stored UTC synchronization time to the FlatPress-local admin time.
-- `plugin_mastodon_sync_time_local_to_utc()` — line 819 — Convert the FlatPress-local admin synchronization time back to stored UTC.
-- `plugin_mastodon_format_admin_datetime()` — line 830 — Format stored UTC timestamps for the admin panel using FlatPress `timeoffset`, date format, and time format.
-- `plugin_mastodon_get_options()` — line 915 — Load the saved plugin options and merge them with defaults.
-- `plugin_mastodon_guess_subject()` — line 2626 — Guess a subject line from imported plain text.
-- `plugin_mastodon_head()` — line 1262 — Print Mastodon profile metadata into the HTML head.
-- `plugin_mastodon_html_entity_decode()` — line 2668 — Decode HTML entities using the plugin defaults.
-- `plugin_mastodon_http_build_query()` — line 5530 — Build an application/x-www-form-urlencoded query string.
-- `plugin_mastodon_http_request()` — line 5585 — Perform an HTTP request using cURL or the stream fallback.
-- `plugin_mastodon_http_request_multipart()` — line 4884 — Perform a multipart HTTP request.
-- `plugin_mastodon_import_remote_comment()` — line 6396 — Import a remote Mastodon reply into FlatPress as a comment while respecting comment tombstones, including early tombstones for locally deleted exported comments.
-- `plugin_mastodon_import_remote_context_descendants()` — line 6480 — Import remote Mastodon replies from a fetched thread context while blocking tombstoned parent/child replies.
-- `plugin_mastodon_import_remote_entry()` — line 6145 — Import a remote Mastodon status into FlatPress as an entry.
-- `plugin_mastodon_instance_authority()` — line 1198 — Return the Mastodon instance authority used in fediverse creator metadata.
-- `plugin_mastodon_instance_character_limit()` — line 5880 — Return the status character limit of the configured instance.
-- `plugin_mastodon_instance_configuration()` — line 4724 — Load and cache the Mastodon instance configuration document.
-- `plugin_mastodon_instance_media_description_limit()` — line 4747 — Return the media description length limit of the configured instance.
-- `plugin_mastodon_instance_media_limit()` — line 4734 — Return the media attachment limit of the configured instance.
-- `plugin_mastodon_instance_url_reserved_length()` — line 4760 — Return the reserved Mastodon character budget used for each URL.
-- `plugin_mastodon_io_append_file()` — line 804 — Append to a file via the FlatPress I/O layer.
-- `plugin_mastodon_io_read_file()` — line 761 — Read a file through the FlatPress I/O layer when available.
-- `plugin_mastodon_io_read_file_uncached()` — line 774 — Read a file without FlatPress request-local caches.
-- `plugin_mastodon_io_write_file()` — line 791 — Write a file through the FlatPress I/O layer when available.
-- `plugin_mastodon_is_public_host()` — line 3288 — Determine whether a host name resolves to a public endpoint.
-- `plugin_mastodon_lang_string()` — line 2772 — Return a localized plugin string or a provided fallback.
-- `plugin_mastodon_limit_status_text()` — line 4806 — Truncate status text using Mastodon URL-budget rules.
-- `plugin_mastodon_limit_text()` — line 3882 — Limit text to a maximum number of characters.
-- `plugin_mastodon_list_local_entries()` — line 5385 — List local FlatPress entry identifiers.
-- `plugin_mastodon_local_item_date_key()` — line 1489 — Determine the date key of a local FlatPress entry or comment.
-- `plugin_mastodon_local_item_matches_sync_start()` — line 1578 — Determine whether a local FlatPress item should be synchronized.
-- `plugin_mastodon_local_item_timestamp()` — line 5341 — Resolve the best timestamp for a local FlatPress item.
-- `plugin_mastodon_log()` — line 1648 — Append a line to the plugin sync log.
-- `plugin_mastodon_mapping_matches_sync_start()` — line 1599 — Determine whether a stored synchronization mapping still belongs to the active sync-start window.
-- `plugin_mastodon_mastodon_api()` — line 5702 — Call the Mastodon API and return the raw HTTP response.
-- `plugin_mastodon_mastodon_hashtag_footer()` — line 3047 — Convert FlatPress tag labels into a Mastodon hashtag footer line.
-- `plugin_mastodon_mastodon_html_to_flatpress()` — line 3665 — Convert Mastodon HTML content into FlatPress BBCode.
-- `plugin_mastodon_mastodon_json()` — line 5746 — Call the Mastodon API and decode a JSON response.
-- `plugin_mastodon_maybe_sync()` — line 7161 — Run the scheduled synchronization when the current request is due.
-- `plugin_mastodon_media_copy_tree()` — line 4018 — Copy a directory tree used for media synchronization.
-- `plugin_mastodon_media_delete_tree()` — line 3991 — Delete a directory tree used for imported media.
-- `plugin_mastodon_media_download()` — line 4499 — Download a remote media asset.
-- `plugin_mastodon_media_guess_mime_type()` — line 4068 — Guess the MIME type of a local media file.
-- `plugin_mastodon_media_description_from_bbcode_content()` — line 4495 — Normalize optional AudioVideo BBCode content into a Mastodon media description.
-- `plugin_mastodon_media_parse_tag_attributes()` — line 4464 — Parse key/value attributes from a FlatPress media tag.
-- `plugin_mastodon_media_prepare_directory()` — line 3975 — Ensure that a media directory exists.
-- `plugin_mastodon_media_relative_to_absolute()` — line 3962 — Resolve a FlatPress media path to an absolute file path.
-- `plugin_mastodon_media_processing_attempts()` — current source — Calculate media-type- and size-aware polling attempts for asynchronous Mastodon media processing.
-- `plugin_mastodon_media_transfer_timeout()` — current source — Calculate media-type- and size-aware HTTP transfer timeouts for uploads.
-- `plugin_mastodon_normalize_comment_parent_id()` — line 2496 — Normalize a stored local comment parent identifier.
-- `plugin_mastodon_normalize_delete_sync_enabled()` — line 1457 — Normalize the toggle that enables or disables the follow-up deletion synchronization.
-- `plugin_mastodon_normalize_head_username()` — line 1159 — Normalize the configured Mastodon username for HTML head metadata.
-- `plugin_mastodon_normalize_import_synced_comments_as_entries()` — line 1421 — Normalize the toggle that allows importing already synchronized local comments as entries.
-- `plugin_mastodon_normalize_instance_url()` — line 1126 — Normalize the configured Mastodon instance URL.
-- `plugin_mastodon_normalize_status_language()` — line 1302 — Normalize a FlatPress locale string to a Mastodon-compatible ISO 639-1 code.
-- `plugin_mastodon_normalize_sync_start_date()` — line 1361 — Normalize the configured sync start date.
-- `plugin_mastodon_normalize_sync_time()` — line 1344 — Normalize the configured daily sync time.
-- `plugin_mastodon_normalize_tag_list()` — line 2974 — Normalize a list of tag labels.
-- `plugin_mastodon_normalize_update_local_from_remote()` — line 1403 — Normalize the toggle that controls whether existing local content may be updated from remote Mastodon data.
-- `plugin_mastodon_oauth_legacy_scopes()` — line 491 — Return the legacy OAuth scope string used before scope discovery was added.
-- `plugin_mastodon_oauth_preferred_scopes()` — line 585 — Prefer the narrow `profile` scope on current instances and fall back to `read:accounts` on older ones.
-- `plugin_mastodon_oauth_profile_scopes()` — line 499 — Return the stricter OAuth scope string that uses `profile` for `verify_credentials`.
-- `plugin_mastodon_oauth_scope_supported()` — line 564 — Check whether the configured Mastodon instance advertises support for a specific OAuth scope.
-- `plugin_mastodon_oauth_scopes()` — line 602 — Return the OAuth scopes that the currently registered app may safely request.
-- `plugin_mastodon_oauth_server_metadata()` — line 508 — Discover and cache OAuth authorization-server metadata from `/.well-known/oauth-authorization-server`.
-- `plugin_mastodon_oauth_supported_scopes()` — line 527 — Parse the discoverable OAuth scopes supported by the configured Mastodon instance.
-- `plugin_mastodon_parse_http_response_headers()` — line 5422 — Parse raw HTTP response headers.
-- `plugin_mastodon_parse_iso_datetime()` — line 2403 — Parse an ISO date/time string into FlatPress date format.
-- `plugin_mastodon_parse_iso_timestamp()` — line 2421 — Parse an ISO date/time value into a Unix timestamp.
-- `plugin_mastodon_photoswipe_plugin_active()` — line 2901 — Determine whether the PhotoSwipe plugin is active for the current FlatPress request.
-- `plugin_mastodon_plain_text_from_bbcode()` — line 3455 — Convert FlatPress BBCode into plain text for Mastodon export, removing complete AudioVideo player tags including optional description content.
-- `plugin_mastodon_profile_url()` — line 1228 — Build the public Mastodon profile URL used for the rel-me link.
-- `plugin_mastodon_public_comment_url()` — line 3650 — Return the public URL for a specific FlatPress comment.
-- `plugin_mastodon_public_comments_url()` — line 3622 — Return the public comments URL for a FlatPress entry.
-- `plugin_mastodon_public_entry_url()` — line 3595 — Return the public URL for a FlatPress entry.
-- `plugin_mastodon_public_url_for_mastodon()` — line 3311 — Return a Mastodon-safe public URL or an empty string.
-- `plugin_mastodon_register_app()` — line 5790 — Register the FlatPress application on the configured Mastodon instance with the preferred discoverable scope set.
-- `plugin_mastodon_remote_media_description()` — line 4378 — Resolve the best description for a remote attachment.
-- `plugin_mastodon_remote_media_source_url()` — line 4364 — Resolve the best downloadable source URL for a remote attachment.
-- `plugin_mastodon_remote_media_source_urls()` — current source — Resolve direct-download fallback candidates for a remote attachment.
-- `plugin_mastodon_remote_status_date_key()` — line 1509 — Determine the date key of a remote Mastodon status.
-- `plugin_mastodon_remote_status_image_attachments()` — line 4341 — Extract image attachments from a remote Mastodon status.
-- `plugin_mastodon_remote_status_is_importable()` — line 2475 — Determine whether a remote Mastodon status may be imported.
-- `plugin_mastodon_remote_status_matches_sync_start()` — line 1588 — Determine whether a remote Mastodon status should be synchronized.
-- `plugin_mastodon_remote_status_tags()` — line 3068 — Collect remote Mastodon tags from a status entity.
-- `plugin_mastodon_remote_status_timestamp()` — line 2443 — Resolve the best FlatPress-adjusted timestamp for a remote Mastodon status.
-- `plugin_mastodon_remote_status_visibility()` — line 2462 — Return the normalized visibility of a remote Mastodon status.
-- `plugin_mastodon_replace_emoticon_shortcodes_with_unicode()` — line 3238 — Replace FlatPress emoticon shortcodes with Unicode glyphs.
-- `plugin_mastodon_replace_unicode_emoticons_with_shortcodes()` — line 3266 — Replace Unicode emoticons with FlatPress shortcodes.
-- `plugin_mastodon_resolve_comment_reply_target()` — line 2535 — Resolve the remote reply target for a local comment export.
-- `plugin_mastodon_list_local_comment_ids()` — line 2589 — Scan the FlatPress comment directory directly so local reply export is not blocked by stale comment-list caches.
-- `plugin_mastodon_response_error_message()` — line 5761 — Extract the most useful error message from an API response.
-- `plugin_mastodon_run_deletion_sync()` — line 6875 — Run the deferred deletion synchronization in a follow-up request after content sync completed.
-- `plugin_mastodon_run_sync()` — line 7096 — Run a full synchronization cycle.
-- `plugin_mastodon_runtime_cache_clear()` — line 664 — Clear one request-local plugin cache bucket or the complete cache.
-- `plugin_mastodon_runtime_cache_get()` — line 622 — Return a value from the request-local plugin cache.
-- `plugin_mastodon_runtime_cache_set()` — line 646 — Store a value in the request-local plugin cache.
-- `plugin_mastodon_safe_filename()` — line 3949 — Sanitize a file name for local storage.
-- `plugin_mastodon_safe_path_component()` — line 3934 — Sanitize a string so it can be used as a path component.
-- `plugin_mastodon_save_options()` — line 970 — Persist plugin options.
-- `plugin_mastodon_secret_decode()` — line 1095 — Decode a previously stored secret value.
-- `plugin_mastodon_secret_encode()` — line 1072 — Encode a secret value before storing it in the configuration.
-- `plugin_mastodon_secret_key()` — line 1055 — Build the encryption key used for stored secrets.
-- `plugin_mastodon_should_import_synced_comments_as_entries()` — line 1430 — Check whether a remote Mastodon status that is already mapped to a local FlatPress comment may also be imported as an entry.
-- `plugin_mastodon_should_run_deletion_sync()` — line 1466 — Check whether the follow-up deletion synchronization is enabled.
-- `plugin_mastodon_should_update_local_from_remote()` — line 1412 — Check whether remote Mastodon updates may overwrite already existing local FlatPress content.
-- `plugin_mastodon_state_comment_key()` — line 1781 — Build the compound state key used for comment mappings.
-- `plugin_mastodon_state_get_comment_meta()` — line 2004 — Return mapping metadata for a local comment.
-- `plugin_mastodon_state_set_comment_tombstone()` — line 2018 — Store a tombstone that blocks stale re-imports of one deleted remote comment.
-- `plugin_mastodon_state_has_comment_tombstone()` — line 2038 — Check whether one remote Mastodon comment status was tombstoned locally.
-- `plugin_mastodon_protect_locally_deleted_exported_comments()` — line 2050 — Tombstone locally deleted exported FlatPress comment mappings before the next content sync can stale-reimport them from Mastodon thread context.
-- `plugin_mastodon_reattach_local_comment_to_entry_status()` — line 2096 — Remove a local imported reply parent link and reattach the surviving reply to the synchronized entry status after its remote parent reply disappeared.
-- `plugin_mastodon_state_remove_pending_comment_remote_recheck()` — line 2156 — Remove one pending descendant recheck marker.
-- `plugin_mastodon_state_get_pending_comment_remote_recheck()` — line 2170 — Return one pending descendant recheck marker.
-- `plugin_mastodon_state_set_pending_comment_remote_recheck()` — line 2185 — Mark one local comment for follow-up verification after an ancestor disappeared remotely.
-- `plugin_mastodon_state_set_deletions_pending()` — line 2210 — Persist whether another deletion follow-up request is pending and which scope it should run.
-- `plugin_mastodon_state_has_comment_recheck_scope()` — line 2222 — Check whether the next deletion follow-up request should run only the targeted descendant recheck scope.
-- `plugin_mastodon_build_comment_remote_child_index()` — line 2231 — Build a direct-child index for mapped remote reply trees.
-- `plugin_mastodon_queue_comment_descendant_remote_rechecks()` — line 2259 — Queue only the direct mapped local children of one deleted remote comment for additional verification passes.
-- `plugin_mastodon_process_pending_comment_remote_rechecks()` — line 2298 — Process pending descendant rechecks breadth-first so deeper reply chains can converge within the same targeted follow-up request.
-- `plugin_mastodon_state_get_entry_meta()` — line 1909 — Return mapping metadata for a local entry.
-- `plugin_mastodon_normalize_deletions_pending_scope()` — line 1721 — Normalize the targeted deletion-follow-up scope marker.
-- `plugin_mastodon_state_normalize()` — line 1734 — Normalize a runtime state array and fill in missing keys.
-- `plugin_mastodon_state_read()` — line 1658 — Load the persisted runtime state from disk.
-- `plugin_mastodon_state_remove_comment_mapping()` — line 1888 — Remove the mapping between a local comment and a remote status.
-- `plugin_mastodon_state_remove_entry_mapping()` — line 1869 — Remove the mapping between a local entry and a remote status.
-- `plugin_mastodon_state_set_comment_mapping()` — line 1834 — Store the mapping between a local comment and a remote status.
-- `plugin_mastodon_state_set_entry_mapping()` — line 1796 — Store the mapping between a local entry and a remote status.
-- `plugin_mastodon_state_write()` — line 1697 — Persist the runtime state to disk.
-- `plugin_mastodon_status_missing_response()` — line 5977 — Check whether an API response means that the referenced Mastodon status no longer exists.
-- `plugin_mastodon_status_text_length()` — line 4774 — Calculate the Mastodon-visible status length with instance URL budgeting.
-- `plugin_mastodon_stream_context_request()` — line 5452 — Perform an HTTP request through a stream context fallback.
-- `plugin_mastodon_strip_flatpress_tag_bbcode()` — line 3030 — Remove Tag plugin BBCode blocks from entry content.
-- `plugin_mastodon_strip_trailing_mastodon_hashtag_footer()` — line 3095 — Remove a trailing Mastodon hashtag footer from imported plain text.
-- `plugin_mastodon_subject_line_is_noise()` — line 3372 — Determine whether an extracted line should be ignored as a subject.
-- `plugin_mastodon_sync_due()` — line 7074 — Determine whether the scheduled synchronization is currently due.
-- `plugin_mastodon_sync_local_to_remote()` — line 6676 — Synchronize local FlatPress content to Mastodon.
-- `plugin_mastodon_sync_remote_to_local()` — line 6617 — Synchronize remote Mastodon content into FlatPress.
-- `plugin_mastodon_tag_plugin_active()` — line 2867 — Determine whether the Tag plugin is active for the current FlatPress request.
-- `plugin_mastodon_timestamp_date_key()` — line 1475 — Convert a FlatPress-adjusted timestamp into a stable date key.
-- `plugin_mastodon_update_status()` — line 6015 — Update an existing Mastodon status.
-- `plugin_mastodon_upload_media_items()` — line 5128 — Upload local media items to Mastodon and collect the created media IDs.
-- `plugin_mastodon_verify_credentials()` — line 5863 — Verify the currently configured access token.
-- `plugin_mastodon_wait_for_media_attachment()` — line 5082 — Poll an asynchronously processed Mastodon media attachment until it is ready or times out.
-- `setup()` — line 7362 — Register the Mastodon admin panel template and assign plugin data to Smarty.
+- `main()` — line 8725 — Keep the admin panel lifecycle compatible with FlatPress without extra processing.
+- `onsubmit()` — line 8729 — Process configuration saves, OAuth actions, including app registration and authorization-code exchange, and the manual synchronization trigger.
+- `plugin_mastodon_absolute_url()` — line 3346 — Convert a URL or path into an absolute URL when possible.
+- `plugin_mastodon_admin_assign()` — line 8675 — Assign plugin data to Smarty for the admin panel.
+- `plugin_mastodon_apcu_cache_key()` — line 981 — Build the namespaced APCu key used by this plugin.
+- `plugin_mastodon_apcu_delete()` — line 1023 — Delete a value from APCu using the FlatPress namespace key builder.
+- `plugin_mastodon_apcu_enabled()` — line 972 — Check whether shared APCu caching is available for the plugin.
+- `plugin_mastodon_apcu_fetch()` — line 995 — Fetch a value from APCu through the FlatPress namespace helper.
+- `plugin_mastodon_apcu_store()` — line 1010 — Store a value in APCu through the FlatPress namespace helper.
+- `plugin_mastodon_state_fallback_key()` — line 1035 — Return the APCu key used for the short-lived last-known-good state fallback.
+- `plugin_mastodon_state_fallback_store()` — line 1044 — Store a normalized runtime state in APCu for a 5-minute emergency fallback window.
+- `plugin_mastodon_state_fallback_read()` — line 1056 — Fetch the short-lived last-known-good state fallback from APCu.
+- `plugin_mastodon_sync_guard_kind()` — line 1074 — Normalize the cooldown guard kind.
+- `plugin_mastodon_sync_guard_apcu_key()` — line 1084 — Return the APCu key used for one sync cooldown guard.
+- `plugin_mastodon_sync_guard_entry_active()` — line 1094 — Check whether one cooldown guard entry is still active.
+- `plugin_mastodon_sync_guard_apcu_store()` — line 1105 — Store one cooldown guard in APCu.
+- `plugin_mastodon_sync_guard_file_read()` — line 1118 — Read and prune the file-backed cooldown guard.
+- `plugin_mastodon_sync_guard_file_write()` — line 1145 — Write the file-backed cooldown guard.
+- `plugin_mastodon_sync_guard_active()` — line 1166 — Check whether a recent scheduled content/deletion pass is still cooling down.
+- `plugin_mastodon_sync_guard_mark()` — line 1191 — Mark a 5-minute cooldown guard for a scheduled sync/deletion pass.
+- `plugin_mastodon_sync_guard_clear()` — line 1212 — Clear one sync cooldown guard.
+- `plugin_mastodon_rate_limit_default_budgets()` — line 1227 — Return conservative per-run Mastodon API budgets.
+- `plugin_mastodon_rate_limit_guard_start()` — line 1252 — Start the per-run Mastodon API rate-limit guard.
+- `plugin_mastodon_rate_limit_guard_stop()` — line 1276 — Stop the per-run Mastodon API rate-limit guard while keeping its summary inspectable.
+- `plugin_mastodon_rate_limit_guard_active()` — line 1287 — Check whether the per-run Mastodon API guard is active.
+- `plugin_mastodon_rate_limit_guard_summary()` — line 1295 — Return the current per-run rate-limit guard summary.
+- `plugin_mastodon_rate_limit_headers()` — line 1304 — Normalize response headers for rate-limit checks.
+- `plugin_mastodon_rate_limit_request_kind()` — line 1325 — Classify Mastodon API requests as general, media upload, or status deletion.
+- `plugin_mastodon_rate_limit_block()` — line 1347 — Mark the current run as blocked by a rate-limit budget or Mastodon response and log the stop reason with budget counters once per run.
+- `plugin_mastodon_rate_limit_acquire()` — line 1383 — Reserve request/media/delete budget before a Mastodon API request proceeds.
+- `plugin_mastodon_rate_limit_observe_response()` — line 1424 — Update the guard from `X-RateLimit-*` headers and `429` responses.
+- `plugin_mastodon_rate_limit_blocked_reason()` — line 1448 — Return the current rate-limit block reason.
+- `plugin_mastodon_rate_limit_blocked_response()` — line 1460 — Build the synthetic `429` response used for locally blocked requests.
+- `plugin_mastodon_rate_limit_state_error()` — line 1476 — Return the rate-limit reason that should be written to synchronization state.
+- `plugin_mastodon_bbcode_attr_escape()` — line 4723 — Escape a value for safe BBCode attribute usage.
+- `plugin_mastodon_bbcode_text_escape()` — line 4735 — Escape plain text embedded between BBCode tags.
+- `plugin_mastodon_bbcode_plugin_active()` — line 3500 — Determine whether the BBCode plugin is active for the current FlatPress request.
+- `plugin_mastodon_blog_base_url()` — line 3293 — Return the absolute base URL of the current FlatPress installation.
+- `plugin_mastodon_build_authorize_url()` — line 7116 — Build the OAuth authorization URL using the scopes that the registered app may safely request.
+- `plugin_mastodon_build_comment_status_text()` — line 7414 — Build the status body used when exporting a FlatPress comment.
+- `plugin_mastodon_build_entry_status_text()` — line 7346 — Build the status body used when exporting a FlatPress entry.
+- `plugin_mastodon_build_flatpress_tag_bbcode()` — line 3798 — Build Tag plugin BBCode from a list of remote Mastodon tags.
+- `plugin_mastodon_build_imported_media_bbcode()` — line 5643 — Build FlatPress BBCode for imported remote media attachments, including AudioVideo optional description endtag text.
+- `plugin_mastodon_cleanup_imported_text()` — line 4056 — Clean imported text before saving it to FlatPress.
+- `plugin_mastodon_cleanup_uploaded_media()` — line 6275 — Best-effort cleanup for uploaded Mastodon media that never reached a final status request.
+- `plugin_mastodon_collect_entry_files()` — line 6610 — Collect entry files recursively from the FlatPress content tree.
+- `plugin_mastodon_collect_known_entry_context_targets()` — line 7890 — Collect known synchronized entry threads that should have their Mastodon reply context refreshed.
+- `plugin_mastodon_collect_local_entry_media()` — line 5114 — Collect local images, galleries, AudioVideo media, optional AudioVideo endtag descriptions, and video poster thumbnails referenced by an entry.
+- `plugin_mastodon_comment_hash()` — line 4560 — Build a change-detection hash for a FlatPress comment.
+- `plugin_mastodon_comment_parent_fields()` — line 3104 — Return the comment fields that may contain a parent reference.
+- `plugin_mastodon_companion_plugins_status()` — line 3566 — Return the status of companion FlatPress plugins used for the full Mastodon feature set.
+- `plugin_mastodon_compare_local_entries_for_export()` — line 6663 — Compare local FlatPress entries for Mastodon export order.
+- `plugin_mastodon_configured_status_language()` — line 1926 — Read the configured FlatPress locale and return the Mastodon language code.
+- `plugin_mastodon_create_status()` — line 7293 — Create a Mastodon status.
+- `plugin_mastodon_date_matches_sync_start()` — line 2161 — Determine whether a content date passes the configured sync start date.
+- `plugin_mastodon_datetime_date_key()` — line 2137 — Normalize a stored date/datetime string to the sync-start date-key format.
+- `plugin_mastodon_default_content_stats()` — line 458 — Return the default counters for the last content synchronization.
+- `plugin_mastodon_default_deletion_stats()` — line 475 — Return the default counters for the last deletion synchronization.
+- `plugin_mastodon_default_options()` — line 77 — Return the default plugin option values.
+- `plugin_mastodon_default_state()` — line 488 — Return the default runtime state structure, including the targeted deletion-follow-up scope marker.
+- `plugin_mastodon_delete_media_attachment()` — line 6256 — Delete an uploaded Mastodon media attachment before it is attached to a final status.
+- `plugin_mastodon_delete_status()` — line 7267 — Delete a Mastodon status, including media when requested.
+- `plugin_mastodon_detect_local_comment_parent_id()` — line 3130 — Detect the local parent comment identifier from comment data.
+- `plugin_mastodon_dom_children_to_flatpress()` — line 4110 — Convert DOM child nodes into FlatPress BBCode text.
+- `plugin_mastodon_dom_node_to_flatpress()` — line 4128 — Convert a single DOM node into FlatPress BBCode text.
+- `plugin_mastodon_domains_match()` — line 4042 — Determine whether two host names belong to the same domain family.
+- `plugin_mastodon_emoticon_entity_to_unicode()` — line 3811 — Convert an emoticon HTML entity into a Unicode character.
+- `plugin_mastodon_emoticon_map()` — line 3824 — Return the FlatPress emoticon-to-Unicode lookup map.
+- `plugin_mastodon_emoticons_plugin_active()` — line 3551 — Determine whether the Emoticons plugin is active for the current FlatPress request.
+- `plugin_mastodon_enabled_plugin_state()` — line 3418 — Determine whether a FlatPress plugin is enabled in the centralized plugin configuration.
+- `plugin_mastodon_ensure_state_dir()` — line 2241 — Ensure that the plugin runtime directory exists.
+- `plugin_mastodon_entry_hash()` — line 4548 — Build a change-detection hash for a FlatPress entry.
+- `plugin_mastodon_entry_media_signature()` — line 5325 — Build a signature for media references contained in entry content.
+- `plugin_mastodon_exchange_code_for_token()` — line 7136 — Exchange an OAuth authorization code for an access token using the same negotiated scope string.
+- `plugin_mastodon_extend_time_limit()` — line 5842 — Refresh or raise the PHP execution time budget for long-running Mastodon work without lowering an existing higher or unlimited limit.
+- `plugin_mastodon_extract_flatpress_tags()` — line 3645 — Extract FlatPress Tag plugin labels from an entry body.
+- `plugin_mastodon_extract_url_token()` — line 3329 — Extract the URL token from a BBCode or attribute fragment.
+- `plugin_mastodon_fediverse_creator_value()` — line 1846 — Build the fediverse creator meta value.
+- `plugin_mastodon_fetch_account_statuses()` — line 7198 — Fetch statuses for the authenticated Mastodon account.
+- `plugin_mastodon_fetch_media_attachment()` — line 6246 — Fetch a single Mastodon media attachment by ID.
+- `plugin_mastodon_fetch_status()` — line 7256 — Fetch a single Mastodon status.
+- `plugin_mastodon_fetch_status_context()` — line 7245 — Fetch the conversation context for a Mastodon status.
+- `plugin_mastodon_file_prestat()` — line 1486 — Read a cheap file metadata snapshot for cache validation.
+- `plugin_mastodon_file_prestat_signature()` — line 1506 — Convert a file metadata snapshot into a stable cache signature.
+- `plugin_mastodon_flatpress_to_mastodon()` — line 4409 — Convert FlatPress content into Mastodon-ready plain text.
+- `plugin_mastodon_fp_config()` — line 700 — Return the FlatPress configuration, preferring the early-loaded core cache.
+- `plugin_mastodon_fp_config_value()` — line 736 — Read a nested FlatPress configuration value.
+- `plugin_mastodon_fp_timeoffset_seconds()` — line 752 — Return the configured FlatPress time offset in seconds for exact local admin-time conversion.
+- `plugin_mastodon_fp_timeoffset_label()` — line 772 — Format the configured FlatPress time offset as a UTC label for admin users.
+- `plugin_mastodon_sync_time_to_minutes()` — line 802 — Convert a normalized `HH:MM` sync-time value into minutes after midnight.
+- `plugin_mastodon_minutes_to_sync_time()` — line 813 — Convert minutes after midnight back into a normalized `HH:MM` sync-time value.
+- `plugin_mastodon_sync_time_utc_to_local()` — line 829 — Convert the stored UTC synchronization time to the FlatPress-local admin time.
+- `plugin_mastodon_sync_time_local_to_utc()` — line 840 — Convert the FlatPress-local admin synchronization time back to stored UTC.
+- `plugin_mastodon_format_admin_datetime()` — line 851 — Format stored UTC timestamps for the admin panel using FlatPress `timeoffset`, date format, and time format.
+- `plugin_mastodon_get_options()` — line 1517 — Load the saved plugin options and merge them with defaults.
+- `plugin_mastodon_guess_subject()` — line 3242 — Guess a subject line from imported plain text.
+- `plugin_mastodon_head()` — line 1864 — Print Mastodon profile metadata into the HTML head.
+- `plugin_mastodon_html_entity_decode()` — line 3284 — Decode HTML entities using the plugin defaults.
+- `plugin_mastodon_http_build_query()` — line 6826 — Build an application/x-www-form-urlencoded query string.
+- `plugin_mastodon_http_request()` — line 6882 — Perform an HTTP request using cURL or the stream fallback.
+- `plugin_mastodon_http_request_multipart()` — line 6113 — Perform a multipart HTTP request.
+- `plugin_mastodon_import_remote_comment()` — line 7703 — Import a remote Mastodon reply into FlatPress as a comment while respecting comment tombstones, including early tombstones for locally deleted exported comments.
+- `plugin_mastodon_import_remote_context_descendants()` — line 7787 — Import remote Mastodon replies from a fetched thread context while blocking tombstoned parent/child replies.
+- `plugin_mastodon_import_remote_entry()` — line 7452 — Import a remote Mastodon status into FlatPress as an entry.
+- `plugin_mastodon_instance_authority()` — line 1800 — Return the Mastodon instance authority used in fediverse creator metadata.
+- `plugin_mastodon_instance_character_limit()` — line 7183 — Return the status character limit of the configured instance.
+- `plugin_mastodon_instance_configuration()` — line 5952 — Load and cache the Mastodon instance configuration document.
+- `plugin_mastodon_instance_media_description_limit()` — line 5975 — Return the media description length limit of the configured instance.
+- `plugin_mastodon_instance_media_limit()` — line 5962 — Return the media attachment limit of the configured instance.
+- `plugin_mastodon_instance_url_reserved_length()` — line 5988 — Return the reserved Mastodon character budget used for each URL.
+- `plugin_mastodon_io_append_file()` — line 956 — Append to a file via the FlatPress I/O layer.
+- `plugin_mastodon_io_read_file()` — line 885 — Read a file through the FlatPress I/O layer when available.
+- `plugin_mastodon_io_read_file_uncached()` — line 898 — Read a file without FlatPress request-local caches.
+- `plugin_mastodon_file_permissions_mode()` — line 913 — Return the FlatPress `FILE_PERMISSIONS` mode used for plugin runtime files.
+- `plugin_mastodon_apply_file_permissions()` — line 922 — Apply FlatPress `FILE_PERMISSIONS` to a plugin runtime file.
+- `plugin_mastodon_io_write_file()` — line 935 — Write a file through the FlatPress I/O layer when available and enforce `FILE_PERMISSIONS` after successful writes.
+- `plugin_mastodon_is_public_host()` — line 3928 — Determine whether a host name resolves to a public endpoint.
+- `plugin_mastodon_lang_string()` — line 3388 — Return a localized plugin string or a provided fallback.
+- `plugin_mastodon_limit_status_text()` — line 6034 — Truncate status text using Mastodon URL-budget rules.
+- `plugin_mastodon_limit_text()` — line 4526 — Limit text to a maximum number of characters.
+- `plugin_mastodon_list_local_entries()` — line 6681 — List local FlatPress entry identifiers.
+- `plugin_mastodon_local_item_date_key()` — line 2091 — Determine the date key of a local FlatPress entry or comment.
+- `plugin_mastodon_local_item_matches_sync_start()` — line 2180 — Determine whether a local FlatPress item should be synchronized.
+- `plugin_mastodon_local_item_timestamp()` — line 6637 — Resolve the best timestamp for a local FlatPress item.
+- `plugin_mastodon_log()` — line 2250 — Append a line to the plugin sync log.
+- `plugin_mastodon_mapping_matches_sync_start()` — line 2201 — Determine whether a stored synchronization mapping still belongs to the active sync-start window.
+- `plugin_mastodon_mastodon_api()` — line 7000 — Call the Mastodon API and return the raw HTTP response.
+- `plugin_mastodon_mastodon_hashtag_footer()` — line 3687 — Convert FlatPress tag labels into a Mastodon hashtag footer line.
+- `plugin_mastodon_mastodon_html_to_flatpress()` — line 4307 — Convert Mastodon HTML content into FlatPress BBCode.
+- `plugin_mastodon_mastodon_json()` — line 7049 — Call the Mastodon API and decode a JSON response.
+- `plugin_mastodon_maybe_sync()` — line 8513 — Run the scheduled synchronization when the current request is due.
+- `plugin_mastodon_media_copy_tree()` — line 4685 — Copy a directory tree used for media synchronization.
+- `plugin_mastodon_media_delete_tree()` — line 4658 — Delete a directory tree used for imported media.
+- `plugin_mastodon_media_download()` — line 5577 — Download a remote media asset.
+- `plugin_mastodon_media_guess_mime_type()` — line 4757 — Guess the MIME type of a local media file.
+- `plugin_mastodon_media_description_from_bbcode_content()` — line 5010 — Normalize optional AudioVideo BBCode content into a Mastodon media description.
+- `plugin_mastodon_media_parse_tag_attributes()` — line 4979 — Parse key/value attributes from a FlatPress media tag.
+- `plugin_mastodon_media_prepare_directory()` — line 4642 — Ensure that a media directory exists.
+- `plugin_mastodon_media_relative_to_absolute()` — line 4629 — Resolve a FlatPress media path to an absolute file path.
+- `plugin_mastodon_media_processing_attempts()` — line 6311 — Calculate media-type- and size-aware polling attempts for asynchronous Mastodon media processing.
+- `plugin_mastodon_media_transfer_timeout()` — line 6335 — Calculate media-type- and size-aware HTTP transfer timeouts for uploads.
+- `plugin_mastodon_normalize_comment_parent_id()` — line 3113 — Normalize a stored local comment parent identifier.
+- `plugin_mastodon_normalize_delete_sync_enabled()` — line 2059 — Normalize the toggle that enables or disables the follow-up deletion synchronization.
+- `plugin_mastodon_normalize_head_username()` — line 1761 — Normalize the configured Mastodon username for HTML head metadata.
+- `plugin_mastodon_normalize_import_synced_comments_as_entries()` — line 2023 — Normalize the toggle that allows importing already synchronized local comments as entries.
+- `plugin_mastodon_normalize_instance_url()` — line 1728 — Normalize the configured Mastodon instance URL.
+- `plugin_mastodon_normalize_status_language()` — line 1904 — Normalize a FlatPress locale string to a Mastodon-compatible ISO 639-1 code.
+- `plugin_mastodon_normalize_sync_start_date()` — line 1963 — Normalize the configured sync start date.
+- `plugin_mastodon_normalize_sync_time()` — line 1946 — Normalize the configured daily sync time.
+- `plugin_mastodon_normalize_tag_list()` — line 3614 — Normalize a list of tag labels.
+- `plugin_mastodon_normalize_update_local_from_remote()` — line 2005 — Normalize the toggle that controls whether existing local content may be updated from remote Mastodon data.
+- `plugin_mastodon_oauth_legacy_scopes()` — line 512 — Return the legacy OAuth scope string used before scope discovery was added.
+- `plugin_mastodon_oauth_preferred_scopes()` — line 606 — Prefer the narrow `profile` scope on current instances and fall back to `read:accounts` on older ones.
+- `plugin_mastodon_oauth_profile_scopes()` — line 520 — Return the stricter OAuth scope string that uses `profile` for `verify_credentials`.
+- `plugin_mastodon_oauth_scope_supported()` — line 585 — Check whether the configured Mastodon instance advertises support for a specific OAuth scope.
+- `plugin_mastodon_oauth_scopes()` — line 623 — Return the OAuth scopes that the currently registered app may safely request.
+- `plugin_mastodon_oauth_server_metadata()` — line 529 — Discover and cache OAuth authorization-server metadata from `/.well-known/oauth-authorization-server`.
+- `plugin_mastodon_oauth_supported_scopes()` — line 548 — Parse the discoverable OAuth scopes supported by the configured Mastodon instance.
+- `plugin_mastodon_parse_http_response_headers()` — line 6718 — Parse raw HTTP response headers.
+- `plugin_mastodon_parse_iso_datetime()` — line 3020 — Parse an ISO date/time string into FlatPress date format.
+- `plugin_mastodon_parse_iso_timestamp()` — line 3038 — Parse an ISO date/time value into a Unix timestamp.
+- `plugin_mastodon_photoswipe_plugin_active()` — line 3517 — Determine whether the PhotoSwipe plugin is active for the current FlatPress request.
+- `plugin_mastodon_plain_text_from_bbcode()` — line 3970 — Convert FlatPress BBCode into plain text for Mastodon export, removing complete AudioVideo player tags including optional description content.
+- `plugin_mastodon_profile_url()` — line 1830 — Build the public Mastodon profile URL used for the rel-me link.
+- `plugin_mastodon_public_comment_url()` — line 4292 — Return the public URL for a specific FlatPress comment.
+- `plugin_mastodon_public_comments_url()` — line 4264 — Return the public comments URL for a FlatPress entry.
+- `plugin_mastodon_public_entry_url()` — line 4237 — Return the public URL for a FlatPress entry.
+- `plugin_mastodon_public_url_for_mastodon()` — line 3951 — Return a Mastodon-safe public URL or an empty string.
+- `plugin_mastodon_register_app()` — line 7093 — Register the FlatPress application on the configured Mastodon instance with the preferred discoverable scope set.
+- `plugin_mastodon_remote_media_description()` — line 5448 — Resolve the best description for a remote attachment.
+- `plugin_mastodon_remote_media_source_url()` — line 5408 — Resolve the best downloadable source URL for a remote attachment.
+- `plugin_mastodon_remote_media_source_urls()` — line 5426 — Resolve direct-download fallback candidates for a remote attachment.
+- `plugin_mastodon_remote_status_date_key()` — line 2111 — Determine the date key of a remote Mastodon status.
+- `plugin_mastodon_remote_status_image_attachments()` — line 5399 — Extract image attachments from a remote Mastodon status.
+- `plugin_mastodon_remote_status_is_importable()` — line 3092 — Determine whether a remote Mastodon status may be imported.
+- `plugin_mastodon_remote_status_matches_sync_start()` — line 2190 — Determine whether a remote Mastodon status should be synchronized.
+- `plugin_mastodon_remote_status_tags()` — line 3708 — Collect remote Mastodon tags from a status entity.
+- `plugin_mastodon_remote_status_timestamp()` — line 3060 — Resolve the best FlatPress-adjusted timestamp for a remote Mastodon status.
+- `plugin_mastodon_remote_status_visibility()` — line 3079 — Return the normalized visibility of a remote Mastodon status.
+- `plugin_mastodon_replace_emoticon_shortcodes_with_unicode()` — line 3878 — Replace FlatPress emoticon shortcodes with Unicode glyphs.
+- `plugin_mastodon_replace_unicode_emoticons_with_shortcodes()` — line 3906 — Replace Unicode emoticons with FlatPress shortcodes.
+- `plugin_mastodon_resolve_comment_reply_target()` — line 3152 — Resolve the remote reply target for a local comment export.
+- `plugin_mastodon_list_local_comment_ids()` — line 3205 — Scan the FlatPress comment directory directly so local reply export is not blocked by stale comment-list caches.
+- `plugin_mastodon_response_error_message()` — line 7064 — Extract the most useful error message from an API response.
+- `plugin_mastodon_run_deletion_sync()` — line 8192 — Run the deferred deletion synchronization in a follow-up request after content sync completed.
+- `plugin_mastodon_run_sync()` — line 8434 — Run a full synchronization cycle.
+- `plugin_mastodon_runtime_cache_clear()` — line 685 — Clear one request-local plugin cache bucket or the complete cache.
+- `plugin_mastodon_runtime_cache_get()` — line 643 — Return a value from the request-local plugin cache.
+- `plugin_mastodon_runtime_cache_set()` — line 667 — Store a value in the request-local plugin cache.
+- `plugin_mastodon_safe_filename()` — line 4593 — Sanitize a file name for local storage.
+- `plugin_mastodon_safe_path_component()` — line 4578 — Sanitize a string so it can be used as a path component.
+- `plugin_mastodon_save_options()` — line 1572 — Persist plugin options.
+- `plugin_mastodon_secret_decode()` — line 1697 — Decode a previously stored secret value.
+- `plugin_mastodon_secret_encode()` — line 1674 — Encode a secret value before storing it in the configuration.
+- `plugin_mastodon_secret_key()` — line 1657 — Build the encryption key used for stored secrets.
+- `plugin_mastodon_should_import_synced_comments_as_entries()` — line 2032 — Check whether a remote Mastodon status that is already mapped to a local FlatPress comment may also be imported as an entry.
+- `plugin_mastodon_should_run_deletion_sync()` — line 2068 — Check whether the follow-up deletion synchronization is enabled.
+- `plugin_mastodon_should_update_local_from_remote()` — line 2014 — Check whether remote Mastodon updates may overwrite already existing local FlatPress content.
+- `plugin_mastodon_state_comment_key()` — line 2399 — Build the compound state key used for comment mappings.
+- `plugin_mastodon_state_get_comment_meta()` — line 2622 — Return mapping metadata for a local comment.
+- `plugin_mastodon_state_set_comment_tombstone()` — line 2636 — Store a tombstone that blocks stale re-imports of one deleted remote comment.
+- `plugin_mastodon_state_has_comment_tombstone()` — line 2656 — Check whether one remote Mastodon comment status was tombstoned locally.
+- `plugin_mastodon_protect_locally_deleted_exported_comments()` — line 2667 — Tombstone locally deleted exported FlatPress comment mappings before the next content sync can stale-reimport them from Mastodon thread context.
+- `plugin_mastodon_reattach_local_comment_to_entry_status()` — line 2713 — Remove a local imported reply parent link and reattach the surviving reply to the synchronized entry status after its remote parent reply disappeared.
+- `plugin_mastodon_state_remove_pending_comment_remote_recheck()` — line 2773 — Remove one pending descendant recheck marker.
+- `plugin_mastodon_state_get_pending_comment_remote_recheck()` — line 2787 — Return one pending descendant recheck marker.
+- `plugin_mastodon_state_set_pending_comment_remote_recheck()` — line 2802 — Mark one local comment for follow-up verification after an ancestor disappeared remotely.
+- `plugin_mastodon_state_set_deletions_pending()` — line 2827 — Persist whether another deletion follow-up request is pending and which scope it should run.
+- `plugin_mastodon_state_has_comment_recheck_scope()` — line 2839 — Check whether the next deletion follow-up request should run only the targeted descendant recheck scope.
+- `plugin_mastodon_build_comment_remote_child_index()` — line 2848 — Build a direct-child index for mapped remote reply trees.
+- `plugin_mastodon_queue_comment_descendant_remote_rechecks()` — line 2876 — Queue only the direct mapped local children of one deleted remote comment for additional verification passes.
+- `plugin_mastodon_process_pending_comment_remote_rechecks()` — line 2915 — Process pending descendant rechecks breadth-first so deeper reply chains can converge within the same targeted follow-up request.
+- `plugin_mastodon_state_get_entry_meta()` — line 2527 — Return mapping metadata for a local entry.
+- `plugin_mastodon_normalize_deletions_pending_scope()` — line 2339 — Normalize the targeted deletion-follow-up scope marker.
+- `plugin_mastodon_state_normalize()` — line 2352 — Normalize a runtime state array and fill in missing keys.
+- `plugin_mastodon_state_read()` — line 2260 — Load the persisted runtime state from disk and fall back to the short-lived APCu state if the file is temporarily missing, empty, or invalid.
+- `plugin_mastodon_state_remove_comment_mapping()` — line 2506 — Remove the mapping between a local comment and a remote status.
+- `plugin_mastodon_state_remove_entry_mapping()` — line 2487 — Remove the mapping between a local entry and a remote status.
+- `plugin_mastodon_state_set_comment_mapping()` — line 2452 — Store the mapping between a local comment and a remote status.
+- `plugin_mastodon_state_set_entry_mapping()` — line 2414 — Store the mapping between a local entry and a remote status.
+- `plugin_mastodon_state_write()` — line 2314 — Persist the runtime state to disk and always refresh the short-lived APCu last-known-good state when possible.
+- `plugin_mastodon_status_missing_response()` — line 7280 — Check whether an API response means that the referenced Mastodon status no longer exists.
+- `plugin_mastodon_status_text_length()` — line 6002 — Calculate the Mastodon-visible status length with instance URL budgeting.
+- `plugin_mastodon_stream_context_request()` — line 6748 — Perform an HTTP request through a stream context fallback.
+- `plugin_mastodon_strip_flatpress_tag_bbcode()` — line 3670 — Remove Tag plugin BBCode blocks from entry content.
+- `plugin_mastodon_strip_trailing_mastodon_hashtag_footer()` — line 3735 — Remove a trailing Mastodon hashtag footer from imported plain text.
+- `plugin_mastodon_subject_line_is_noise()` — line 4014 — Determine whether an extracted line should be ignored as a subject.
+- `plugin_mastodon_sync_due()` — line 8412 — Determine whether the scheduled synchronization is currently due.
+- `plugin_mastodon_sync_local_to_remote()` — line 7989 — Synchronize local FlatPress content to Mastodon.
+- `plugin_mastodon_sync_remote_to_local()` — line 7924 — Synchronize remote Mastodon content into FlatPress.
+- `plugin_mastodon_tag_plugin_active()` — line 3483 — Determine whether the Tag plugin is active for the current FlatPress request.
+- `plugin_mastodon_timestamp_date_key()` — line 2077 — Convert a FlatPress-adjusted timestamp into a stable date key.
+- `plugin_mastodon_update_status()` — line 7320 — Update an existing Mastodon status.
+- `plugin_mastodon_upload_media_items()` — line 6404 — Upload local media items to Mastodon and collect the created media IDs.
+- `plugin_mastodon_verify_credentials()` — line 7166 — Verify the currently configured access token.
+- `plugin_mastodon_wait_for_media_attachment()` — line 6355 — Poll an asynchronously processed Mastodon media attachment until it is ready or times out.
+- `setup()` — line 8720 — Register the Mastodon admin panel template and assign plugin data to Smarty.

--- a/fp-plugins/mastodon/plugin.mastodon.php
+++ b/fp-plugins/mastodon/plugin.mastodon.php
@@ -3,7 +3,7 @@
  * Plugin Name: Mastodon
  * Plugin URI: https://www.flatpress.org
  * Description: Synchronizes FlatPress entries and comments with Mastodon. <a href="./fp-plugins/mastodon/doc_mastodon.txt" title="Instructions" target="_blank">[Instructions]</a>
- * Version: 2.2.0
+ * Version: 2.2.2
  * Author: FlatPress
  * Author URI: https://www.flatpress.org
  */
@@ -18,10 +18,18 @@ if (!defined('PLUGIN_MASTODON_STATE_DIR')) {
 	define('PLUGIN_MASTODON_STATE_DIR', FP_CONTENT . 'plugin_mastodon' . DIRECTORY_SEPARATOR);
 }
 if (!defined('PLUGIN_MASTODON_STATE_FILE')) {
+	/**
+	 * Internal runtime data structures:
+	 * - plugin options are normalized associative arrays with string values
+	 * - runtime state is a nested associative array persisted as JSON
+	 */
 	define('PLUGIN_MASTODON_STATE_FILE', PLUGIN_MASTODON_STATE_DIR . 'state.json');
 }
 if (!defined('PLUGIN_MASTODON_LOCK_FILE')) {
 	define('PLUGIN_MASTODON_LOCK_FILE', PLUGIN_MASTODON_STATE_DIR . 'sync.lock');
+}
+if (!defined('PLUGIN_MASTODON_GUARD_FILE')) {
+	define('PLUGIN_MASTODON_GUARD_FILE', PLUGIN_MASTODON_STATE_DIR . 'sync.guard.json');
 }
 if (!defined('PLUGIN_MASTODON_LOG_FILE')) {
 	define('PLUGIN_MASTODON_LOG_FILE', PLUGIN_MASTODON_STATE_DIR . 'sync.log');
@@ -41,13 +49,26 @@ if (!defined('PLUGIN_MASTODON_IMPORTED_MEDIA_WIDTH')) {
 if (!defined('PLUGIN_MASTODON_PENDING_COMMENT_RECHECK_LIMIT')) {
 	define('PLUGIN_MASTODON_PENDING_COMMENT_RECHECK_LIMIT', 3);
 }
-
-/**
- * Internal runtime data structures:
- * - plugin options are normalized associative arrays with string values
- * - runtime state is a nested associative array persisted as JSON
- */
-
+// ttl for sync guards
+if (!defined('PLUGIN_MASTODON_STATE_FALLBACK_TTL')) {
+	define('PLUGIN_MASTODON_STATE_FALLBACK_TTL', 300);
+}
+if (!defined('PLUGIN_MASTODON_COOLDOWN_TTL')) {
+	define('PLUGIN_MASTODON_COOLDOWN_TTL', 300);
+}
+// Rate limit and budget guards
+if (!defined('PLUGIN_MASTODON_RUN_REQUEST_BUDGET')) {
+	define('PLUGIN_MASTODON_RUN_REQUEST_BUDGET', 240);
+}
+if (!defined('PLUGIN_MASTODON_RUN_MEDIA_UPLOAD_BUDGET')) {
+	define('PLUGIN_MASTODON_RUN_MEDIA_UPLOAD_BUDGET', 24);
+}
+if (!defined('PLUGIN_MASTODON_RUN_DELETE_BUDGET')) {
+	define('PLUGIN_MASTODON_RUN_DELETE_BUDGET', 24);
+}
+if (!defined('PLUGIN_MASTODON_RATE_LIMIT_REMAINING_FLOOR')) {
+	define('PLUGIN_MASTODON_RATE_LIMIT_REMAINING_FLOOR', 10);
+}
 
 /**
  * Return the default plugin option values.
@@ -886,6 +907,26 @@ function plugin_mastodon_io_read_file_uncached($file, $assumeExists = false) {
 }
 
 /**
+ * Return the FlatPress file permission mode for runtime files.
+ * @return int
+ */
+function plugin_mastodon_file_permissions_mode() {
+	return defined('FILE_PERMISSIONS') ? (int) constant('FILE_PERMISSIONS') : 0644;
+}
+
+/**
+ * Apply FlatPress FILE_PERMISSIONS to a runtime file.
+ * @param string $file
+ * @return bool
+ */
+function plugin_mastodon_apply_file_permissions($file) {
+	if (!@file_exists($file) || !@is_file($file)) {
+		return false;
+	}
+	return @chmod($file, plugin_mastodon_file_permissions_mode());
+}
+
+/**
  * Write a file through the FlatPress I/O layer when available.
  * @param string $file
  * @param string $payload
@@ -893,9 +934,17 @@ function plugin_mastodon_io_read_file_uncached($file, $assumeExists = false) {
  */
 function plugin_mastodon_io_write_file($file, $payload) {
 	if (function_exists('io_write_file')) {
-		return (bool) io_write_file($file, $payload);
+		$written = (bool) io_write_file($file, $payload);
+		if ($written) {
+			plugin_mastodon_apply_file_permissions($file);
+		}
+		return $written;
 	}
-	return (@file_put_contents($file, $payload) !== false);
+	if (@file_put_contents($file, $payload) === false) {
+		return false;
+	}
+	plugin_mastodon_apply_file_permissions($file);
+	return true;
 }
 
 /**
@@ -977,6 +1026,456 @@ function plugin_mastodon_apcu_delete($suffix) {
 	}
 	$cacheKey = plugin_mastodon_apcu_cache_key($suffix);
 	@apcu_delete($cacheKey);
+}
+
+/**
+ * Return the APCu key used for the short-lived last-known-good state fallback.
+ * @return string
+ */
+function plugin_mastodon_state_fallback_key() {
+	return 'state:last_known_good:v1';
+}
+
+/**
+ * Store a normalized runtime state in APCu for a short emergency fallback window.
+ * @param array<string, mixed> $state
+ * @return bool
+ */
+function plugin_mastodon_state_fallback_store($state) {
+	$state = plugin_mastodon_state_normalize(is_array($state) ? $state : array());
+	return plugin_mastodon_apcu_store(plugin_mastodon_state_fallback_key(), array(
+		'stored_at' => time(),
+		'state' => $state
+	), PLUGIN_MASTODON_STATE_FALLBACK_TTL);
+}
+
+/**
+ * Fetch the short-lived last-known-good state fallback from APCu.
+ * @return array<string, mixed>
+ */
+function plugin_mastodon_state_fallback_read() {
+	$hit = false;
+	$value = plugin_mastodon_apcu_fetch(plugin_mastodon_state_fallback_key(), $hit);
+	if (!$hit || !is_array($value) || !isset($value ['state']) || !is_array($value ['state'])) {
+		return array();
+	}
+	if (isset($value ['stored_at']) && ((int) $value ['stored_at']) > 0 && ((int) $value ['stored_at']) + PLUGIN_MASTODON_STATE_FALLBACK_TTL < time()) {
+		plugin_mastodon_apcu_delete(plugin_mastodon_state_fallback_key());
+		return array();
+	}
+	return plugin_mastodon_state_normalize($value ['state']);
+}
+
+/**
+ * Normalize the cooldown guard kind.
+ * @param string $kind
+ * @return string
+ */
+function plugin_mastodon_sync_guard_kind($kind) {
+	$kind = trim((string) $kind);
+	return $kind === 'deletion' ? 'deletion' : 'content';
+}
+
+/**
+ * Return the APCu key used for a sync cooldown guard.
+ * @param string $kind
+ * @return string
+ */
+function plugin_mastodon_sync_guard_apcu_key($kind) {
+	return 'sync_guard:' . plugin_mastodon_sync_guard_kind($kind) . ':v1';
+}
+
+/**
+ * Return true when one guard entry is still active.
+ * @param mixed $entry
+ * @param int $now
+ * @return bool
+ */
+function plugin_mastodon_sync_guard_entry_active($entry, $now) {
+	return is_array($entry) && isset($entry ['expires_at']) && (int) $entry ['expires_at'] > (int) $now;
+}
+
+/**
+ * Store one cooldown guard in APCu.
+ * @param string $kind
+ * @param array<string, mixed> $entry
+ * @param int $now
+ * @return bool
+ */
+function plugin_mastodon_sync_guard_apcu_store($kind, $entry, $now) {
+	$ttl = isset($entry ['expires_at']) ? ((int) $entry ['expires_at'] - (int) $now) : PLUGIN_MASTODON_COOLDOWN_TTL;
+	if ($ttl < 1) {
+		return false;
+	}
+	return plugin_mastodon_apcu_store(plugin_mastodon_sync_guard_apcu_key($kind), $entry, $ttl);
+}
+
+/**
+ * Read and prune the file-backed cooldown guard.
+ * @param int $now
+ * @return array<string, array<string, mixed>>
+ */
+function plugin_mastodon_sync_guard_file_read($now) {
+	$prestat = plugin_mastodon_file_prestat(PLUGIN_MASTODON_GUARD_FILE);
+	if (empty($prestat ['exists'])) {
+		return array();
+	}
+	$json = plugin_mastodon_io_read_file_uncached(PLUGIN_MASTODON_GUARD_FILE, true);
+	if (!is_string($json) || trim($json) === '') {
+		return array();
+	}
+	$data = json_decode($json, true);
+	if (!is_array($data)) {
+		return array();
+	}
+	$guards = array();
+	foreach (array('content', 'deletion') as $kind) {
+		if (isset($data [$kind]) && plugin_mastodon_sync_guard_entry_active($data [$kind], $now)) {
+			$guards [$kind] = $data [$kind];
+		}
+	}
+	return $guards;
+}
+
+/**
+ * Write the file-backed cooldown guard.
+ * @param array<string, array<string, mixed>> $guards
+ * @return bool
+ */
+function plugin_mastodon_sync_guard_file_write($guards) {
+	plugin_mastodon_ensure_state_dir();
+	$payload = array('version' => 1);
+	foreach (array('content', 'deletion') as $kind) {
+		if (isset($guards [$kind]) && is_array($guards [$kind])) {
+			$payload [$kind] = $guards [$kind];
+		}
+	}
+	$json = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+	if (!is_string($json)) {
+		return false;
+	}
+	return plugin_mastodon_io_write_file(PLUGIN_MASTODON_GUARD_FILE, $json . PHP_EOL);
+}
+
+/**
+ * Return true when a recent scheduled sync/deletion pass should cool down.
+ * @param string $kind
+ * @param int|null $now
+ * @return bool
+ */
+function plugin_mastodon_sync_guard_active($kind, $now = null) {
+	$kind = plugin_mastodon_sync_guard_kind($kind);
+	$now = $now === null ? time() : (int) $now;
+
+	$hit = false;
+	$apcuEntry = plugin_mastodon_apcu_fetch(plugin_mastodon_sync_guard_apcu_key($kind), $hit);
+	if ($hit && plugin_mastodon_sync_guard_entry_active($apcuEntry, $now)) {
+		return true;
+	}
+
+	$guards = plugin_mastodon_sync_guard_file_read($now);
+	if (isset($guards [$kind]) && plugin_mastodon_sync_guard_entry_active($guards [$kind], $now)) {
+		plugin_mastodon_sync_guard_apcu_store($kind, $guards [$kind], $now);
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Mark a short cooldown guard for a scheduled sync/deletion pass.
+ * @param string $kind
+ * @param string $reason
+ * @param int|null $now
+ * @return bool
+ */
+function plugin_mastodon_sync_guard_mark($kind, $reason, $now = null) {
+	$kind = plugin_mastodon_sync_guard_kind($kind);
+	$now = $now === null ? time() : (int) $now;
+	$entry = array(
+		'started_at' => $now,
+		'expires_at' => $now + PLUGIN_MASTODON_COOLDOWN_TTL,
+		'reason' => trim((string) $reason)
+	);
+	$apcuOk = plugin_mastodon_sync_guard_apcu_store($kind, $entry, $now);
+	$guards = plugin_mastodon_sync_guard_file_read($now);
+	$guards [$kind] = $entry;
+	$fileOk = plugin_mastodon_sync_guard_file_write($guards);
+	return $apcuOk || $fileOk;
+}
+
+/**
+ * Clear one sync cooldown guard.
+ * @param string $kind
+ * @param int|null $now
+ * @return bool
+ */
+function plugin_mastodon_sync_guard_clear($kind, $now = null) {
+	$kind = plugin_mastodon_sync_guard_kind($kind);
+	$now = $now === null ? time() : (int) $now;
+	plugin_mastodon_apcu_delete(plugin_mastodon_sync_guard_apcu_key($kind));
+	$guards = plugin_mastodon_sync_guard_file_read($now);
+	if (isset($guards [$kind])) {
+		unset($guards [$kind]);
+	}
+	return plugin_mastodon_sync_guard_file_write($guards);
+}
+
+/**
+ * Return the default Mastodon API budgets for one synchronization run.
+ * @return array<string, int>
+ */
+function plugin_mastodon_rate_limit_default_budgets() {
+	$budgets = array(
+		'requests' => (int) PLUGIN_MASTODON_RUN_REQUEST_BUDGET,
+		'media_uploads' => (int) PLUGIN_MASTODON_RUN_MEDIA_UPLOAD_BUDGET,
+		'deletes' => (int) PLUGIN_MASTODON_RUN_DELETE_BUDGET,
+		'remote_remaining_floor' => (int) PLUGIN_MASTODON_RATE_LIMIT_REMAINING_FLOOR
+	);
+	if (isset($GLOBALS ['plugin_mastodon_test_rate_limit_budgets']) && is_array($GLOBALS ['plugin_mastodon_test_rate_limit_budgets'])) {
+		foreach ($budgets as $key => $value) {
+			if (isset($GLOBALS ['plugin_mastodon_test_rate_limit_budgets'] [$key]) && is_numeric($GLOBALS ['plugin_mastodon_test_rate_limit_budgets'] [$key])) {
+				$budgets [$key] = (int) $GLOBALS ['plugin_mastodon_test_rate_limit_budgets'] [$key];
+			}
+		}
+	}
+	foreach ($budgets as $key => $value) {
+		$budgets [$key] = max(0, (int) $value);
+	}
+	return $budgets;
+}
+
+/**
+ * Start a per-run Mastodon API rate-limit guard.
+ * @param string $scope
+ * @return void
+ */
+function plugin_mastodon_rate_limit_guard_start($scope) {
+	$budgets = plugin_mastodon_rate_limit_default_budgets();
+	$GLOBALS ['plugin_mastodon_rate_limit_guard'] = array(
+		'active' => true,
+		'scope' => trim((string) $scope),
+		'requests_budget' => $budgets ['requests'],
+		'requests_used' => 0,
+		'media_uploads_budget' => $budgets ['media_uploads'],
+		'media_uploads_used' => 0,
+		'deletes_budget' => $budgets ['deletes'],
+		'deletes_used' => 0,
+		'remote_remaining_floor' => $budgets ['remote_remaining_floor'],
+		'remote_limit' => null,
+		'remote_remaining' => null,
+		'remote_reset' => '',
+		'blocked_reason' => '',
+		'blocked_logged' => false
+	);
+}
+
+/**
+ * Stop the current per-run Mastodon API rate-limit guard while keeping its summary inspectable.
+ * @return void
+ */
+function plugin_mastodon_rate_limit_guard_stop() {
+	if (!isset($GLOBALS ['plugin_mastodon_rate_limit_guard']) || !is_array($GLOBALS ['plugin_mastodon_rate_limit_guard'])) {
+		return;
+	}
+	$GLOBALS ['plugin_mastodon_rate_limit_guard'] ['active'] = false;
+}
+
+/**
+ * Return whether a per-run Mastodon API rate-limit guard is active.
+ * @return bool
+ */
+function plugin_mastodon_rate_limit_guard_active() {
+	return isset($GLOBALS ['plugin_mastodon_rate_limit_guard']) && is_array($GLOBALS ['plugin_mastodon_rate_limit_guard']) && !empty($GLOBALS ['plugin_mastodon_rate_limit_guard'] ['active']);
+}
+
+/**
+ * Return the current rate-limit guard summary.
+ * @return array<string, mixed>
+ */
+function plugin_mastodon_rate_limit_guard_summary() {
+	return isset($GLOBALS ['plugin_mastodon_rate_limit_guard']) && is_array($GLOBALS ['plugin_mastodon_rate_limit_guard']) ? $GLOBALS ['plugin_mastodon_rate_limit_guard'] : array();
+}
+
+/**
+ * Normalize a response header map for rate-limit checks.
+ * @param mixed $headers
+ * @return array<string, string>
+ */
+function plugin_mastodon_rate_limit_headers($headers) {
+	$normalized = array();
+	if (!is_array($headers)) {
+		return $normalized;
+	}
+	foreach ($headers as $name => $value) {
+		$name = strtolower(trim((string) $name));
+		if ($name === '') {
+			continue;
+		}
+		$normalized [$name] = trim((string) $value);
+	}
+	return $normalized;
+}
+
+/**
+ * Determine whether a Mastodon API request consumes one of the stricter per-run budgets.
+ * @param string $method
+ * @param string $target
+ * @return string
+ */
+function plugin_mastodon_rate_limit_request_kind($method, $target) {
+	$method = strtoupper(trim((string) $method));
+	$target = (string) $target;
+	$path = $target;
+	if (preg_match('#^https?://#i', $path)) {
+		$parts = parse_url($path);
+		$path = isset($parts ['path']) ? (string) $parts ['path'] : '';
+	}
+	if ($method === 'POST' && preg_match('#/api/v[12]/media/?$#', $path)) {
+		return 'media_upload';
+	}
+	if (($method === 'DELETE' && preg_match('#/api/v1/statuses/[^/?]+#', $path)) || ($method === 'POST' && preg_match('#/api/v1/statuses/[^/?]+/unreblog#', $path))) {
+		return 'status_delete';
+	}
+	return 'request';
+}
+
+/**
+ * Mark the current rate-limit guard as blocked.
+ * @param string $reason
+ * @return string
+ */
+function plugin_mastodon_rate_limit_block($reason) {
+	$reason = trim((string) $reason);
+	if ($reason === '') {
+		$reason = 'rate_limit_budget_exhausted';
+	}
+	if (isset($GLOBALS ['plugin_mastodon_rate_limit_guard']) && is_array($GLOBALS ['plugin_mastodon_rate_limit_guard'])) {
+		$GLOBALS ['plugin_mastodon_rate_limit_guard'] ['blocked_reason'] = $reason;
+		if (empty($GLOBALS ['plugin_mastodon_rate_limit_guard'] ['blocked_logged'])) {
+			$summary = plugin_mastodon_rate_limit_guard_summary();
+			$message = 'Mastodon rate-limit guard stopped synchronization: ' . $reason;
+			if (!empty($summary)) {
+				$message .= ' (scope=' . (isset($summary ['scope']) ? (string) $summary ['scope'] : 'unknown')
+					. ', requests=' . (isset($summary ['requests_used']) ? (int) $summary ['requests_used'] : 0) . '/' . (isset($summary ['requests_budget']) ? (int) $summary ['requests_budget'] : 0)
+					. ', media_uploads=' . (isset($summary ['media_uploads_used']) ? (int) $summary ['media_uploads_used'] : 0) . '/' . (isset($summary ['media_uploads_budget']) ? (int) $summary ['media_uploads_budget'] : 0)
+					. ', deletes=' . (isset($summary ['deletes_used']) ? (int) $summary ['deletes_used'] : 0) . '/' . (isset($summary ['deletes_budget']) ? (int) $summary ['deletes_budget'] : 0);
+				if (isset($summary ['remote_remaining']) && $summary ['remote_remaining'] !== null) {
+					$message .= ', remote_remaining=' . (int) $summary ['remote_remaining'];
+				}
+				if (!empty($summary ['remote_reset'])) {
+					$message .= ', remote_reset=' . (string) $summary ['remote_reset'];
+				}
+				$message .= ')';
+			}
+			plugin_mastodon_log($message);
+			$GLOBALS ['plugin_mastodon_rate_limit_guard'] ['blocked_logged'] = true;
+		}
+	}
+	return $reason;
+}
+
+/**
+ * Reserve budget for one Mastodon API request.
+ * @param string $method
+ * @param string $target
+ * @return string Empty string means the request may proceed.
+ */
+function plugin_mastodon_rate_limit_acquire($method, $target) {
+	if (!plugin_mastodon_rate_limit_guard_active()) {
+		return '';
+	}
+	$guard = &$GLOBALS ['plugin_mastodon_rate_limit_guard'];
+	$kind = plugin_mastodon_rate_limit_request_kind($method, $target);
+	if (!empty($guard ['blocked_reason'])) {
+		$blockedReason = (string) $guard ['blocked_reason'];
+		if (!(($blockedReason === 'rate_limit_media_upload_budget_exhausted' && $kind !== 'media_upload') || ($blockedReason === 'rate_limit_delete_budget_exhausted' && $kind !== 'status_delete'))) {
+			return $blockedReason;
+		}
+	}
+	$remaining = isset($guard ['remote_remaining']) && is_numeric($guard ['remote_remaining']) ? (int) $guard ['remote_remaining'] : null;
+	$floor = isset($guard ['remote_remaining_floor']) ? max(0, (int) $guard ['remote_remaining_floor']) : 0;
+	if ($remaining !== null && $remaining <= $floor) {
+		return plugin_mastodon_rate_limit_block('rate_limit_remote_remaining_low');
+	}
+	if (isset($guard ['requests_budget']) && (int) $guard ['requests_budget'] > 0 && (int) $guard ['requests_used'] >= (int) $guard ['requests_budget']) {
+		return plugin_mastodon_rate_limit_block('rate_limit_request_budget_exhausted');
+	}
+	if ($kind === 'media_upload' && isset($guard ['media_uploads_budget']) && (int) $guard ['media_uploads_budget'] > 0 && (int) $guard ['media_uploads_used'] >= (int) $guard ['media_uploads_budget']) {
+		return plugin_mastodon_rate_limit_block('rate_limit_media_upload_budget_exhausted');
+	}
+	if ($kind === 'status_delete' && isset($guard ['deletes_budget']) && (int) $guard ['deletes_budget'] > 0 && (int) $guard ['deletes_used'] >= (int) $guard ['deletes_budget']) {
+		return plugin_mastodon_rate_limit_block('rate_limit_delete_budget_exhausted');
+	}
+	$guard ['requests_used'] = isset($guard ['requests_used']) ? ((int) $guard ['requests_used']) + 1 : 1;
+	if ($kind === 'media_upload') {
+		$guard ['media_uploads_used'] = isset($guard ['media_uploads_used']) ? ((int) $guard ['media_uploads_used']) + 1 : 1;
+	}
+	if ($kind === 'status_delete') {
+		$guard ['deletes_used'] = isset($guard ['deletes_used']) ? ((int) $guard ['deletes_used']) + 1 : 1;
+	}
+	return '';
+}
+
+/**
+ * Update the current per-run guard from Mastodon rate-limit response headers.
+ * @param array<string, mixed> $response
+ * @return void
+ */
+function plugin_mastodon_rate_limit_observe_response($response) {
+	if (!plugin_mastodon_rate_limit_guard_active()) {
+		return;
+	}
+	$response = is_array($response) ? $response : array();
+	$headers = plugin_mastodon_rate_limit_headers(isset($response ['headers']) ? $response ['headers'] : array());
+	if (isset($headers ['x-ratelimit-limit']) && is_numeric($headers ['x-ratelimit-limit'])) {
+		$GLOBALS ['plugin_mastodon_rate_limit_guard'] ['remote_limit'] = (int) $headers ['x-ratelimit-limit'];
+	}
+	if (isset($headers ['x-ratelimit-remaining']) && is_numeric($headers ['x-ratelimit-remaining'])) {
+		$GLOBALS ['plugin_mastodon_rate_limit_guard'] ['remote_remaining'] = (int) $headers ['x-ratelimit-remaining'];
+	}
+	if (isset($headers ['x-ratelimit-reset'])) {
+		$GLOBALS ['plugin_mastodon_rate_limit_guard'] ['remote_reset'] = (string) $headers ['x-ratelimit-reset'];
+	}
+	if ((isset($response ['code']) ? (int) $response ['code'] : 0) === 429) {
+		plugin_mastodon_rate_limit_block('rate_limit_remote_exhausted');
+	}
+}
+
+/**
+ * Return the current rate-limit block reason, if any.
+ * @return string
+ */
+function plugin_mastodon_rate_limit_blocked_reason() {
+	if (!isset($GLOBALS ['plugin_mastodon_rate_limit_guard']) || !is_array($GLOBALS ['plugin_mastodon_rate_limit_guard'])) {
+		return '';
+	}
+	return !empty($GLOBALS ['plugin_mastodon_rate_limit_guard'] ['blocked_reason']) ? (string) $GLOBALS ['plugin_mastodon_rate_limit_guard'] ['blocked_reason'] : '';
+}
+
+/**
+ * Build a synthetic API response for locally blocked Mastodon requests.
+ * @param string $reason
+ * @return array<string, mixed>
+ */
+function plugin_mastodon_rate_limit_blocked_response($reason) {
+	$reason = plugin_mastodon_rate_limit_block($reason);
+	$body = json_encode(array('error' => $reason));
+	return array(
+		'ok' => false,
+		'code' => 429,
+		'headers' => array(),
+		'body' => is_string($body) ? $body : '',
+		'error' => $reason
+	);
+}
+
+/**
+ * Return the rate-limit reason that should be written to sync state, if any.
+ * @return string
+ */
+function plugin_mastodon_rate_limit_state_error() {
+	$reason = plugin_mastodon_rate_limit_blocked_reason();
+	return $reason !== '' ? $reason : '';
 }
 
 /**
@@ -1764,6 +2263,12 @@ function plugin_mastodon_state_read() {
 	$prestat = plugin_mastodon_file_prestat(PLUGIN_MASTODON_STATE_FILE);
 	if (empty($prestat ['exists'])) {
 		plugin_mastodon_runtime_cache_clear('state');
+		$fallbackState = plugin_mastodon_state_fallback_read();
+		if ($fallbackState !== array()) {
+			plugin_mastodon_runtime_cache_set('state', '__signature__', 'apcu-fallback');
+			plugin_mastodon_runtime_cache_set('state', 'apcu-fallback', $fallbackState);
+			return $fallbackState;
+		}
 		return $defaults;
 	}
 
@@ -1780,15 +2285,24 @@ function plugin_mastodon_state_read() {
 
 	$json = plugin_mastodon_io_read_file_uncached(PLUGIN_MASTODON_STATE_FILE, !empty($prestat ['exists']));
 	if (!is_string($json) || trim($json) === '') {
+		$fallbackState = plugin_mastodon_state_fallback_read();
+		if ($fallbackState !== array()) {
+			return $fallbackState;
+		}
 		return $defaults;
 	}
 	$data = json_decode($json, true);
 	if (!is_array($data)) {
+		$fallbackState = plugin_mastodon_state_fallback_read();
+		if ($fallbackState !== array()) {
+			return $fallbackState;
+		}
 		return $defaults;
 	}
 	$state = plugin_mastodon_state_normalize($data);
 	plugin_mastodon_runtime_cache_set('state', '__signature__', $signature);
 	plugin_mastodon_runtime_cache_set('state', $signature, $state);
+	plugin_mastodon_state_fallback_store($state);
 	return $state;
 }
 
@@ -1807,6 +2321,7 @@ function plugin_mastodon_state_write($state) {
 	$payload = $json . PHP_EOL;
 	$written = plugin_mastodon_io_write_file(PLUGIN_MASTODON_STATE_FILE, $payload);
 	plugin_mastodon_runtime_cache_clear('state');
+	plugin_mastodon_state_fallback_store($state);
 	if ($written) {
 		$prestat = plugin_mastodon_file_prestat(PLUGIN_MASTODON_STATE_FILE);
 		$signature = plugin_mastodon_file_prestat_signature($prestat);
@@ -5937,7 +6452,13 @@ function plugin_mastodon_upload_media_items($options, $mediaItems, $limit) {
 		if (!empty($options ['access_token'])) {
 			$headers [] = 'Authorization: Bearer ' . $options ['access_token'];
 		}
-		$response = plugin_mastodon_http_request_multipart('POST', plugin_mastodon_normalize_instance_url(isset($options ['instance_url']) ? $options ['instance_url'] : '') . '/api/v2/media', $headers, $fields, plugin_mastodon_media_transfer_timeout($mediaType, $fileSize));
+		$rateLimitReason = plugin_mastodon_rate_limit_acquire('POST', '/api/v2/media');
+		if ($rateLimitReason !== '') {
+			$response = plugin_mastodon_rate_limit_blocked_response($rateLimitReason);
+		} else {
+			$response = plugin_mastodon_http_request_multipart('POST', plugin_mastodon_normalize_instance_url(isset($options ['instance_url']) ? $options ['instance_url'] : '') . '/api/v2/media', $headers, $fields, plugin_mastodon_media_transfer_timeout($mediaType, $fileSize));
+			plugin_mastodon_rate_limit_observe_response($response);
+		}
 		$data = json_decode(isset($response ['body']) ? $response ['body'] : '', true);
 		if (!is_array($data)) {
 			$data = array();
@@ -6504,7 +7025,12 @@ function plugin_mastodon_mastodon_api($options, $method, $path, $params, $auth) 
 		}
 	}
 
+	$rateLimitReason = plugin_mastodon_rate_limit_acquire($method, $path);
+	if ($rateLimitReason !== '') {
+		return plugin_mastodon_rate_limit_blocked_response($rateLimitReason);
+	}
 	$response = plugin_mastodon_http_request($method, $url, $headers, $body, $contentType);
+	plugin_mastodon_rate_limit_observe_response($response);
 	if (!$response ['ok']) {
 		plugin_mastodon_log('HTTP ' . $method . ' ' . $url . ' failed: ' . $response ['code'] . ' ' . $response ['error'] . ' ' . plugin_mastodon_limit_text($response ['body'], 400));
 	}
@@ -7399,7 +7925,8 @@ function plugin_mastodon_sync_remote_to_local(&$options, &$state) {
 	plugin_mastodon_extend_time_limit(180);
 	$verify = plugin_mastodon_verify_credentials($options);
 	if (!$verify ['ok'] || empty($verify ['json'] ['id'])) {
-		$state ['last_error'] = 'verify_credentials_failed';
+		$rateLimitError = plugin_mastodon_rate_limit_state_error();
+		$state ['last_error'] = $rateLimitError !== '' ? $rateLimitError : 'verify_credentials_failed';
 		return false;
 	}
 
@@ -7444,6 +7971,11 @@ function plugin_mastodon_sync_remote_to_local(&$options, &$state) {
 
 	if ($maxRemoteId !== '') {
 		$state ['last_remote_status_id'] = $maxRemoteId;
+	}
+	$rateLimitError = plugin_mastodon_rate_limit_state_error();
+	if ($rateLimitError !== '') {
+		$state ['last_error'] = $rateLimitError;
+		return false;
 	}
 	return true;
 }
@@ -7645,7 +8177,11 @@ function plugin_mastodon_sync_local_to_remote(&$options, &$state) {
 		}
 	}
 
-	return !$hadFailure;
+	$rateLimitError = plugin_mastodon_rate_limit_state_error();
+	if ($rateLimitError !== '' && !$hadFailure) {
+		$state ['last_error'] = $rateLimitError;
+	}
+	return !$hadFailure && $rateLimitError === '';
 }
 
 /**
@@ -7678,6 +8214,12 @@ function plugin_mastodon_run_deletion_sync($force) {
 	if (!$force && empty($state ['deletions_pending'])) {
 		return array('ok' => true, 'state' => $state, 'message' => 'no_deletions_pending');
 	}
+	if (!$force && plugin_mastodon_sync_guard_active('deletion')) {
+		return array('ok' => true, 'state' => $state, 'message' => 'deletion_sync_cooldown');
+	}
+	if (!$force) {
+		plugin_mastodon_sync_guard_mark('deletion', 'scheduled_deletion_sync');
+	}
 
 	plugin_mastodon_ensure_state_dir();
 	$lockHandle = @fopen(PLUGIN_MASTODON_LOCK_FILE, 'c+');
@@ -7686,10 +8228,12 @@ function plugin_mastodon_run_deletion_sync($force) {
 		plugin_mastodon_state_write($state);
 		return array('ok' => false, 'state' => $state, 'message' => 'lock_open_failed');
 	}
+	plugin_mastodon_apply_file_permissions(PLUGIN_MASTODON_LOCK_FILE);
 	if (!@flock($lockHandle, LOCK_EX | LOCK_NB)) {
 		return array('ok' => true, 'state' => $state, 'message' => 'sync_locked');
 	}
 
+	plugin_mastodon_rate_limit_guard_start('deletion_sync');
 	$state ['last_error'] = '';
 	$state ['deletion_stats'] = plugin_mastodon_default_state() ['deletion_stats'];
 	$hadFailure = false;
@@ -7815,6 +8359,13 @@ function plugin_mastodon_run_deletion_sync($force) {
 	}
 
 	$pendingCommentRechecksRemaining = plugin_mastodon_process_pending_comment_remote_rechecks($options, $state, $childIndex, $hadFailure);
+	$rateLimitError = plugin_mastodon_rate_limit_state_error();
+	if ($rateLimitError !== '') {
+		$hadFailure = true;
+		if ($state ['last_error'] === '') {
+			$state ['last_error'] = $rateLimitError;
+		}
+	}
 
 	if (!$hadFailure) {
 		$state ['last_deletion_run'] = date('Y-m-d H:i:s');
@@ -7837,11 +8388,17 @@ function plugin_mastodon_run_deletion_sync($force) {
 		plugin_mastodon_log('Deletion synchronization failed');
 	}
 
-	plugin_mastodon_state_write($state);
+	$stateWriteOk = plugin_mastodon_state_write($state);
+	if (!$stateWriteOk && !$hadFailure) {
+		$state ['last_error'] = 'state_write_failed_after_deletion_sync';
+		plugin_mastodon_state_fallback_store($state);
+		plugin_mastodon_log('Deletion synchronization completed but state.json could not be persisted');
+	}
 	@flock($lockHandle, LOCK_UN);
 	@fclose($lockHandle);
+	plugin_mastodon_rate_limit_guard_stop();
 
-	return array('ok' => !$hadFailure, 'state' => $state, 'message' => $state ['last_error'] === '' ? 'ok' : $state ['last_error']);
+	return array('ok' => (!$hadFailure && $stateWriteOk), 'state' => $state, 'message' => $state ['last_error'] === '' ? 'ok' : $state ['last_error']);
 }
 
 /**
@@ -7892,6 +8449,12 @@ function plugin_mastodon_run_sync($force) {
 	if (!$force && !plugin_mastodon_sync_due($options, $state, time())) {
 		return array('ok' => true, 'state' => $state, 'message' => 'not_due');
 	}
+	if (!$force && plugin_mastodon_sync_guard_active('content')) {
+		return array('ok' => true, 'state' => $state, 'message' => 'sync_cooldown');
+	}
+	if (!$force) {
+		plugin_mastodon_sync_guard_mark('content', 'scheduled_content_sync');
+	}
 
 	plugin_mastodon_ensure_state_dir();
 	$lockHandle = @fopen(PLUGIN_MASTODON_LOCK_FILE, 'c+');
@@ -7900,10 +8463,12 @@ function plugin_mastodon_run_sync($force) {
 		plugin_mastodon_state_write($state);
 		return array('ok' => false, 'state' => $state, 'message' => 'lock_open_failed');
 	}
+	plugin_mastodon_apply_file_permissions(PLUGIN_MASTODON_LOCK_FILE);
 	if (!@flock($lockHandle, LOCK_EX | LOCK_NB)) {
 		return array('ok' => true, 'state' => $state, 'message' => 'sync_locked');
 	}
 
+	plugin_mastodon_rate_limit_guard_start('content_sync');
 	$state ['last_error'] = '';
 	$state ['content_stats'] = plugin_mastodon_default_state() ['content_stats'];
 
@@ -7928,11 +8493,17 @@ function plugin_mastodon_run_sync($force) {
 		plugin_mastodon_log('Synchronization failed');
 	}
 
-	plugin_mastodon_state_write($state);
+	$stateWriteOk = plugin_mastodon_state_write($state);
+	if (!$stateWriteOk && $okRemote && $okLocal) {
+		$state ['last_error'] = 'state_write_failed_after_sync';
+		plugin_mastodon_state_fallback_store($state);
+		plugin_mastodon_log('Synchronization completed but state.json could not be persisted');
+	}
 	@flock($lockHandle, LOCK_UN);
 	@fclose($lockHandle);
+	plugin_mastodon_rate_limit_guard_stop();
 
-	return array('ok' => ($okRemote && $okLocal), 'state' => $state, 'message' => $state ['last_error'] === '' ? 'ok' : $state ['last_error']);
+	return array('ok' => ($okRemote && $okLocal && $stateWriteOk), 'state' => $state, 'message' => $state ['last_error'] === '' ? 'ok' : $state ['last_error']);
 }
 
 /**


### PR DESCRIPTION
- APCu- and file-based cooldown guard for scheduled content and deletion synchronizations, ensuring that synchronization does not occur again with every web request under unfavorable conditions.
- Rate-limit guard with request budget, media upload budget, and delete budget per run.