### PR TITLE
Update Mastodon to version 2.4.1 | Performance Update

### DIFF
--- a/fp-includes/core/core.comment.php
+++ b/fp-includes/core/core.comment.php
@@ -248,12 +248,22 @@ function comment_save($id, $comment) {
 		$comment ['DATE'] = date_time();
 	}
 	$comment_id = bdb_idfromtime(BDB_COMMENT, $comment ['DATE']);
+	$old_comment = comment_parse($entryid, $comment_id);
+	$is_update = is_array($old_comment);
 	$f = $comment_dir . $comment_id . EXT;
 	$str = utils_kimplode($comment);
 	if (io_write_file($f, $str)) {
 		// Invalidate cached comment count for this entry (file cache + APCu).
 		@unlink(comment_count_cachefile($entryid));
 		do_action('comment_save', $entryid, $comment_id);
+		$saved_comment = comment_parse($entryid, $comment_id);
+		if (!is_array($saved_comment)) {
+			$saved_comment = array_change_key_case($comment, CASE_LOWER);
+		}
+		if (!is_array($old_comment)) {
+			$old_comment = array();
+		}
+		do_action('comment_saved', $entryid, $comment_id, $saved_comment, $old_comment, $is_update);
 		return $comment_id;
 	}
 
@@ -277,12 +287,16 @@ function comment_save($id, $comment) {
 function comment_delete($id, $comment_id) {
 	// Pre-delete event
 	do_action('comment_delete', $id, $comment_id);
+	$old_comment = comment_parse($id, $comment_id);
+	if (!is_array($old_comment)) {
+		$old_comment = array();
+	}
 	$comment_dir = bdb_idtofile($id, BDB_COMMENT);
 	$f = $comment_dir . $comment_id . EXT;
 	$ok = fs_delete($f);
 	if ($ok) {
 		// Post-delete event for cache invalidation
-		do_action('comment_deleted', $id, $comment_id);
+		do_action('comment_deleted', $id, $comment_id, $old_comment);
 		@unlink(comment_count_cachefile($id));
 	}
 	return $ok;

--- a/fp-includes/core/core.entry.php
+++ b/fp-includes/core/core.entry.php
@@ -344,13 +344,13 @@ function entry_timetokey($time) {
 }
 
 function entry_keytotime($key) {
-	$arr ['y'] = substr($key, 0, 2);
-	$arr ['m'] = substr($key, 2, 2);
-	$arr ['d'] = substr($key, 4, 2);
+	$arr ['y'] = (int) substr($key, 0, 2);
+	$arr ['m'] = (int) substr($key, 2, 2);
+	$arr ['d'] = (int) substr($key, 4, 2);
 
-	$arr ['H'] = substr($key, 6, 2);
-	$arr ['M'] = substr($key, 8, 2);
-	$arr ['S'] = substr($key, 10, 2);
+	$arr ['H'] = (int) substr($key, 6, 2);
+	$arr ['M'] = (int) substr($key, 8, 2);
+	$arr ['S'] = (int) substr($key, 10, 2);
 
 	return mktime($arr ['H'], $arr ['M'], $arr ['S'], $arr ['m'], $arr ['d'], $arr ['y']);
 }
@@ -785,12 +785,17 @@ function entry_save($entry, $id = null, $update_index = true) {
 	$delete_cats = array();
 	$all_cats = @$entry ['categories'];
 	$update_title = true;
-	if ($old_entry = entry_parse($id)) {
+	$old_entry = entry_parse($id);
+	$is_update = is_array($old_entry);
+	if ($is_update) {
+		$old_cats = (isset($old_entry ['categories']) && is_array($old_entry ['categories'])) ? $old_entry ['categories'] : array();
 		if ($all_cats) {
-			$delete_cats = array_diff($old_entry ['categories'], $all_cats);
+			$delete_cats = array_diff($old_cats, $all_cats);
 		}
-		$all_cats = $all_cats ? array_merge($all_cats, $old_entry ['categories']) : $old_entry ['categories'];
-		$update_title = $entry ['subject'] != $old_entry ['subject'];
+		$all_cats = $all_cats ? array_merge($all_cats, $old_cats) : $old_cats;
+		$entry_subject = isset($entry ['subject']) ? (string) $entry ['subject'] : '';
+		$old_subject = isset($old_entry ['subject']) ? (string) $old_entry ['subject'] : '';
+		$update_title = $entry_subject != $old_subject;
 	}
 
 	/**
@@ -838,6 +843,14 @@ function entry_save($entry, $id = null, $update_index = true) {
 		} else {
 			// SUCCESS : delete draft, move comments along
 			draft_to_entry($id);
+			$saved_entry = entry_parse($id);
+			if (!is_array($saved_entry)) {
+				$saved_entry = $entry;
+			}
+			if (!is_array($old_entry)) {
+				$old_entry = array();
+			}
+			do_action('entry_saved', $id, $saved_entry, $old_entry, $is_update);
 			return $id;
 		}
 	}
@@ -861,15 +874,24 @@ function entry_delete($id) {
 	 * $f = bdb_idtofile($id);
 	 */
 
+	$old_entry = entry_parse($id);
+	if (!is_array($old_entry)) {
+		$old_entry = array();
+	}
+
 	$d = entry_dir($id);
 	fs_delete_recursive($d);
 
 	$obj = & entry_init();
-	$obj->delete($id, entry_parse($id));
+	$obj->delete($id, $old_entry);
 
 	do_action('delete_post', $id);
 
-	return fs_delete($f);
+	$deleted = fs_delete($f);
+	if ($deleted) {
+		do_action('entry_deleted', $id, $old_entry);
+	}
+	return $deleted;
 }
 
 function entry_purge_cache() {

--- a/fp-plugins/mastodon/Function-Organigram.md
+++ b/fp-plugins/mastodon/Function-Organigram.md
@@ -10,10 +10,11 @@ The layout is intentionally hierarchical so responsibilities, call paths, and im
 
 - The focus is the Mastodon plugin PHP code.
 - The document is organized by responsibility and call path.
-- Recently added FlatPress configuration reuse, centralized plugin-state detection, FlatPress I/O helpers, explicit `FILE_PERMISSIONS` handling for Mastodon runtime files, APCu-backed last-known-good state fallback, and file-backed synchronization cooldown guards are reflected explicitly.
+- The lightweight `scheduler-state.json` request-time summary is covered separately from the full `state.json` synchronization mapping state.
+- Recently added FlatPress configuration reuse, centralized plugin-state detection, FlatPress I/O helpers, explicit `FILE_PERMISSIONS` handling for Mastodon runtime files, the compact APCu-capable scheduler-state summary, append-only rotated sync logging, and file-backed synchronization cooldown guards are reflected explicitly.
 - The companion-plugin diagnostics for BBCode, PhotoSwipe, AudioVideo, Tag, and Emoticons are covered.
 - The admin-side Mastodon instance-information snapshot, manual refresh button, exact-version display, and reuse of cached instance capabilities for later sync runs are covered.
-- Mastodon instance-dependent URL budgeting, bounded PHP execution-budget refreshes, central per-run Mastodon API rate-limit guards with request/media-upload/delete budgets, persistent cross-run media-upload/delete/account-status-page windows, OAuth scope discovery with a strict `profile`-scope preference and an older-instance fallback to `read:accounts`, media-type-aware asynchronous media-upload readiness polling for longer AudioVideo processing, AudioVideo optional endtag descriptions for local export and remote import, scheduled-run recent-content windows, dirty queues for changed older mapped content, optional rotating known-thread reply checks, best-effort cleanup of unattached uploaded Mastodon media before a failed final posting finishes, follow-up deletion synchronization with scheduled-window-limited remote existence lookups and progress cursors for large mapping sets, the admin toggle that can disable deletion synchronization, comment tombstones that block stale re-imports of deleted remote replies, early protection of locally deleted exported FlatPress comments before the next content sync, local reattachment of surviving descendant replies to the synchronized entry status during deletion follow-up, targeted descendant-recheck queues with a dedicated `comment_rechecks` follow-up scope, 5-minute scheduled-sync cooldown guards, state-write failure reporting, and the separate persistence of content-sync and deletion-sync counters are reflected explicitly.
+- Mastodon instance-dependent URL budgeting, bounded PHP execution-budget refreshes, central per-run Mastodon API rate-limit guards with request/media-upload/delete budgets, persistent cross-run media-upload/delete/account-status-page windows, OAuth scope discovery with a strict `profile`-scope preference and an older-instance fallback to `read:accounts`, media-type-aware asynchronous media-upload readiness polling for longer AudioVideo processing, AudioVideo optional endtag descriptions for local export and remote import, scheduled-run recent-content windows, Core post-success-hook-driven dirty queues for changed older mapped content, a Mastodon local-write guard for remote mirror operations, targeted non-full local candidate lists, optional rotating known-thread reply checks, best-effort cleanup of unattached uploaded Mastodon media before a failed final posting finishes, follow-up deletion synchronization with scheduled-window-limited remote existence lookups and progress cursors for large mapping sets, the admin toggle that can disable deletion synchronization, comment tombstones that block stale re-imports of deleted remote replies, early protection of locally deleted exported FlatPress comments before the next content sync, local reattachment of surviving descendant replies to the synchronized entry status during deletion follow-up, targeted descendant-recheck queues with a dedicated `comment_rechecks` follow-up scope, 5-minute scheduled-sync cooldown guards, state-write failure reporting, and the separate persistence of content-sync and deletion-sync counters are reflected explicitly.
 - FlatPress timeoffset-aware remote import timestamps for Mastodon statuses and replies are reflected explicitly.
 - FlatPress-local admin time display for the daily synchronization time, last content sync, and last deletion sync is reflected explicitly while keeping the stored synchronization time in UTC.
 - Friendly deletion-sync guards for normalized comment mapping metadata are reflected explicitly.
@@ -54,8 +55,8 @@ Current export behavior uses these endpoints in a version-aware way:
 
 ## Function count
 
-The plugin file currently contains **314** callable functions/methods documented in this organigram:
-- **311** top-level plugin functions
+The plugin file currently contains **337** callable functions/methods documented in this organigram:
+- **334** top-level plugin functions
 - **3** admin panel class methods (`setup()`, `main()`, `onsubmit()`)
 
 ## High-level call flow
@@ -68,15 +69,16 @@ The plugin file currently contains **314** callable functions/methods documented
   - `<meta name="fediverse:creator" ...>`
 
 - `plugin_mastodon_maybe_sync()`  
-  Reads the saved state for the current request and then either:
+  Reads only the compact scheduler-state summary for normal non-POST frontend requests and then either:
   - runs `plugin_mastodon_run_sync()` when the scheduled content sync is due, or
   - runs `plugin_mastodon_run_deletion_sync()` in a later follow-up request when deletion work is pending and its persisted not-before timestamp has passed.
+  The full `state.json` mapping state is loaded only after a real synchronization path starts or when the scheduler summary is missing/stale and must be rebuilt conservatively.
 
 - `plugin_mastodon_run_sync()`  
   Refreshes the shared-request PHP execution budget through `plugin_mastodon_extend_time_limit()`, protects locally deleted exported FlatPress comment mappings through `plugin_mastodon_protect_locally_deleted_exported_comments()` so stale Mastodon thread context cannot resurrect them during the same request, and then executes the two main directions in order:
   1. `plugin_mastodon_sync_remote_to_local()`
   2. `plugin_mastodon_sync_local_to_remote()`
-  The first boolean argument means "explicitly triggered / bypass the daily due check"; the optional second boolean controls whether the automatic scheduled window is ignored. This keeps normal admin-triggered synchronization aligned with scheduled behavior (`true, false`) while preserving explicit full checks (`true, true`). Non-forced scheduled runs are gated by `plugin_mastodon_sync_guard_active()` and mark a 5-minute `content` cooldown through `plugin_mastodon_sync_guard_mark()` before network work starts. After acquiring the sync lock, the function starts a per-run Mastodon API guard through `plugin_mastodon_rate_limit_guard_start()`, so general requests, media uploads, status deletes, persistent cross-run media/delete windows, persistent account-status paging windows, and Mastodon `X-RateLimit-*` headers can stop the run cleanly. If both directions finish successfully, the function marks a follow-up deletion pass as pending for a later web request and stores a `deletions_not_before` timestamp at least 5 minutes after the completed content sync. A completed sync is reported as failed if `plugin_mastodon_state_write()` cannot persist the updated state; the updated state is still placed in the short APCu fallback cache when APCu is available.
+  The first boolean argument means "explicitly triggered / bypass the daily due check"; the optional second boolean controls whether the automatic scheduled window is ignored. This keeps normal admin-triggered synchronization aligned with scheduled behavior (`true, false`) while preserving explicit full checks (`true, true`). Non-forced scheduled runs are gated by `plugin_mastodon_sync_guard_active()` and mark a 5-minute `content` cooldown through `plugin_mastodon_sync_guard_mark()` before network work starts. After acquiring the sync lock, the function starts a per-run Mastodon API guard through `plugin_mastodon_rate_limit_guard_start()`, so general requests, media uploads, status deletes, persistent cross-run media/delete windows, persistent account-status paging windows, and Mastodon `X-RateLimit-*` headers can stop the run cleanly. If both directions finish successfully, the function marks a follow-up deletion pass as pending for a later web request and stores a `deletions_not_before` timestamp at least 5 minutes after the completed content sync. A completed sync is reported as failed if `plugin_mastodon_state_write()` cannot persist the updated state; the plugin no longer places the full mapping state into APCu.
 
 - `plugin_mastodon_run_deletion_sync()`  
   Runs the real deletion synchronization in a separate follow-up request. It first checks `plugin_mastodon_should_run_deletion_sync()` so the user-controlled admin toggle can disable the delete pass, then checks `plugin_mastodon_deletion_sync_due()` so the delete pass cannot start before the persisted 5-minute separation window has passed. It applies the same 5-minute cooldown guard with the `deletion` kind for non-forced scheduled runs, starts the per-run Mastodon API guard after acquiring the sync lock, and every remote status delete must pass both the per-run delete budget and the persistent cross-run delete window. It resets only `deletion_stats` while preserving `content_stats` from the last content sync, gates all mapped items through `plugin_mastodon_mapping_matches_sync_start()` so the delete pass stays inside the manual sync-start window, and uses `plugin_mastodon_mapping_matches_deletion_lookup_window()` to limit only remote existence lookups for still-existing local items to the automatic scheduled 7/14/30-day window. Local deletions are still propagated to Mastodon when they are inside the manual sync-start range, even if they are outside the automatic scheduled window. Large full delete passes advance through `deletion_cursor_entries` and `deletion_cursor_comments` via `plugin_mastodon_mapping_keys_after_cursor()`, so later runs continue after the last successfully checked mapping instead of repeating the first batch. The function then either runs the full reconciliation pass or a targeted `comment_rechecks` follow-up scope via `plugin_mastodon_state_has_comment_recheck_scope()`. Direct descendants of newly deleted replies are queued with `plugin_mastodon_queue_comment_descendant_remote_rechecks()`, surviving direct child replies can be reattached to the synchronized entry status through `plugin_mastodon_reattach_local_comment_to_entry_status()`, and pending deep-thread cleanup is processed breadth-first through `plugin_mastodon_process_pending_comment_remote_rechecks()`. A successful delete pass is reported as failed if the resulting state cannot be persisted.
@@ -85,9 +87,9 @@ The plugin file currently contains **314** callable functions/methods documented
 
 - `plugin_mastodon_sync_local_to_remote()`
   - loads options and persisted state
-  - retrieves export candidates with `plugin_mastodon_list_local_entries()`
+  - retrieves export candidates with `plugin_mastodon_list_local_entries_for_sync()`: scheduled/non-full runs parse only the active recent-content window plus dirty-entry targets, while explicit full repair runs keep the complete local scan
   - applies the permanent `sync_start_date` lower bound and, for scheduled non-forced runs, the selected 7/14/30-day recent-content window
-  - queues changed older mapped entries and comments through the dirty queue so edits outside the scheduled window are still sent to Mastodon without exporting unrelated old content
+  - relies on Core post-success hooks to queue changed older mapped entries/comments and local mapped deletions, so scheduled/non-full runs do not parse all old files merely to discover dirty work
   - orders entries with `plugin_mastodon_compare_local_entries_for_export()`
   - builds entry text with `plugin_mastodon_build_entry_status_text()`
   - budgets status length via `plugin_mastodon_instance_url_reserved_length()`, `plugin_mastodon_status_text_length()`, and `plugin_mastodon_limit_status_text()`
@@ -126,9 +128,13 @@ The plugin file currently contains **314** callable functions/methods documented
   - refreshes newly fetched thread contexts immediately and, when enabled in the admin panel, refreshes older known synchronized threads through `plugin_mastodon_collect_known_entry_context_targets()` in bounded rotating batches while still skipping mappings outside the configured synchronization start-date window
   - aborts the import direction with the rate-limit reason when the central per-run guard has blocked further API work
 
+### FlatPress Core post-success dirty-tracking hooks
+
+The FlatPress Core emits the new `entry_saved`, `entry_deleted`, `comment_saved`, and `comment_deleted` hooks only after the corresponding write/delete operation has succeeded. The Mastodon plugin handlers use these hooks to persist dirty queues for changed older mapped entries/comments and deletion follow-up work. Remote import/delete code wraps its own FlatPress writes in a depth-based local-write guard so Mastodon mirror operations do not look like local manual edits.
+
 ### Admin panel flow
 
-- `plugin_mastodon_admin_assign()` assigns the plugin data for the Smarty view, including companion-plugin diagnostics, the scheduled-window radio choices, the known-thread reply-check toggle, cached Mastodon instance-information rows, and cache-state/error metadata.
+- `plugin_mastodon_admin_assign()` assigns the plugin data for the Smarty view, including companion-plugin diagnostics, the scheduled-window radio choices, the known-thread reply-check toggle, compact scheduler-state status/statistics, cached Mastodon instance-information rows, and cache-state/error metadata.
 - `setup()` registers the admin template and delegates to `plugin_mastodon_admin_assign()`.
 - `main()` keeps the FlatPress admin lifecycle stable.
 - `onsubmit()` handles:
@@ -143,339 +149,370 @@ The plugin file currently contains **314** callable functions/methods documented
 
 ## A. Entry points and admin integration
 
-- `plugin_mastodon_head()` — line 2106 — Print Mastodon profile metadata into the HTML head.
-- `plugin_mastodon_maybe_sync()` — line 9239 — Run the scheduled synchronization when the current request is due.
-- `plugin_mastodon_run_sync()` — line 9159 — Run a full synchronization cycle.
-- `plugin_mastodon_run_deletion_sync()` — line 8847 — Run the deferred deletion synchronization in a follow-up request after content sync completed, with scheduled-window-limited remote existence lookups and progress cursors.
-- `plugin_mastodon_sync_due()` — line 9137 — Determine whether the scheduled synchronization is currently due.
-- `plugin_mastodon_admin_assign()` — line 9401 — Assign plugin data to Smarty for the admin panel, including cached instance-information rows.
-- `setup()` — line 9453 — Register the Mastodon admin panel template and assign plugin data to Smarty.
-- `main()` — line 9458 — Keep the admin panel lifecycle compatible with FlatPress without extra processing.
-- `onsubmit()` — line 9462 — Process configuration saves, OAuth actions, authorization-code exchange, manual instance-information refreshes, and the manual synchronization trigger.
+- `plugin_mastodon_head()` — line 2216 — Print Mastodon profile metadata into the HTML head.
+- `plugin_mastodon_maybe_sync()` — line 9915 — Run the scheduled synchronization when the current request is due, using the compact scheduler summary before any full state load.
+- `plugin_mastodon_run_sync()` — line 9832 — Run a full synchronization cycle.
+- `plugin_mastodon_run_deletion_sync()` — line 9501 — Run the deferred deletion synchronization in a follow-up request after content sync completed, with scheduled-window-limited remote existence lookups and progress cursors.
+- `plugin_mastodon_sync_due()` — line 9802 — Determine whether the scheduled synchronization is currently due.
+- `plugin_mastodon_admin_boolean_label()` — line 9947 — Return a localized yes/no/unknown label for admin diagnostics.
+- `plugin_mastodon_admin_add_info_row()` — line 9962 — Add one populated admin diagnostics row to the instance-information table.
+- `plugin_mastodon_admin_assign()` — line 10081 — Assign plugin data to Smarty for the admin panel, including compact scheduler status/statistics and cached instance-information rows.
+- `setup()` — line 10129 — Register the Mastodon admin panel template and assign plugin data to Smarty.
+- `main()` — line 10134 — Keep the admin panel lifecycle compatible with FlatPress without extra processing.
+- `onsubmit()` — line 10138 — Process configuration saves, OAuth actions, authorization-code exchange, manual instance-information refreshes, and the manual synchronization trigger.
 
 ## B. Defaults, configuration, secrets, and centralized FlatPress feature toggles
 
-- `plugin_mastodon_default_options()` — line 101 — Return the default plugin option values.
-- `plugin_mastodon_clear_saved_instance_info()` — line 133 — Remove persisted instance-information snapshots and related admin refresh errors from an option array.
-- `plugin_mastodon_compact_instance_document()` — line 152 — Reduce `/api/v2/instance` responses to the stable subset reused by the plugin and admin table.
-- `plugin_mastodon_saved_instance_document()` — line 357 — Decode the persisted compact instance snapshot from the saved plugin configuration.
-- `plugin_mastodon_store_instance_document()` — line 402 — Persist a compact instance-information snapshot in the FlatPress plugin configuration and warm request/APCu caches.
-- `plugin_mastodon_store_instance_error()` — line 448 — Persist the latest instance-information refresh failure for the admin diagnostics view.
-- `plugin_mastodon_refresh_instance_information()` — line 464 — Force a live `/api/v2/instance` refresh, compact the response, and store it for later requests.
-- `plugin_mastodon_default_content_stats()` — line 484 — Return the default counters for the last content synchronization.
-- `plugin_mastodon_default_deletion_stats()` — line 501 — Return the default counters for the last deletion synchronization.
-- `plugin_mastodon_default_state()` — line 514 — Return the default runtime state structure, including the targeted deletion-follow-up scope marker and deletion progress cursors.
-- `plugin_mastodon_oauth_legacy_scopes()` — line 542 — Return the legacy OAuth scope string used before scope discovery was added.
-- `plugin_mastodon_oauth_profile_scopes()` — line 550 — Return the stricter OAuth scope string that uses `profile` for `verify_credentials`.
-- `plugin_mastodon_oauth_server_metadata()` — line 559 — Discover and cache OAuth authorization-server metadata from `/.well-known/oauth-authorization-server`.
-- `plugin_mastodon_oauth_supported_scopes()` — line 578 — Parse the discoverable OAuth scopes supported by the configured Mastodon instance.
-- `plugin_mastodon_oauth_scope_supported()` — line 615 — Check whether the configured Mastodon instance advertises support for a specific OAuth scope.
-- `plugin_mastodon_oauth_preferred_scopes()` — line 636 — Prefer the narrow `profile` scope on current instances and fall back to `read:accounts` on older ones.
-- `plugin_mastodon_oauth_scopes()` — line 653 — Return the OAuth scopes that the currently registered app may safely request.
-- `plugin_mastodon_fp_config()` — line 730 — Return the FlatPress configuration, preferring the early-loaded core cache.
-- `plugin_mastodon_fp_config_value()` — line 766 — Read a nested FlatPress configuration value.
-- `plugin_mastodon_fp_timeoffset_seconds()` — line 782 — Return the configured FlatPress time offset in seconds for exact local admin-time conversion.
-- `plugin_mastodon_fp_timeoffset_label()` — line 802 — Format the configured FlatPress time offset as a UTC label for admin users.
-- `plugin_mastodon_sync_time_to_minutes()` — line 832 — Convert a normalized `HH:MM` sync-time value into minutes after midnight.
-- `plugin_mastodon_minutes_to_sync_time()` — line 843 — Convert minutes after midnight back into a normalized `HH:MM` sync-time value.
-- `plugin_mastodon_sync_time_utc_to_local()` — line 859 — Convert the stored UTC synchronization time to the FlatPress-local admin time.
-- `plugin_mastodon_sync_time_local_to_utc()` — line 870 — Convert the FlatPress-local admin synchronization time back to stored UTC.
-- `plugin_mastodon_format_admin_datetime()` — line 881 — Format stored UTC timestamps for the admin panel using FlatPress `timeoffset`, date format, and time format.
-- `plugin_mastodon_fp_timeoffset_hours()` — line 794 — Return the configured FlatPress time offset in whole hours.
-- `plugin_mastodon_get_options()` — line 1748 — Load the saved plugin options and merge them with defaults.
-- `plugin_mastodon_save_options()` — line 1807 — Persist plugin options, invalidate mismatching instance snapshots on URL changes, and keep matching refreshed snapshots.
-- `plugin_mastodon_secret_key()` — line 1899 — Build the encryption key used for stored secrets.
-- `plugin_mastodon_secret_encode()` — line 1916 — Encode a secret value before storing it in the configuration.
-- `plugin_mastodon_secret_decode()` — line 1939 — Decode a previously stored secret value.
-- `plugin_mastodon_normalize_instance_url()` — line 1970 — Normalize the configured Mastodon instance URL.
-- `plugin_mastodon_normalize_head_username()` — line 2003 — Normalize the configured Mastodon username for HTML head metadata.
-- `plugin_mastodon_instance_authority()` — line 2042 — Return the Mastodon instance authority used in fediverse creator metadata.
-- `plugin_mastodon_profile_url()` — line 2072 — Build the public Mastodon profile URL used for the rel-me link.
-- `plugin_mastodon_fediverse_creator_value()` — line 2088 — Build the fediverse creator meta value.
-- `plugin_mastodon_normalize_status_language()` — line 2146 — Normalize a FlatPress locale string to a Mastodon-compatible ISO 639-1 code.
-- `plugin_mastodon_configured_status_language()` — line 2168 — Read the configured FlatPress locale and return the Mastodon language code.
-- `plugin_mastodon_normalize_sync_time()` — line 2188 — Normalize the configured daily sync time.
-- `plugin_mastodon_normalize_sync_start_date()` — line 2205 — Normalize the configured sync start date.
-- `plugin_mastodon_normalize_scheduled_window_days()` — line 2231 — Normalize the configured 7/14/30-day automatic window for scheduled runs.
-- `plugin_mastodon_scheduled_window_choices()` — line 2243 — Return the localized admin radio choices for the scheduled synchronization window.
-- `plugin_mastodon_normalize_boolean_option()` — line 2256 — Normalize a boolean-like option value to the stored string representation.
-- `plugin_mastodon_normalize_update_local_from_remote()` — line 2272 — Normalize the toggle that controls whether existing local content may be updated from remote Mastodon data.
-- `plugin_mastodon_should_update_local_from_remote()` — line 2281 — Check whether remote Mastodon updates may overwrite already existing local FlatPress content.
-- `plugin_mastodon_normalize_import_synced_comments_as_entries()` — line 2290 — Normalize the toggle that allows importing already synchronized local comments as entries.
-- `plugin_mastodon_should_import_synced_comments_as_entries()` — line 2299 — Check whether a remote Mastodon status that is already mapped to a local FlatPress comment may also be imported as an entry.
-- `plugin_mastodon_normalize_quote_imported_reply_parent()` — line 2308 — Normalize the toggle that controls whether imported Mastodon replies should quote the replied-to comment.
-- `plugin_mastodon_should_quote_imported_reply_parent()` — line 2317 — Check whether imported Mastodon replies should include a quote of the replied-to comment.
-- `plugin_mastodon_normalize_old_thread_reply_check()` — line 2326 — Normalize the toggle that enables rotating context checks for known synchronized Mastodon threads.
-- `plugin_mastodon_should_check_old_thread_replies()` — line 2335 — Check whether known synchronized Mastodon threads should be checked for replies in rotating batches.
-- `plugin_mastodon_normalize_delete_sync_enabled()` — line 2344 — Normalize the toggle that enables or disables the follow-up deletion synchronization.
-- `plugin_mastodon_should_run_deletion_sync()` — line 2353 — Check whether the follow-up deletion synchronization is enabled.
-- `plugin_mastodon_enabled_plugin_state()` — line 3898 — Determine whether a FlatPress plugin is enabled in the centralized plugin configuration.
-- `plugin_mastodon_tag_plugin_active()` — line 3963 — Determine whether the Tag plugin is active for the current FlatPress request.
-- `plugin_mastodon_bbcode_plugin_active()` — line 3980 — Determine whether the BBCode plugin is active for the current FlatPress request.
-- `plugin_mastodon_photoswipe_plugin_active()` — line 3997 — Determine whether the PhotoSwipe plugin is active for the current FlatPress request.
-- `plugin_mastodon_audiovideo_plugin_active()` — line 4014 — Determine whether the AudioVideo plugin is active for the current FlatPress request.
-- `plugin_mastodon_emoticons_plugin_active()` — line 4031 — Determine whether the Emoticons plugin is active for the current FlatPress request.
-- `plugin_mastodon_companion_plugins_status()` — line 4046 — Return the status of companion FlatPress plugins used for the full Mastodon feature set.
+- `plugin_mastodon_default_options()` — line 120 — Return the default plugin option values.
+- `plugin_mastodon_clear_saved_instance_info()` — line 152 — Remove persisted instance-information snapshots and related admin refresh errors from an option array.
+- `plugin_mastodon_compact_instance_document()` — line 171 — Reduce `/api/v2/instance` responses to the stable subset reused by the plugin and admin table.
+- `plugin_mastodon_saved_instance_document()` — line 376 — Decode the persisted compact instance snapshot from the saved plugin configuration.
+- `plugin_mastodon_store_instance_document()` — line 421 — Persist a compact instance-information snapshot in the FlatPress plugin configuration and warm request/APCu caches.
+- `plugin_mastodon_store_instance_error()` — line 467 — Persist the latest instance-information refresh failure for the admin diagnostics view.
+- `plugin_mastodon_refresh_instance_information()` — line 483 — Force a live `/api/v2/instance` refresh, compact the response, and store it for later requests.
+- `plugin_mastodon_default_content_stats()` — line 503 — Return the default counters for the last content synchronization.
+- `plugin_mastodon_default_deletion_stats()` — line 520 — Return the default counters for the last deletion synchronization.
+- `plugin_mastodon_default_state()` — line 533 — Return the default runtime state structure, including the targeted deletion-follow-up scope marker and deletion progress cursors.
+- `plugin_mastodon_oauth_legacy_scopes()` — line 563 — Return the legacy OAuth scope string used before scope discovery was added.
+- `plugin_mastodon_oauth_profile_scopes()` — line 571 — Return the stricter OAuth scope string that uses `profile` for `verify_credentials`.
+- `plugin_mastodon_oauth_server_metadata()` — line 580 — Discover and cache OAuth authorization-server metadata from `/.well-known/oauth-authorization-server`.
+- `plugin_mastodon_oauth_supported_scopes()` — line 599 — Parse the discoverable OAuth scopes supported by the configured Mastodon instance.
+- `plugin_mastodon_oauth_scope_supported()` — line 636 — Check whether the configured Mastodon instance advertises support for a specific OAuth scope.
+- `plugin_mastodon_oauth_preferred_scopes()` — line 657 — Prefer the narrow `profile` scope on current instances and fall back to `read:accounts` on older ones.
+- `plugin_mastodon_oauth_scopes()` — line 674 — Return the OAuth scopes that the currently registered app may safely request.
+- `plugin_mastodon_fp_config()` — line 751 — Return the FlatPress configuration, preferring the early-loaded core cache.
+- `plugin_mastodon_fp_config_value()` — line 787 — Read a nested FlatPress configuration value.
+- `plugin_mastodon_fp_timeoffset_seconds()` — line 803 — Return the configured FlatPress time offset in seconds for exact local admin-time conversion.
+- `plugin_mastodon_fp_timeoffset_label()` — line 823 — Format the configured FlatPress time offset as a UTC label for admin users.
+- `plugin_mastodon_sync_time_to_minutes()` — line 853 — Convert a normalized `HH:MM` sync-time value into minutes after midnight.
+- `plugin_mastodon_minutes_to_sync_time()` — line 864 — Convert minutes after midnight back into a normalized `HH:MM` sync-time value.
+- `plugin_mastodon_sync_time_utc_to_local()` — line 880 — Convert the stored UTC synchronization time to the FlatPress-local admin time.
+- `plugin_mastodon_sync_time_local_to_utc()` — line 891 — Convert the FlatPress-local admin synchronization time back to stored UTC.
+- `plugin_mastodon_format_admin_datetime()` — line 902 — Format stored UTC timestamps for the admin panel using FlatPress `timeoffset`, date format, and time format.
+- `plugin_mastodon_fp_timeoffset_hours()` — line 815 — Return the configured FlatPress time offset in whole hours.
+- `plugin_mastodon_get_options()` — line 1858 — Load the saved plugin options and merge them with defaults.
+- `plugin_mastodon_save_options()` — line 1917 — Persist plugin options, invalidate mismatching instance snapshots on URL changes, and keep matching refreshed snapshots.
+- `plugin_mastodon_secret_key()` — line 2009 — Build the encryption key used for stored secrets.
+- `plugin_mastodon_secret_encode()` — line 2026 — Encode a secret value before storing it in the configuration.
+- `plugin_mastodon_secret_decode()` — line 2049 — Decode a previously stored secret value.
+- `plugin_mastodon_normalize_instance_url()` — line 2080 — Normalize the configured Mastodon instance URL.
+- `plugin_mastodon_normalize_head_username()` — line 2113 — Normalize the configured Mastodon username for HTML head metadata.
+- `plugin_mastodon_instance_authority()` — line 2152 — Return the Mastodon instance authority used in fediverse creator metadata.
+- `plugin_mastodon_profile_url()` — line 2182 — Build the public Mastodon profile URL used for the rel-me link.
+- `plugin_mastodon_fediverse_creator_value()` — line 2198 — Build the fediverse creator meta value.
+- `plugin_mastodon_normalize_status_language()` — line 2256 — Normalize a FlatPress locale string to a Mastodon-compatible ISO 639-1 code.
+- `plugin_mastodon_configured_status_language()` — line 2278 — Read the configured FlatPress locale and return the Mastodon language code.
+- `plugin_mastodon_normalize_sync_time()` — line 2298 — Normalize the configured daily sync time.
+- `plugin_mastodon_normalize_sync_start_date()` — line 2315 — Normalize the configured sync start date.
+- `plugin_mastodon_normalize_scheduled_window_days()` — line 2341 — Normalize the configured 7/14/30-day automatic window for scheduled runs.
+- `plugin_mastodon_scheduled_window_choices()` — line 2353 — Return the localized admin radio choices for the scheduled synchronization window.
+- `plugin_mastodon_normalize_boolean_option()` — line 2366 — Normalize a boolean-like option value to the stored string representation.
+- `plugin_mastodon_normalize_update_local_from_remote()` — line 2382 — Normalize the toggle that controls whether existing local content may be updated from remote Mastodon data.
+- `plugin_mastodon_should_update_local_from_remote()` — line 2391 — Check whether remote Mastodon updates may overwrite already existing local FlatPress content.
+- `plugin_mastodon_normalize_import_synced_comments_as_entries()` — line 2400 — Normalize the toggle that allows importing already synchronized local comments as entries.
+- `plugin_mastodon_should_import_synced_comments_as_entries()` — line 2409 — Check whether a remote Mastodon status that is already mapped to a local FlatPress comment may also be imported as an entry.
+- `plugin_mastodon_normalize_quote_imported_reply_parent()` — line 2418 — Normalize the toggle that controls whether imported Mastodon replies should quote the replied-to comment.
+- `plugin_mastodon_should_quote_imported_reply_parent()` — line 2427 — Check whether imported Mastodon replies should include a quote of the replied-to comment.
+- `plugin_mastodon_normalize_old_thread_reply_check()` — line 2436 — Normalize the toggle that enables rotating context checks for known synchronized Mastodon threads.
+- `plugin_mastodon_should_check_old_thread_replies()` — line 2445 — Check whether known synchronized Mastodon threads should be checked for replies in rotating batches.
+- `plugin_mastodon_normalize_delete_sync_enabled()` — line 2454 — Normalize the toggle that enables or disables the follow-up deletion synchronization.
+- `plugin_mastodon_should_run_deletion_sync()` — line 2463 — Check whether the follow-up deletion synchronization is enabled.
+- `plugin_mastodon_enabled_plugin_state()` — line 4515 — Determine whether a FlatPress plugin is enabled in the centralized plugin configuration.
+- `plugin_mastodon_tag_plugin_active()` — line 4580 — Determine whether the Tag plugin is active for the current FlatPress request.
+- `plugin_mastodon_bbcode_plugin_active()` — line 4597 — Determine whether the BBCode plugin is active for the current FlatPress request.
+- `plugin_mastodon_photoswipe_plugin_active()` — line 4614 — Determine whether the PhotoSwipe plugin is active for the current FlatPress request.
+- `plugin_mastodon_audiovideo_plugin_active()` — line 4631 — Determine whether the AudioVideo plugin is active for the current FlatPress request.
+- `plugin_mastodon_emoticons_plugin_active()` — line 4648 — Determine whether the Emoticons plugin is active for the current FlatPress request.
+- `plugin_mastodon_companion_plugins_status()` — line 4663 — Return the status of companion FlatPress plugins used for the full Mastodon feature set.
 
 ## C. Caching, filesystem helpers, logging, and persisted state
 
-- `plugin_mastodon_runtime_cache_get()` — line 673 — Return a value from the request-local plugin cache.
-- `plugin_mastodon_runtime_cache_set()` — line 697 — Store a value in the request-local plugin cache.
-- `plugin_mastodon_runtime_cache_clear()` — line 715 — Clear one request-local plugin cache bucket or the complete cache.
-- `plugin_mastodon_io_read_file()` — line 915 — Read a file through the FlatPress I/O layer when available.
-- `plugin_mastodon_io_read_file_uncached()` — line 928 — Read a file without FlatPress request-local caches.
-- `plugin_mastodon_file_permissions_mode()` — line 943 — Return the FlatPress `FILE_PERMISSIONS` mode used for plugin runtime files.
-- `plugin_mastodon_apply_file_permissions()` — line 952 — Apply FlatPress `FILE_PERMISSIONS` to a plugin runtime file.
-- `plugin_mastodon_io_write_file()` — line 965 — Write a file through the FlatPress I/O layer when available and enforce `FILE_PERMISSIONS` after successful writes.
-- `plugin_mastodon_io_append_file()` — line 986 — Append to a file via the FlatPress I/O layer.
-- `plugin_mastodon_apcu_enabled()` — line 1002 — Check whether shared APCu caching is available for the plugin.
-- `plugin_mastodon_apcu_cache_key()` — line 1011 — Build the namespaced APCu key used by this plugin.
-- `plugin_mastodon_apcu_fetch()` — line 1025 — Fetch a value from APCu through the FlatPress namespace helper.
-- `plugin_mastodon_apcu_store()` — line 1040 — Store a value in APCu through the FlatPress namespace helper.
-- `plugin_mastodon_apcu_delete()` — line 1053 — Delete a value from APCu using the FlatPress namespace key builder.
-- `plugin_mastodon_state_fallback_key()` — line 1065 — Return the APCu key used for the short-lived last-known-good state fallback.
-- `plugin_mastodon_state_fallback_store()` — line 1074 — Store a normalized runtime state in APCu for a 5-minute emergency fallback window.
-- `plugin_mastodon_state_fallback_read()` — line 1086 — Fetch the short-lived last-known-good state fallback from APCu.
-- `plugin_mastodon_sync_guard_kind()` — line 1104 — Normalize the cooldown guard kind.
-- `plugin_mastodon_sync_guard_apcu_key()` — line 1114 — Return the APCu key used for one sync cooldown guard.
-- `plugin_mastodon_sync_guard_entry_active()` — line 1124 — Check whether one cooldown guard entry is still active.
-- `plugin_mastodon_sync_guard_apcu_store()` — line 1135 — Store one cooldown guard in APCu.
-- `plugin_mastodon_sync_guard_file_read()` — line 1148 — Read and prune the file-backed cooldown guard.
-- `plugin_mastodon_sync_guard_file_write()` — line 1175 — Write the file-backed cooldown guard.
-- `plugin_mastodon_sync_guard_active()` — line 1196 — Check whether a recent scheduled content/deletion pass is still cooling down.
-- `plugin_mastodon_sync_guard_mark()` — line 1221 — Mark a 5-minute cooldown guard for a scheduled sync/deletion pass.
-- `plugin_mastodon_sync_guard_clear()` — line 1242 — Clear one sync cooldown guard.
-- `plugin_mastodon_rate_limit_default_budgets()` — line 1257 — Return conservative per-run Mastodon API budgets.
-- `plugin_mastodon_rate_limit_window_budgets()` — line 1281 — Return persistent cross-run Mastodon API window budgets.
-- `plugin_mastodon_rate_limit_window_config()` — line 1308 — Return the persistent window key, budget, TTL, and block reason for one request kind.
-- `plugin_mastodon_rate_limit_window_entry()` — line 1328 — Normalize one persistent rate-limit window entry and drop expired values.
-- `plugin_mastodon_rate_limit_window_read()` — line 1348 — Read and prune the persistent cross-run rate-limit windows.
-- `plugin_mastodon_rate_limit_window_write()` — line 1380 — Persist cross-run rate-limit windows with FlatPress file permissions.
-- `plugin_mastodon_rate_limit_window_acquire()` — line 1405 — Reserve one media-upload/delete/account-status-page slot from the persistent cross-run window.
-- `plugin_mastodon_rate_limit_window_clear()` — line 1454 — Clear persistent rate-limit windows for tests or recovery tooling.
-- `plugin_mastodon_rate_limit_guard_start()` — line 1466 — Start the per-run Mastodon API rate-limit guard.
-- `plugin_mastodon_rate_limit_guard_stop()` — line 1492 — Stop the per-run Mastodon API rate-limit guard while keeping its summary inspectable.
-- `plugin_mastodon_rate_limit_guard_active()` — line 1503 — Check whether the per-run Mastodon API guard is active.
-- `plugin_mastodon_rate_limit_guard_summary()` — line 1511 — Return the current per-run rate-limit guard summary.
-- `plugin_mastodon_rate_limit_headers()` — line 1520 — Normalize response headers for rate-limit checks.
-- `plugin_mastodon_rate_limit_request_kind()` — line 1541 — Classify Mastodon API requests as general, media upload, status deletion, or account-status paging.
-- `plugin_mastodon_rate_limit_block()` — line 1566 — Mark the current run as blocked by a rate-limit budget, persistent window, or Mastodon response and log the stop reason with budget counters once per run.
-- `plugin_mastodon_rate_limit_acquire()` — line 1610 — Reserve per-run and persistent window budget before a Mastodon API request proceeds.
-- `plugin_mastodon_rate_limit_observe_response()` — line 1655 — Update the guard from `X-RateLimit-*` headers and `429` responses.
-- `plugin_mastodon_rate_limit_blocked_reason()` — line 1679 — Return the current rate-limit block reason.
-- `plugin_mastodon_rate_limit_blocked_response()` — line 1691 — Build the synthetic `429` response used for locally blocked requests.
-- `plugin_mastodon_rate_limit_state_error()` — line 1707 — Return the rate-limit reason that should be written to synchronization state.
-- `plugin_mastodon_file_prestat()` — line 1717 — Read a cheap file metadata snapshot for cache validation.
-- `plugin_mastodon_file_prestat_signature()` — line 1737 — Convert a file metadata snapshot into a stable cache signature.
-- `plugin_mastodon_ensure_state_dir()` — line 2587 — Ensure that the plugin runtime directory exists.
-- `plugin_mastodon_log()` — line 2596 — Append a line to the plugin sync log.
-- `plugin_mastodon_state_read()` — line 2606 — Load the persisted runtime state from disk and fall back to the short-lived APCu state if the file is temporarily missing, empty, or invalid.
-- `plugin_mastodon_state_write()` — line 2660 — Persist the runtime state to disk and always refresh the short-lived APCu last-known-good state when possible.
-- `plugin_mastodon_normalize_deletions_pending_scope()` — line 2685 — Normalize the targeted deletion-follow-up scope marker.
-- `plugin_mastodon_state_normalize()` — line 2698 — Normalize a runtime state array and fill in missing keys.
-- `plugin_mastodon_state_comment_key()` — line 2747 — Build the compound state key used for comment mappings.
-- `plugin_mastodon_state_set_entry_mapping()` — line 2762 — Store the mapping between a local entry and a remote status.
-- `plugin_mastodon_state_set_comment_mapping()` — line 2800 — Store the mapping between a local comment and a remote status.
-- `plugin_mastodon_state_remove_entry_mapping()` — line 2835 — Remove the mapping between a local entry and a remote status.
-- `plugin_mastodon_state_remove_comment_mapping()` — line 2857 — Remove the mapping between a local comment and a remote status.
-- `plugin_mastodon_state_set_dirty_entry()` — line 2882 — Add an older changed entry to the persistent dirty queue.
-- `plugin_mastodon_state_remove_dirty_entry()` — line 2902 — Remove an entry from the dirty queue after successful synchronization or cleanup.
-- `plugin_mastodon_state_has_dirty_entry()` — line 2915 — Check whether an entry is queued for synchronization outside the scheduled window.
-- `plugin_mastodon_state_set_dirty_comment()` — line 2928 — Add an older changed comment to the persistent dirty queue.
-- `plugin_mastodon_state_remove_dirty_comment()` — line 2951 — Remove a comment from the dirty queue after successful synchronization or cleanup.
-- `plugin_mastodon_state_has_dirty_comment()` — line 2965 — Check whether a comment is queued for synchronization outside the scheduled window.
-- `plugin_mastodon_state_get_entry_meta()` — line 2976 — Return mapping metadata for a local entry.
-- `plugin_mastodon_state_set_entry_media_meta()` — line 2990 — Persist cached remote media IDs plus local attachment/description signatures for a synchronized entry.
-- `plugin_mastodon_state_get_comment_meta()` — line 3071 — Return mapping metadata for a local comment.
-- `plugin_mastodon_state_set_comment_tombstone()` — line 3085 — Store a tombstone that blocks stale re-imports of one deleted remote comment.
-- `plugin_mastodon_state_has_comment_tombstone()` — line 3105 — Check whether one remote Mastodon comment status was tombstoned locally.
-- `plugin_mastodon_protect_locally_deleted_exported_comments()` — line 3116 — Tombstone locally deleted exported FlatPress comment mappings before the next content sync can stale-reimport them from Mastodon thread context.
-- `plugin_mastodon_reattach_local_comment_to_entry_status()` — line 3162 — Remove a local imported reply parent link and reattach the surviving reply to the synchronized entry status after its remote parent reply disappeared.
-- `plugin_mastodon_state_remove_pending_comment_remote_recheck()` — line 3222 — Remove one pending descendant recheck marker.
-- `plugin_mastodon_state_get_pending_comment_remote_recheck()` — line 3236 — Return one pending descendant recheck marker.
-- `plugin_mastodon_state_set_pending_comment_remote_recheck()` — line 3251 — Mark one local comment for follow-up verification after an ancestor disappeared remotely.
-- `plugin_mastodon_state_set_deletions_pending()` — line 3277 — Persist whether another deletion follow-up request is pending, which scope it should run, and when it may start.
-- `plugin_mastodon_deletion_sync_due()` — line 3291 — Check whether the pending deletion synchronization may start after its persisted not-before timestamp.
-- `plugin_mastodon_state_has_comment_recheck_scope()` — line 3319 — Check whether the next deletion follow-up request should run only the targeted descendant recheck scope.
-- `plugin_mastodon_build_comment_remote_child_index()` — line 3328 — Build a direct-child index for mapped remote reply trees.
-- `plugin_mastodon_queue_comment_descendant_remote_rechecks()` — line 3356 — Queue only the direct mapped local children of one deleted remote comment for additional verification passes.
-- `plugin_mastodon_process_pending_comment_remote_rechecks()` — line 3395 — Process pending descendant rechecks breadth-first so deeper reply chains can converge within the same targeted follow-up request.
+- `plugin_mastodon_runtime_cache_get()` — line 694 — Return a value from the request-local plugin cache.
+- `plugin_mastodon_runtime_cache_set()` — line 718 — Store a value in the request-local plugin cache.
+- `plugin_mastodon_runtime_cache_clear()` — line 736 — Clear one request-local plugin cache bucket or the complete cache.
+- `plugin_mastodon_io_read_file()` — line 936 — Read a file through the FlatPress I/O layer when available, allowing the core APCu file hotcache for small files.
+- `plugin_mastodon_io_read_file_uncached()` — line 952 — Read a file without FlatPress request-local caches.
+- `plugin_mastodon_file_permissions_mode()` — line 970 — Return the FlatPress `FILE_PERMISSIONS` mode used for plugin runtime files.
+- `plugin_mastodon_apply_file_permissions()` — line 979 — Apply FlatPress `FILE_PERMISSIONS` to a plugin runtime file.
+- `plugin_mastodon_io_write_file()` — line 992 — Write a file through the FlatPress I/O layer when available and enforce `FILE_PERMISSIONS` after successful writes.
+- `plugin_mastodon_io_append_file()` — line 1013 — Append to a file with `FILE_APPEND | LOCK_EX`, without re-reading/re-writing the complete log payload.
+- `plugin_mastodon_log_max_bytes()` — line 1053 — Return the sync.log rotation size limit, with a simulation override for load tests.
+- `plugin_mastodon_log_rotate_files()` — line 1064 — Return the number of retained rotated sync logs.
+- `plugin_mastodon_io_rotate_file_if_needed()` — line 1077 — Rotate `sync.log` before append when the next line would exceed the size cap.
+- `plugin_mastodon_apcu_enabled()` — line 1116 — Check whether shared APCu caching is available for the plugin.
+- `plugin_mastodon_apcu_cache_key()` — line 1125 — Build the namespaced APCu key used by this plugin.
+- `plugin_mastodon_apcu_fetch()` — line 1139 — Fetch a value from APCu through the FlatPress namespace helper.
+- `plugin_mastodon_apcu_store()` — line 1154 — Store a value in APCu through the FlatPress namespace helper.
+- `plugin_mastodon_apcu_delete()` — line 1167 — Delete a value from APCu using FlatPress `apcu_delete_key()` when available.
+- `plugin_mastodon_state_fallback_key()` — line 1186 — Return the legacy APCu key that used to hold a full last-known-good state fallback.
+- `plugin_mastodon_state_fallback_store()` — line 1195 — Remove the legacy full-state APCu fallback instead of storing large mapping arrays.
+- `plugin_mastodon_state_fallback_read()` — line 1204 — Return an empty full-state fallback and delete the legacy APCu entry when APCu is available.
+- `plugin_mastodon_sync_guard_kind()` — line 1214 — Normalize the cooldown guard kind.
+- `plugin_mastodon_sync_guard_apcu_key()` — line 1224 — Return the APCu key used for one sync cooldown guard.
+- `plugin_mastodon_sync_guard_entry_active()` — line 1234 — Check whether one cooldown guard entry is still active.
+- `plugin_mastodon_sync_guard_apcu_store()` — line 1245 — Store one cooldown guard in APCu.
+- `plugin_mastodon_sync_guard_file_read()` — line 1258 — Read and prune the file-backed cooldown guard.
+- `plugin_mastodon_sync_guard_file_write()` — line 1285 — Write the file-backed cooldown guard.
+- `plugin_mastodon_sync_guard_active()` — line 1306 — Check whether a recent scheduled content/deletion pass is still cooling down.
+- `plugin_mastodon_sync_guard_mark()` — line 1331 — Mark a 5-minute cooldown guard for a scheduled sync/deletion pass.
+- `plugin_mastodon_sync_guard_clear()` — line 1352 — Clear one sync cooldown guard.
+- `plugin_mastodon_rate_limit_default_budgets()` — line 1367 — Return conservative per-run Mastodon API budgets.
+- `plugin_mastodon_rate_limit_window_budgets()` — line 1391 — Return persistent cross-run Mastodon API window budgets.
+- `plugin_mastodon_rate_limit_window_config()` — line 1418 — Return the persistent window key, budget, TTL, and block reason for one request kind.
+- `plugin_mastodon_rate_limit_window_entry()` — line 1438 — Normalize one persistent rate-limit window entry and drop expired values.
+- `plugin_mastodon_rate_limit_window_read()` — line 1458 — Read and prune the persistent cross-run rate-limit windows.
+- `plugin_mastodon_rate_limit_window_write()` — line 1490 — Persist cross-run rate-limit windows with FlatPress file permissions.
+- `plugin_mastodon_rate_limit_window_acquire()` — line 1515 — Reserve one media-upload/delete/account-status-page slot from the persistent cross-run window.
+- `plugin_mastodon_rate_limit_window_clear()` — line 1564 — Clear persistent rate-limit windows for tests or recovery tooling.
+- `plugin_mastodon_rate_limit_guard_start()` — line 1576 — Start the per-run Mastodon API rate-limit guard.
+- `plugin_mastodon_rate_limit_guard_stop()` — line 1602 — Stop the per-run Mastodon API rate-limit guard while keeping its summary inspectable.
+- `plugin_mastodon_rate_limit_guard_active()` — line 1613 — Check whether the per-run Mastodon API guard is active.
+- `plugin_mastodon_rate_limit_guard_summary()` — line 1621 — Return the current per-run rate-limit guard summary.
+- `plugin_mastodon_rate_limit_headers()` — line 1630 — Normalize response headers for rate-limit checks.
+- `plugin_mastodon_rate_limit_request_kind()` — line 1651 — Classify Mastodon API requests as general, media upload, status deletion, or account-status paging.
+- `plugin_mastodon_rate_limit_block()` — line 1676 — Mark the current run as blocked by a rate-limit budget, persistent window, or Mastodon response and log the stop reason with budget counters once per run.
+- `plugin_mastodon_rate_limit_acquire()` — line 1720 — Reserve per-run and persistent window budget before a Mastodon API request proceeds.
+- `plugin_mastodon_rate_limit_observe_response()` — line 1765 — Update the guard from `X-RateLimit-*` headers and `429` responses.
+- `plugin_mastodon_rate_limit_blocked_reason()` — line 1789 — Return the current rate-limit block reason.
+- `plugin_mastodon_rate_limit_blocked_response()` — line 1801 — Build the synthetic `429` response used for locally blocked requests.
+- `plugin_mastodon_rate_limit_state_error()` — line 1817 — Return the rate-limit reason that should be written to synchronization state.
+- `plugin_mastodon_file_prestat()` — line 1827 — Read a cheap file metadata snapshot for cache validation.
+- `plugin_mastodon_file_prestat_signature()` — line 1847 — Convert a file metadata snapshot into a stable cache signature.
+- `plugin_mastodon_ensure_state_dir()` — line 2788 — Ensure that the plugin runtime directory exists.
+- `plugin_mastodon_log()` — line 2797 — Append a line to the rotated append-only plugin sync log.
+- `plugin_mastodon_log_skip()` — line 2812 — Aggregate high-volume skip messages by reason until the current sync phase ends.
+- `plugin_mastodon_log_flush_skip_summaries()` — line 2842 — Flush aggregated skip counters as concise summary lines.
+- `plugin_mastodon_state_read()` — line 2872 — Load the persisted runtime state from disk without storing or reading a full-state APCu fallback.
+- `plugin_mastodon_scheduler_state_default()` — line 2910 — Return an empty compact scheduler summary derived from the full default state.
+- `plugin_mastodon_scheduler_source_signature()` — line 2931 — Return the current stat-based signature of `state.json` used to validate scheduler summaries.
+- `plugin_mastodon_scheduler_state_normalize()` — line 2940 — Normalize scheduler summary fields without touching full mapping arrays.
+- `plugin_mastodon_scheduler_state_from_state()` — line 2978 — Build the lightweight scheduler summary from a full runtime state.
+- `plugin_mastodon_scheduler_state_write()` — line 2998 — Persist the compact scheduler summary; write failures only disable the optimization.
+- `plugin_mastodon_scheduler_state_read()` — line 3022 — Load the compact scheduler summary through the APCu-capable FlatPress file I/O path and rebuild it from full state only when missing, invalid, or stale.
+- `plugin_mastodon_state_write()` — line 3063 — Persist the runtime state to disk and refresh the compact scheduler summary after successful writes, without caching the full state in APCu.
+- `plugin_mastodon_normalize_deletions_pending_scope()` — line 3088 — Normalize the targeted deletion-follow-up scope marker.
+- `plugin_mastodon_state_normalize()` — line 3101 — Normalize a runtime state array and fill in missing keys.
+- `plugin_mastodon_state_comment_key()` — line 3152 — Build the compound state key used for comment mappings.
+- `plugin_mastodon_state_set_entry_mapping()` — line 3167 — Store the mapping between a local entry and a remote status.
+- `plugin_mastodon_state_set_comment_mapping()` — line 3205 — Store the mapping between a local comment and a remote status.
+- `plugin_mastodon_state_remove_entry_mapping()` — line 3240 — Remove the mapping between a local entry and a remote status.
+- `plugin_mastodon_state_remove_comment_mapping()` — line 3262 — Remove the mapping between a local comment and a remote status.
+- `plugin_mastodon_state_set_dirty_entry()` — line 3287 — Add an older changed entry to the persistent dirty queue.
+- `plugin_mastodon_state_remove_dirty_entry()` — line 3307 — Remove an entry from the dirty queue after successful synchronization or cleanup.
+- `plugin_mastodon_state_has_dirty_entry()` — line 3320 — Check whether an entry is queued for synchronization outside the scheduled window.
+- `plugin_mastodon_state_set_dirty_comment()` — line 3333 — Add an older changed comment to the persistent dirty queue.
+- `plugin_mastodon_state_remove_dirty_comment()` — line 3356 — Remove a comment from the dirty queue after successful synchronization or cleanup.
+- `plugin_mastodon_state_has_dirty_comment()` — line 3370 — Check whether a comment is queued for synchronization outside the scheduled window.
+- `plugin_mastodon_local_write_guard_enter()` — line 3379 — Increase the depth guard while the plugin mirrors remote Mastodon data into FlatPress.
+- `plugin_mastodon_local_write_guard_leave()` — line 3390 — Decrease the local-write guard depth after a guarded FlatPress write/delete.
+- `plugin_mastodon_local_write_guard_active()` — line 3402 — Check whether Mastodon-owned local writes should suppress dirty hook handling.
+- `plugin_mastodon_dirty_tracking_options()` — line 3410 — Return normalized options for post-success dirty hooks, or an empty array when guard/configuration prevents state writes.
+- `plugin_mastodon_on_entry_saved()` — line 3429 — Handle Core `entry_saved` and queue changed mapped local entries when they require a later targeted export.
+- `plugin_mastodon_on_entry_deleted()` — line 3478 — Handle Core `entry_deleted`, clear dirty-entry state, and mark mapped local deletions for the deletion follow-up pass.
+- `plugin_mastodon_on_comment_saved()` — line 3505 — Handle Core `comment_saved` and queue changed mapped local comments without exporting unrelated old comments.
+- `plugin_mastodon_on_comment_deleted()` — line 3563 — Handle Core `comment_deleted`, clear dirty-comment state, and mark mapped local comment deletions for the deletion follow-up pass.
+- `plugin_mastodon_state_get_entry_meta()` — line 3588 — Return mapping metadata for a local entry.
+- `plugin_mastodon_state_entry_remote_media()` — line 3631 — Return normalized stored remote media descriptors for one entry mapping.
+- `plugin_mastodon_state_entry_media_attachment_signature()` — line 3661 — Return the stored local attachment signature for one entry mapping.
+- `plugin_mastodon_state_entry_media_description_signature()` — line 3671 — Return the stored local media-description signature for one entry mapping.
+- `plugin_mastodon_state_set_entry_media_meta()` — line 3602 — Persist cached remote media IDs plus local attachment/description signatures for a synchronized entry.
+- `plugin_mastodon_state_get_comment_meta()` — line 3683 — Return mapping metadata for a local comment.
+- `plugin_mastodon_state_set_comment_tombstone()` — line 3697 — Store a tombstone that blocks stale re-imports of one deleted remote comment.
+- `plugin_mastodon_state_has_comment_tombstone()` — line 3717 — Check whether one remote Mastodon comment status was tombstoned locally.
+- `plugin_mastodon_protect_locally_deleted_exported_comments()` — line 3728 — Tombstone locally deleted exported FlatPress comment mappings before the next content sync can stale-reimport them from Mastodon thread context.
+- `plugin_mastodon_reattach_local_comment_to_entry_status()` — line 3774 — Remove a local imported reply parent link and reattach the surviving reply to the synchronized entry status after its remote parent reply disappeared.
+- `plugin_mastodon_state_remove_pending_comment_remote_recheck()` — line 3834 — Remove one pending descendant recheck marker.
+- `plugin_mastodon_state_get_pending_comment_remote_recheck()` — line 3848 — Return one pending descendant recheck marker.
+- `plugin_mastodon_state_set_pending_comment_remote_recheck()` — line 3863 — Mark one local comment for follow-up verification after an ancestor disappeared remotely.
+- `plugin_mastodon_state_set_deletions_pending()` — line 3889 — Persist whether another deletion follow-up request is pending, which scope it should run, and when it may start.
+- `plugin_mastodon_deletion_sync_due()` — line 3903 — Check whether the pending deletion synchronization may start after its persisted not-before timestamp.
+- `plugin_mastodon_state_has_comment_recheck_scope()` — line 3931 — Check whether the next deletion follow-up request should run only the targeted descendant recheck scope.
+- `plugin_mastodon_build_comment_remote_child_index()` — line 3940 — Build a direct-child index for mapped remote reply trees.
+- `plugin_mastodon_queue_comment_descendant_remote_rechecks()` — line 3968 — Queue only the direct mapped local children of one deleted remote comment for additional verification passes.
+- `plugin_mastodon_process_pending_comment_remote_rechecks()` — line 4007 — Process pending descendant rechecks breadth-first so deeper reply chains can converge within the same targeted follow-up request.
 
 ## D. Date, timestamp, visibility, and threading helpers
 
-- `plugin_mastodon_timestamp_to_flatpress_time()` — line 816 — Convert a real Unix timestamp into FlatPress's offset-adjusted timestamp model.
-- `plugin_mastodon_timestamp_date_key()` — line 2362 — Convert a FlatPress-adjusted timestamp into a stable date key.
-- `plugin_mastodon_local_item_date_key()` — line 2376 — Determine the date key of a local FlatPress entry or comment.
-- `plugin_mastodon_remote_status_date_key()` — line 2396 — Determine the date key of a remote Mastodon status.
-- `plugin_mastodon_datetime_date_key()` — line 2422 — Normalize a stored date/datetime string to the sync-start date-key format.
-- `plugin_mastodon_date_matches_sync_start()` — line 2446 — Determine whether a content date passes the configured sync start date.
-- `plugin_mastodon_scheduled_window_start_date()` — line 2464 — Return the FlatPress-local date key that starts the automatic scheduled sync window.
-- `plugin_mastodon_date_matches_content_window()` — line 2481 — Combine the durable sync-start lower bound with the scheduled-run recent-content window.
-- `plugin_mastodon_local_item_matches_sync_start()` — line 2503 — Determine whether a local FlatPress item should be synchronized.
-- `plugin_mastodon_local_item_matches_content_window()` — line 2515 — Determine whether a local FlatPress item is inside the active content synchronization window.
-- `plugin_mastodon_remote_status_matches_sync_start()` — line 2525 — Determine whether a remote Mastodon status should be synchronized.
-- `plugin_mastodon_mapping_effective_date_key()` — line 2597 — Resolve the best date key available for a synchronized mapping.
-- `plugin_mastodon_mapping_matches_deletion_lookup_window()` — line 2638 — Decide whether an existing local mapping should receive a remote deletion lookup in the current scheduled or forced delete pass.
-- `plugin_mastodon_mapping_keys_after_cursor()` — line 2659 — Return sorted mapping keys after a saved deletion cursor so large delete passes can continue across runs.
-- `plugin_mastodon_remote_status_matches_content_window()` — line 2536 — Determine whether a remote Mastodon status is inside the active content synchronization window.
-- `plugin_mastodon_mapping_matches_sync_start()` — line 2547 — Determine whether a stored synchronization mapping still belongs to the active sync-start window.
-- `plugin_mastodon_parse_iso_datetime()` — line 3500 — Parse an ISO date/time string into FlatPress date format.
-- `plugin_mastodon_parse_iso_timestamp()` — line 3518 — Parse an ISO date/time value into a Unix timestamp.
-- `plugin_mastodon_remote_status_timestamp()` — line 3540 — Resolve the best FlatPress-adjusted timestamp for a remote Mastodon status.
-- `plugin_mastodon_remote_status_visibility()` — line 3559 — Return the normalized visibility of a remote Mastodon status.
-- `plugin_mastodon_remote_status_is_importable()` — line 3572 — Determine whether a remote Mastodon status may be imported.
-- `plugin_mastodon_comment_parent_fields()` — line 3584 — Return the comment fields that may contain a parent reference.
-- `plugin_mastodon_normalize_boolean_option()` — line 2256 — Normalize a boolean-like option value to the stored string representation.
-- `plugin_mastodon_normalize_comment_parent_id()` — line 3593 — Normalize a stored local comment parent identifier.
-- `plugin_mastodon_detect_local_comment_parent_id()` — line 3610 — Detect the local parent comment identifier from comment data.
-- `plugin_mastodon_resolve_comment_reply_target()` — line 3632 — Resolve the remote reply target for a local comment export.
-- `plugin_mastodon_list_local_comment_ids()` — line 3685 — Scan the FlatPress comment directory directly so local reply export is not blocked by stale comment-list caches.
+- `plugin_mastodon_timestamp_to_flatpress_time()` — line 837 — Convert a real Unix timestamp into FlatPress's offset-adjusted timestamp model.
+- `plugin_mastodon_timestamp_date_key()` — line 2472 — Convert a FlatPress-adjusted timestamp into a stable date key.
+- `plugin_mastodon_local_item_date_key()` — line 2486 — Determine the date key of a local FlatPress entry or comment.
+- `plugin_mastodon_remote_status_date_key()` — line 2509 — Determine the date key of a remote Mastodon status.
+- `plugin_mastodon_datetime_date_key()` — line 2535 — Normalize a stored date/datetime string to the sync-start date-key format.
+- `plugin_mastodon_date_matches_sync_start()` — line 2559 — Determine whether a content date passes the configured sync start date.
+- `plugin_mastodon_scheduled_window_start_date()` — line 2577 — Return the FlatPress-local date key that starts the automatic scheduled sync window.
+- `plugin_mastodon_date_matches_content_window()` — line 2594 — Combine the durable sync-start lower bound with the scheduled-run recent-content window.
+- `plugin_mastodon_local_item_matches_sync_start()` — line 2616 — Determine whether a local FlatPress item should be synchronized.
+- `plugin_mastodon_local_item_matches_content_window()` — line 2628 — Determine whether a local FlatPress item is inside the active content synchronization window.
+- `plugin_mastodon_remote_status_matches_sync_start()` — line 2638 — Determine whether a remote Mastodon status should be synchronized.
+- `plugin_mastodon_mapping_effective_date_key()` — line 2708 — Resolve the best date key available for a synchronized mapping.
+- `plugin_mastodon_mapping_matches_deletion_lookup_window()` — line 2749 — Decide whether an existing local mapping should receive a remote deletion lookup in the current scheduled or forced delete pass.
+- `plugin_mastodon_mapping_keys_after_cursor()` — line 2770 — Return sorted mapping keys after a saved deletion cursor so large delete passes can continue across runs.
+- `plugin_mastodon_remote_status_matches_content_window()` — line 2649 — Determine whether a remote Mastodon status is inside the active content synchronization window.
+- `plugin_mastodon_mapping_matches_sync_start()` — line 2660 — Determine whether a stored synchronization mapping still belongs to the active sync-start window.
+- `plugin_mastodon_parse_iso_datetime()` — line 4117 — Parse an ISO date/time string into FlatPress date format.
+- `plugin_mastodon_parse_iso_timestamp()` — line 4135 — Parse an ISO date/time value into a Unix timestamp.
+- `plugin_mastodon_remote_status_timestamp()` — line 4157 — Resolve the best FlatPress-adjusted timestamp for a remote Mastodon status.
+- `plugin_mastodon_remote_status_visibility()` — line 4176 — Return the normalized visibility of a remote Mastodon status.
+- `plugin_mastodon_remote_status_is_importable()` — line 4189 — Determine whether a remote Mastodon status may be imported.
+- `plugin_mastodon_comment_parent_fields()` — line 4201 — Return the comment fields that may contain a parent reference.
+- `plugin_mastodon_normalize_boolean_option()` — line 2366 — Normalize a boolean-like option value to the stored string representation.
+- `plugin_mastodon_normalize_comment_parent_id()` — line 4210 — Normalize a stored local comment parent identifier.
+- `plugin_mastodon_detect_local_comment_parent_id()` — line 4227 — Detect the local parent comment identifier from comment data.
+- `plugin_mastodon_resolve_comment_reply_target()` — line 4249 — Resolve the remote reply target for a local comment export.
+- `plugin_mastodon_list_local_comment_ids()` — line 4302 — Scan the FlatPress comment directory directly so local reply export is not blocked by stale comment-list caches.
 
 ## E. Text, URLs, language strings, tags, emojis, and BBCode/HTML conversion
 
-- `plugin_mastodon_guess_subject()` — line 3722 — Guess a subject line from imported plain text.
-- `plugin_mastodon_html_entity_decode()` — line 3764 — Decode HTML entities using the plugin defaults.
-- `plugin_mastodon_blog_base_url()` — line 3773 — Return the absolute base URL of the current FlatPress installation.
-- `plugin_mastodon_extract_url_token()` — line 3809 — Extract the URL token from a BBCode or attribute fragment.
-- `plugin_mastodon_absolute_url()` — line 3826 — Convert a URL or path into an absolute URL when possible.
-- `plugin_mastodon_lang_string()` — line 3868 — Return a localized plugin string or a provided fallback.
-- `plugin_mastodon_normalize_tag_list()` — line 4094 — Normalize a list of tag labels.
-- `plugin_mastodon_extend_time_limit()` — line 6322 — Refresh or raise the PHP execution time budget for long-running Mastodon work without lowering an existing higher or unlimited limit.
-- `plugin_mastodon_extract_flatpress_tags()` — line 4125 — Extract FlatPress Tag plugin labels from an entry body.
-- `plugin_mastodon_strip_flatpress_tag_bbcode()` — line 4150 — Remove Tag plugin BBCode blocks from entry content.
-- `plugin_mastodon_mastodon_hashtag_footer()` — line 4167 — Convert FlatPress tag labels into a Mastodon hashtag footer line.
-- `plugin_mastodon_remote_status_tags()` — line 4188 — Collect remote Mastodon tags from a status entity.
-- `plugin_mastodon_strip_trailing_mastodon_hashtag_footer()` — line 4215 — Remove a trailing Mastodon hashtag footer from imported plain text.
-- `plugin_mastodon_build_flatpress_tag_bbcode()` — line 4278 — Build Tag plugin BBCode from a list of remote Mastodon tags.
-- `plugin_mastodon_emoticon_entity_to_unicode()` — line 4291 — Convert an emoticon HTML entity into a Unicode character.
-- `plugin_mastodon_emoticon_map()` — line 4304 — Return the FlatPress emoticon-to-Unicode lookup map.
-- `plugin_mastodon_replace_emoticon_shortcodes_with_unicode()` — line 4358 — Replace FlatPress emoticon shortcodes with Unicode glyphs.
-- `plugin_mastodon_prepare_emoticons_for_mastodon()` — line 4373 — Convert active FlatPress emoticon shortcodes to standard Unicode emoji before Mastodon export.
-- `plugin_mastodon_replace_unicode_emoticons_with_shortcodes()` — line 4386 — Replace Unicode emoticons with FlatPress shortcodes.
-- `plugin_mastodon_is_public_host()` — line 4408 — Determine whether a host name resolves to a public endpoint.
-- `plugin_mastodon_public_url_for_mastodon()` — line 4431 — Return a Mastodon-safe public URL or an empty string.
-- `plugin_mastodon_plain_text_from_bbcode()` — line 4450 — Convert FlatPress BBCode into plain text for Mastodon export, removing complete AudioVideo player tags including optional description endtag content.
-- `plugin_mastodon_subject_line_is_noise()` — line 4494 — Determine whether an extracted line should be ignored as a subject.
-- `plugin_mastodon_domains_match()` — line 4522 — Determine whether two host names belong to the same domain family.
-- `plugin_mastodon_cleanup_imported_text()` — line 4536 — Clean imported text before saving it to FlatPress.
-- `plugin_mastodon_dom_children_to_flatpress()` — line 4590 — Convert DOM child nodes into FlatPress BBCode text.
-- `plugin_mastodon_dom_node_to_flatpress()` — line 4608 — Convert a single DOM node into FlatPress BBCode text.
-- `plugin_mastodon_public_entry_url()` — line 4717 — Return the public URL for a FlatPress entry.
-- `plugin_mastodon_public_comments_url()` — line 4744 — Return the public comments URL for a FlatPress entry.
-- `plugin_mastodon_public_comment_url()` — line 4772 — Return the public URL for a specific FlatPress comment.
-- `plugin_mastodon_mastodon_html_to_flatpress()` — line 4787 — Convert Mastodon HTML content into FlatPress BBCode.
-- `plugin_mastodon_flatpress_to_mastodon()` — line 4889 — Convert FlatPress content into Mastodon-ready plain text.
-- `plugin_mastodon_limit_text()` — line 5006 — Limit text to a maximum number of characters.
+- `plugin_mastodon_guess_subject()` — line 4339 — Guess a subject line from imported plain text.
+- `plugin_mastodon_html_entity_decode()` — line 4381 — Decode HTML entities using the plugin defaults.
+- `plugin_mastodon_blog_base_url()` — line 4390 — Return the absolute base URL of the current FlatPress installation.
+- `plugin_mastodon_extract_url_token()` — line 4426 — Extract the URL token from a BBCode or attribute fragment.
+- `plugin_mastodon_absolute_url()` — line 4443 — Convert a URL or path into an absolute URL when possible.
+- `plugin_mastodon_lang_string()` — line 4485 — Return a localized plugin string or a provided fallback.
+- `plugin_mastodon_normalize_tag_list()` — line 4711 — Normalize a list of tag labels.
+- `plugin_mastodon_extend_time_limit()` — line 6939 — Refresh or raise the PHP execution time budget for long-running Mastodon work without lowering an existing higher or unlimited limit.
+- `plugin_mastodon_extract_flatpress_tags()` — line 4742 — Extract FlatPress Tag plugin labels from an entry body.
+- `plugin_mastodon_strip_flatpress_tag_bbcode()` — line 4767 — Remove Tag plugin BBCode blocks from entry content.
+- `plugin_mastodon_mastodon_hashtag_footer()` — line 4784 — Convert FlatPress tag labels into a Mastodon hashtag footer line.
+- `plugin_mastodon_remote_status_tags()` — line 4805 — Collect remote Mastodon tags from a status entity.
+- `plugin_mastodon_strip_trailing_mastodon_hashtag_footer()` — line 4832 — Remove a trailing Mastodon hashtag footer from imported plain text.
+- `plugin_mastodon_build_flatpress_tag_bbcode()` — line 4895 — Build Tag plugin BBCode from a list of remote Mastodon tags.
+- `plugin_mastodon_emoticon_entity_to_unicode()` — line 4908 — Convert an emoticon HTML entity into a Unicode character.
+- `plugin_mastodon_emoticon_map()` — line 4921 — Return the FlatPress emoticon-to-Unicode lookup map.
+- `plugin_mastodon_replace_emoticon_shortcodes_with_unicode()` — line 4975 — Replace FlatPress emoticon shortcodes with Unicode glyphs.
+- `plugin_mastodon_prepare_emoticons_for_mastodon()` — line 4990 — Convert active FlatPress emoticon shortcodes to standard Unicode emoji before Mastodon export.
+- `plugin_mastodon_replace_unicode_emoticons_with_shortcodes()` — line 5003 — Replace Unicode emoticons with FlatPress shortcodes.
+- `plugin_mastodon_is_public_host()` — line 5025 — Determine whether a host name resolves to a public endpoint.
+- `plugin_mastodon_public_url_for_mastodon()` — line 5048 — Return a Mastodon-safe public URL or an empty string.
+- `plugin_mastodon_plain_text_from_bbcode()` — line 5067 — Convert FlatPress BBCode into plain text for Mastodon export, removing complete AudioVideo player tags including optional description endtag content.
+- `plugin_mastodon_subject_line_is_noise()` — line 5111 — Determine whether an extracted line should be ignored as a subject.
+- `plugin_mastodon_domains_match()` — line 5139 — Determine whether two host names belong to the same domain family.
+- `plugin_mastodon_cleanup_imported_text()` — line 5153 — Clean imported text before saving it to FlatPress.
+- `plugin_mastodon_dom_children_to_flatpress()` — line 5207 — Convert DOM child nodes into FlatPress BBCode text.
+- `plugin_mastodon_dom_node_to_flatpress()` — line 5225 — Convert a single DOM node into FlatPress BBCode text.
+- `plugin_mastodon_public_entry_url()` — line 5334 — Return the public URL for a FlatPress entry.
+- `plugin_mastodon_public_comments_url()` — line 5361 — Return the public comments URL for a FlatPress entry.
+- `plugin_mastodon_public_comment_url()` — line 5389 — Return the public URL for a specific FlatPress comment.
+- `plugin_mastodon_mastodon_html_to_flatpress()` — line 5404 — Convert Mastodon HTML content into FlatPress BBCode.
+- `plugin_mastodon_flatpress_to_mastodon()` — line 5506 — Convert FlatPress content into Mastodon-ready plain text.
+- `plugin_mastodon_limit_text()` — line 5623 — Limit text to a maximum number of characters.
 
 ## F. Local content access, media processing, hashing, and export ordering
 
-- `plugin_mastodon_entry_hash()` — line 5028 — Build a change-detection hash for a FlatPress entry.
-- `plugin_mastodon_comment_hash()` — line 5040 — Build a change-detection hash for a FlatPress comment.
-- `plugin_mastodon_remote_status_author_label()` — line 8032 — Build a readable author label for quoted Mastodon replies.
-- `plugin_mastodon_strip_leading_quote_block()` — line 8065 — Remove one leading BBCode quote block so imported reply quotes do not compound indefinitely.
-- `plugin_mastodon_imported_reply_quote_payload()` — line 8098 — Resolve the author and body that should be quoted for an imported Mastodon reply.
-- `plugin_mastodon_build_imported_reply_quote()` — line 8141 — Build the optional BBCode quote block for an imported Mastodon reply.
-- `plugin_mastodon_safe_path_component()` — line 5058 — Sanitize a string so it can be used as a path component.
-- `plugin_mastodon_safe_filename()` — line 5073 — Sanitize a file name for local storage.
-- `plugin_mastodon_media_relative_to_absolute()` — line 5109 — Resolve a FlatPress media path to an absolute file path.
-- `plugin_mastodon_media_prepare_directory()` — line 5122 — Ensure that a media directory exists.
-- `plugin_mastodon_media_delete_tree()` — line 5138 — Delete a directory tree used for imported media.
-- `plugin_mastodon_media_copy_tree()` — line 5165 — Copy a directory tree used for media synchronization.
-- `plugin_mastodon_bbcode_attr_escape()` — line 5203 — Escape a value for safe BBCode attribute usage.
-- `plugin_mastodon_bbcode_text_escape()` — line 5215 — Escape plain text embedded between BBCode tags, used for imported AudioVideo media descriptions.
-- `plugin_mastodon_media_guess_mime_type()` — line 5237 — Guess the MIME type of a local media file.
-- `plugin_mastodon_media_parse_tag_attributes()` — line 5459 — Parse key/value attributes from a FlatPress media tag.
-- `plugin_mastodon_media_description_from_bbcode_content()` — line 5490 — Normalize optional AudioVideo BBCode content into a Mastodon media description.
-- `plugin_mastodon_instance_supported_media_mime_types()` — line 5385 — Return the MIME types advertised by the configured Mastodon instance.
-- `plugin_mastodon_instance_media_size_limit()` — line 5405 — Return the configured byte-size limit for an image, video/GIFV, or audio upload.
-- `plugin_mastodon_validate_local_media_item()` — line 5432 — Validate one local media file against available instance MIME and byte-size limits before upload.
-- `plugin_mastodon_media_extract_default_path()` — line 5516 — Extract the default path parameter from FlatPress media BBCode such as `[img=...]`, `[gallery=...]`, `[audioplayer="..."]`, and `[videoplayer="..."]`.
-- `plugin_mastodon_add_local_media_item()` — line 5545 — Add one normalized local media item while deduplicating and enforcing an expected media family.
-- `plugin_mastodon_collect_local_entry_media()` — line 5594 — Collect local images, galleries, audio, video, optional AudioVideo endtag descriptions, and video poster thumbnails referenced by an entry.
-- `plugin_mastodon_prepare_entry_media_items()` — line 5732 — Normalize collected local media items into reusable path/description tuples.
-- `plugin_mastodon_entry_media_attachment_signature_from_items()` — line 5763 — Hash only the attachment identity of normalized media items.
-- `plugin_mastodon_entry_media_description_signature_from_items()` — line 5786 — Hash only the alt-text portion of normalized media items.
-- `plugin_mastodon_entry_media_signature()` — line 5805 — Build a combined attachment+description signature for media references contained in entry content.
-- `plugin_mastodon_remote_media_attachment_type()` — line 5822 — Normalize a Mastodon attachment type, including extension-based fallbacks for older or incomplete payloads.
-- `plugin_mastodon_remote_status_media_attachments()` — line 5849 — Extract supported image, audio, video, and GIFV attachments from a remote Mastodon status.
-- `plugin_mastodon_remote_status_image_attachments()` — line 5879 — Extract image attachments from a remote Mastodon status.
-- `plugin_mastodon_remote_media_source_url()` — line 5888 — Resolve the best downloadable source URL for a remote attachment.
-- `plugin_mastodon_remote_media_source_urls()` — line 5906 — Resolve direct-download fallback candidates for a remote attachment; audio/video/GIFV avoid `preview_url` as a file-source fallback, while images may use it.
-- `plugin_mastodon_remote_media_description()` — line 5928 — Resolve the best description for a remote attachment.
-- `plugin_mastodon_remote_media_focus()` — line 5942 — Normalize a Mastodon media focus string when present.
-- `plugin_mastodon_remote_media_descriptors_from_status()` — line 5959 — Extract reusable media descriptors (`id`, `description`, `focus`) from a Mastodon status payload.
-- `plugin_mastodon_remote_media_descriptors_from_media_ids()` — line 5990 — Build fallback reusable media descriptors from already-known IDs and local media items.
-- `plugin_mastodon_media_download()` — line 6057 — Download a remote media asset with an extended media-transfer timeout.
-- `plugin_mastodon_remote_download_basename()` — line 6071 — Build a safe local basename for a downloaded remote image, audio, video, GIFV, or poster.
-- `plugin_mastodon_store_remote_media_url()` — line 6101 — Download and persist one remote media URL.
-- `plugin_mastodon_build_imported_media_bbcode()` — line 6123 — Build FlatPress BBCode for imported remote media attachments: images become `[img]`/`[gallery]`, audio becomes `[audioplayer]`, and video/GIFV becomes `[videoplayer]` with imported optional description endtag text and an imported poster when available; alternate direct media URLs are retried before an attachment is skipped.
-- `plugin_mastodon_collect_entry_files()` — line 7090 — Collect entry files recursively from the FlatPress content tree.
-- `plugin_mastodon_local_item_timestamp()` — line 7117 — Resolve the best timestamp for a local FlatPress item.
-- `plugin_mastodon_compare_local_entries_for_export()` — line 7143 — Compare local FlatPress entries for Mastodon export order.
-- `plugin_mastodon_list_local_entries()` — line 7161 — List local FlatPress entry identifiers.
+- `plugin_mastodon_entry_hash()` — line 5645 — Build a change-detection hash for a FlatPress entry.
+- `plugin_mastodon_comment_hash()` — line 5657 — Build a change-detection hash for a FlatPress comment.
+- `plugin_mastodon_remote_status_author_label()` — line 8773 — Build a readable author label for quoted Mastodon replies.
+- `plugin_mastodon_strip_leading_quote_block()` — line 8806 — Remove one leading BBCode quote block so imported reply quotes do not compound indefinitely.
+- `plugin_mastodon_imported_reply_quote_payload()` — line 8839 — Resolve the author and body that should be quoted for an imported Mastodon reply.
+- `plugin_mastodon_build_imported_reply_quote()` — line 8882 — Build the optional BBCode quote block for an imported Mastodon reply.
+- `plugin_mastodon_safe_path_component()` — line 5675 — Sanitize a string so it can be used as a path component.
+- `plugin_mastodon_safe_filename()` — line 5690 — Sanitize a file name for local storage.
+- `plugin_mastodon_normalize_media_relative_path()` — line 5703 — Normalize a FlatPress media path and reject absolute, URL, or traversal paths.
+- `plugin_mastodon_media_relative_to_absolute()` — line 5726 — Resolve a FlatPress media path to an absolute file path.
+- `plugin_mastodon_media_prepare_directory()` — line 5739 — Ensure that a media directory exists.
+- `plugin_mastodon_media_delete_tree()` — line 5755 — Delete a directory tree used for imported media.
+- `plugin_mastodon_media_copy_tree()` — line 5782 — Copy a directory tree used for media synchronization.
+- `plugin_mastodon_bbcode_attr_escape()` — line 5820 — Escape a value for safe BBCode attribute usage.
+- `plugin_mastodon_bbcode_text_escape()` — line 5832 — Escape plain text embedded between BBCode tags, used for imported AudioVideo media descriptions.
+- `plugin_mastodon_media_guess_mime_type()` — line 5854 — Guess the MIME type of a local media file.
+- `plugin_mastodon_media_type_from_mime()` — line 5921 — Classify a MIME type or file extension as image, video, or audio for Mastodon media handling.
+- `plugin_mastodon_extension_from_mime_type()` — line 5955 — Resolve a safe file extension from a MIME type with a fallback.
+- `plugin_mastodon_media_parse_tag_attributes()` — line 6076 — Parse key/value attributes from a FlatPress media tag.
+- `plugin_mastodon_media_description_from_bbcode_content()` — line 6107 — Normalize optional AudioVideo BBCode content into a Mastodon media description.
+- `plugin_mastodon_instance_supported_media_mime_types()` — line 6002 — Return the MIME types advertised by the configured Mastodon instance.
+- `plugin_mastodon_instance_media_size_limit()` — line 6022 — Return the configured byte-size limit for an image, video/GIFV, or audio upload.
+- `plugin_mastodon_validate_local_media_item()` — line 6049 — Validate one local media file against available instance MIME and byte-size limits before upload.
+- `plugin_mastodon_media_extract_default_path()` — line 6133 — Extract the default path parameter from FlatPress media BBCode such as `[img=...]`, `[gallery=...]`, `[audioplayer="..."]`, and `[videoplayer="..."]`.
+- `plugin_mastodon_add_local_media_item()` — line 6162 — Add one normalized local media item while deduplicating and enforcing an expected media family.
+- `plugin_mastodon_collect_local_entry_media()` — line 6211 — Collect local images, galleries, audio, video, optional AudioVideo endtag descriptions, and video poster thumbnails referenced by an entry.
+- `plugin_mastodon_prepare_entry_media_items()` — line 6349 — Normalize collected local media items into reusable path/description tuples.
+- `plugin_mastodon_entry_media_attachment_signature_from_items()` — line 6380 — Hash only the attachment identity of normalized media items.
+- `plugin_mastodon_entry_media_description_signature_from_items()` — line 6403 — Hash only the alt-text portion of normalized media items.
+- `plugin_mastodon_entry_media_signature()` — line 6422 — Build a combined attachment+description signature for media references contained in entry content.
+- `plugin_mastodon_remote_media_attachment_type()` — line 6439 — Normalize a Mastodon attachment type, including extension-based fallbacks for older or incomplete payloads.
+- `plugin_mastodon_remote_status_media_attachments()` — line 6466 — Extract supported image, audio, video, and GIFV attachments from a remote Mastodon status.
+- `plugin_mastodon_remote_status_image_attachments()` — line 6496 — Extract image attachments from a remote Mastodon status.
+- `plugin_mastodon_remote_media_source_url()` — line 6505 — Resolve the best downloadable source URL for a remote attachment.
+- `plugin_mastodon_remote_media_source_urls()` — line 6523 — Resolve direct-download fallback candidates for a remote attachment; audio/video/GIFV avoid `preview_url` as a file-source fallback, while images may use it.
+- `plugin_mastodon_remote_media_description()` — line 6545 — Resolve the best description for a remote attachment.
+- `plugin_mastodon_remote_media_focus()` — line 6559 — Normalize a Mastodon media focus string when present.
+- `plugin_mastodon_remote_media_descriptors_from_status()` — line 6576 — Extract reusable media descriptors (`id`, `description`, `focus`) from a Mastodon status payload.
+- `plugin_mastodon_remote_media_descriptors_from_media_ids()` — line 6607 — Build fallback reusable media descriptors from already-known IDs and local media items.
+- `plugin_mastodon_media_download()` — line 6674 — Download a remote media asset with an extended media-transfer timeout.
+- `plugin_mastodon_remote_download_basename()` — line 6688 — Build a safe local basename for a downloaded remote image, audio, video, GIFV, or poster.
+- `plugin_mastodon_store_remote_media_url()` — line 6718 — Download and persist one remote media URL.
+- `plugin_mastodon_build_imported_media_bbcode()` — line 6740 — Build FlatPress BBCode for imported remote media attachments: images become `[img]`/`[gallery]`, audio becomes `[audioplayer]`, and video/GIFV becomes `[videoplayer]` with imported optional description endtag text and an imported poster when available; alternate direct media URLs are retried before an attachment is skipped.
+- `plugin_mastodon_collect_entry_files()` — line 7707 — Collect entry files recursively from the FlatPress content tree.
+- `plugin_mastodon_local_item_timestamp()` — line 7734 — Resolve the best timestamp for a local FlatPress item.
+- `plugin_mastodon_compare_local_entries_for_export()` — line 7763 — Compare local FlatPress entries for Mastodon export order.
+- `plugin_mastodon_test_note_local_entry_parse()` — line 7782 — Simulation-only no-op counter hook used to prove targeted scheduled scans avoid parsing all old local entries.
+- `plugin_mastodon_dirty_entry_id_lookup()` — line 7794 — Collect local entry IDs that must be parsed because an entry or one of its comments is present in the dirty queues.
+- `plugin_mastodon_should_parse_local_entry_for_sync()` — line 7825 — Decide whether one entry belongs to the active scheduled window, the dirty target set, or an explicit full scan.
+- `plugin_mastodon_list_local_entries_for_sync()` — line 7850 — Build the local export candidate list for scheduled/non-full runs from active-window entries plus dirty targets while preserving full repair scans.
+- `plugin_mastodon_list_local_entries()` — line 7891 — List local FlatPress entry identifiers.
 
 ## G. HTTP transport, PHP timeout budgeting, instance capability lookup, status-length budgeting, OAuth, Mastodon API calls, and media upload
 
-- `plugin_mastodon_extend_time_limit()` — line 6322 — Refresh or raise the PHP execution time budget for long-running Mastodon work without lowering an existing higher or unlimited limit.
-- `plugin_mastodon_instance_document()` — line 6353 — Load and cache the compact Mastodon instance document, preferring the saved FlatPress snapshot before APCu and live network fetches.
-- `plugin_mastodon_instance_version()` — line 6397 — Extract the human-readable Mastodon server version from the cached instance document.
-- `plugin_mastodon_instance_supports_status_media_attributes()` — line 6415 — Decide whether `PUT /api/v1/statuses/:id` may safely use `media_attributes` for in-place alt-text edits.
-- `plugin_mastodon_instance_configuration()` — line 6432 — Return the normalized `configuration` subtree from the cached Mastodon instance document.
-- `plugin_mastodon_instance_media_limit()` — line 6442 — Return the media attachment limit of the configured instance.
-- `plugin_mastodon_instance_media_description_limit()` — line 6455 — Return the media description length limit of the configured instance.
-- `plugin_mastodon_instance_url_reserved_length()` — line 6468 — Return the reserved Mastodon character budget used for each URL.
-- `plugin_mastodon_instance_registration_summary()` — line 9146 — Summarize the cached registration policy advertised by the instance for the admin diagnostics table.
-- `plugin_mastodon_admin_instance_info_rows()` — line 9172 — Build the localized admin-table rows from the cached instance-information snapshot without forcing another live request.
-- `plugin_mastodon_status_text_length()` — line 6482 — Calculate the Mastodon-visible status length with instance URL budgeting.
-- `plugin_mastodon_limit_status_text()` — line 6514 — Truncate status text using Mastodon URL-budget rules.
-- `plugin_mastodon_http_request_multipart()` — line 6593 — Perform a multipart HTTP request.
-- `plugin_mastodon_fetch_media_attachment()` — line 6726 — Fetch a single Mastodon media attachment by ID.
-- `plugin_mastodon_media_processing_attempts()` — line 6791 — Calculate media-type- and size-aware polling attempts for asynchronous Mastodon media processing.
-- `plugin_mastodon_media_transfer_timeout()` — line 6815 — Calculate longer upload transfer timeouts for audio/video/GIFV while keeping image uploads lighter.
-- `plugin_mastodon_wait_for_media_attachment()` — line 6835 — Poll an asynchronously processed Mastodon media attachment until it is ready or times out, including pending audio/video responses without `preview_url`.
-- `plugin_mastodon_upload_media_items()` — line 6884 — Upload local media items to Mastodon and collect the created media IDs; AudioVideo posters are sent as Mastodon `thumbnail` multipart fields for video uploads.
-- `plugin_mastodon_parse_http_response_headers()` — line 7198 — Parse raw HTTP response headers.
-- `plugin_mastodon_stream_context_request()` — line 7228 — Perform an HTTP request through a stream context fallback.
-- `plugin_mastodon_status_media_attributes()` — line 6024 — Build the `media_attributes` array used for in-place status edits of already attached media.
-- `plugin_mastodon_prepare_entry_media_sync_plan()` — line 7001 — Decide whether an entry should upload fresh media, reuse stored IDs, or reuse IDs plus `media_attributes`.
-- `plugin_mastodon_array_is_list()` — line 7268 — Detect whether a PHP array is a zero-based list that should use `[]` form-field notation.
-- `plugin_mastodon_array_contains_only_form_scalars()` — line 7288 — Detect whether a list can be serialized as repeated scalar `[]` fields.
-- `plugin_mastodon_http_build_query()` — line 7306 — Build an application/x-www-form-urlencoded query string, emitting Rack-compatible Mastodon array fields such as `media_ids[]` and nested `media_attributes[][description]`.
-- `plugin_mastodon_http_request()` — line 7362 — Perform an HTTP request using cURL or the stream fallback.
-- `plugin_mastodon_mastodon_api()` — line 7480 — Call the Mastodon API and return the raw HTTP response.
-- `plugin_mastodon_mastodon_json()` — line 7529 — Call the Mastodon API and decode a JSON response.
-- `plugin_mastodon_response_error_message()` — line 7544 — Extract the most useful error message from an API response.
-- `plugin_mastodon_oauth_legacy_scopes()` — line 542 — Return the legacy OAuth scope string used by older registrations.
-- `plugin_mastodon_oauth_profile_scopes()` — line 550 — Return the stricter scope string that uses `profile` for `verify_credentials`.
-- `plugin_mastodon_oauth_server_metadata()` — line 559 — Discover OAuth server metadata from `/.well-known/oauth-authorization-server`.
-- `plugin_mastodon_oauth_supported_scopes()` — line 578 — Extract the discoverable scope list from OAuth server metadata.
-- `plugin_mastodon_oauth_scope_supported()` — line 615 — Check whether the configured Mastodon instance supports a given OAuth scope.
-- `plugin_mastodon_oauth_preferred_scopes()` — line 636 — Prefer `profile` on current instances and fall back to `read:accounts` on older ones.
-- `plugin_mastodon_register_app()` — line 7573 — Register the FlatPress application on the configured Mastodon instance with the preferred discoverable scope set.
-- `plugin_mastodon_build_authorize_url()` — line 7596 — Build the OAuth authorization URL using the scopes that the registered app may safely request.
-- `plugin_mastodon_exchange_code_for_token()` — line 7616 — Exchange an OAuth authorization code for an access token using the same negotiated scope string.
-- `plugin_mastodon_verify_credentials()` — line 7646 — Verify the currently configured access token.
-- `plugin_mastodon_instance_character_limit()` — line 7663 — Return the status character limit of the configured instance.
-- `plugin_mastodon_fetch_account_statuses()` — line 7678 — Fetch statuses for the authenticated Mastodon account.
-- `plugin_mastodon_fetch_status_context()` — line 7725 — Fetch the conversation context for a Mastodon status.
-- `plugin_mastodon_fetch_status()` — line 7736 — Fetch a single Mastodon status.
-- `plugin_mastodon_delete_status()` — line 7747 — Delete a Mastodon status, including media when requested.
-- `plugin_mastodon_status_missing_response()` — line 7760 — Check whether an API response means that the referenced Mastodon status no longer exists.
-- `plugin_mastodon_create_status()` — line 7773 — Create a Mastodon status.
-- `plugin_mastodon_update_status()` — line 7800 — Update an existing Mastodon status.
+- `plugin_mastodon_extend_time_limit()` — line 6939 — Refresh or raise the PHP execution time budget for long-running Mastodon work without lowering an existing higher or unlimited limit.
+- `plugin_mastodon_instance_document()` — line 6970 — Load and cache the compact Mastodon instance document, preferring the saved FlatPress snapshot before APCu and live network fetches.
+- `plugin_mastodon_instance_version()` — line 7014 — Extract the human-readable Mastodon server version from the cached instance document.
+- `plugin_mastodon_instance_supports_status_media_attributes()` — line 7032 — Decide whether `PUT /api/v1/statuses/:id` may safely use `media_attributes` for in-place alt-text edits.
+- `plugin_mastodon_instance_configuration()` — line 7049 — Return the normalized `configuration` subtree from the cached Mastodon instance document.
+- `plugin_mastodon_instance_media_limit()` — line 7059 — Return the media attachment limit of the configured instance.
+- `plugin_mastodon_instance_media_description_limit()` — line 7072 — Return the media description length limit of the configured instance.
+- `plugin_mastodon_instance_url_reserved_length()` — line 7085 — Return the reserved Mastodon character budget used for each URL.
+- `plugin_mastodon_instance_registration_summary()` — line 9983 — Summarize the cached registration policy advertised by the instance for the admin diagnostics table.
+- `plugin_mastodon_admin_instance_info_rows()` — line 10009 — Build the localized admin-table rows from the cached instance-information snapshot without forcing another live request.
+- `plugin_mastodon_status_text_length()` — line 7099 — Calculate the Mastodon-visible status length with instance URL budgeting.
+- `plugin_mastodon_limit_status_text()` — line 7131 — Truncate status text using Mastodon URL-budget rules.
+- `plugin_mastodon_http_request_multipart()` — line 7210 — Perform a multipart HTTP request.
+- `plugin_mastodon_fetch_media_attachment()` — line 7343 — Fetch a single Mastodon media attachment by ID.
+- `plugin_mastodon_media_processing_attempts()` — line 7408 — Calculate media-type- and size-aware polling attempts for asynchronous Mastodon media processing.
+- `plugin_mastodon_media_transfer_timeout()` — line 7432 — Calculate longer upload transfer timeouts for audio/video/GIFV while keeping image uploads lighter.
+- `plugin_mastodon_wait_for_media_attachment()` — line 7452 — Poll an asynchronously processed Mastodon media attachment until it is ready or times out, including pending audio/video responses without `preview_url`.
+- `plugin_mastodon_upload_media_items()` — line 7501 — Upload local media items to Mastodon and collect the created media IDs; AudioVideo posters are sent as Mastodon `thumbnail` multipart fields for video uploads.
+- `plugin_mastodon_parse_http_response_headers()` — line 7929 — Parse raw HTTP response headers.
+- `plugin_mastodon_stream_context_request()` — line 7959 — Perform an HTTP request through a stream context fallback.
+- `plugin_mastodon_status_media_attributes()` — line 6641 — Build the `media_attributes` array used for in-place status edits of already attached media.
+- `plugin_mastodon_prepare_entry_media_sync_plan()` — line 7618 — Decide whether an entry should upload fresh media, reuse stored IDs, or reuse IDs plus `media_attributes`.
+- `plugin_mastodon_array_is_list()` — line 7999 — Detect whether a PHP array is a zero-based list that should use `[]` form-field notation.
+- `plugin_mastodon_array_contains_only_form_scalars()` — line 8019 — Detect whether a list can be serialized as repeated scalar `[]` fields.
+- `plugin_mastodon_http_build_query()` — line 8037 — Build an application/x-www-form-urlencoded query string, emitting Rack-compatible Mastodon array fields such as `media_ids[]` and nested `media_attributes[][description]`.
+- `plugin_mastodon_http_request()` — line 8093 — Perform an HTTP request using cURL or the stream fallback.
+- `plugin_mastodon_mastodon_api()` — line 8211 — Call the Mastodon API and return the raw HTTP response.
+- `plugin_mastodon_mastodon_json()` — line 8260 — Call the Mastodon API and decode a JSON response.
+- `plugin_mastodon_response_error_message()` — line 8275 — Extract the most useful error message from an API response.
+- `plugin_mastodon_oauth_legacy_scopes()` — line 563 — Return the legacy OAuth scope string used by older registrations.
+- `plugin_mastodon_oauth_profile_scopes()` — line 571 — Return the stricter scope string that uses `profile` for `verify_credentials`.
+- `plugin_mastodon_oauth_server_metadata()` — line 580 — Discover OAuth server metadata from `/.well-known/oauth-authorization-server`.
+- `plugin_mastodon_oauth_supported_scopes()` — line 599 — Extract the discoverable scope list from OAuth server metadata.
+- `plugin_mastodon_oauth_scope_supported()` — line 636 — Check whether the configured Mastodon instance supports a given OAuth scope.
+- `plugin_mastodon_oauth_preferred_scopes()` — line 657 — Prefer `profile` on current instances and fall back to `read:accounts` on older ones.
+- `plugin_mastodon_register_app()` — line 8304 — Register the FlatPress application on the configured Mastodon instance with the preferred discoverable scope set.
+- `plugin_mastodon_build_authorize_url()` — line 8327 — Build the OAuth authorization URL using the scopes that the registered app may safely request.
+- `plugin_mastodon_exchange_code_for_token()` — line 8347 — Exchange an OAuth authorization code for an access token using the same negotiated scope string.
+- `plugin_mastodon_verify_credentials()` — line 8377 — Verify the currently configured access token.
+- `plugin_mastodon_instance_character_limit()` — line 8394 — Return the status character limit of the configured instance.
+- `plugin_mastodon_fetch_account_statuses()` — line 8409 — Fetch statuses for the authenticated Mastodon account.
+- `plugin_mastodon_fetch_status_context()` — line 8456 — Fetch the conversation context for a Mastodon status.
+- `plugin_mastodon_fetch_status()` — line 8467 — Fetch a single Mastodon status.
+- `plugin_mastodon_delete_status()` — line 8478 — Delete a Mastodon status, including media when requested.
+- `plugin_mastodon_status_missing_response()` — line 8491 — Check whether an API response means that the referenced Mastodon status no longer exists.
+- `plugin_mastodon_create_status()` — line 8504 — Create a Mastodon status.
+- `plugin_mastodon_update_status()` — line 8531 — Update an existing Mastodon status.
 
 ## H. Import/export builders and synchronization orchestration
 
-- `plugin_mastodon_build_entry_status_text()` — line 7826 — Build the status body used when exporting a FlatPress entry.
-- `plugin_mastodon_build_comment_status_text()` — line 7894 — Build the status body used when exporting a FlatPress comment.
-- `plugin_mastodon_import_remote_entry()` — line 7932 — Import a remote Mastodon status into FlatPress as an entry.
-- `plugin_mastodon_import_remote_comment()` — line 8183 — Import a remote Mastodon reply into FlatPress as a comment while respecting comment tombstones, including early tombstones for locally deleted exported comments.
-- `plugin_mastodon_import_remote_context_descendants()` — line 8267 — Import remote Mastodon replies from a fetched thread context while blocking tombstoned parent/child replies.
-- `plugin_mastodon_old_thread_context_rotation_limit()` — line 8368 — Return the maximum number of known synchronized threads checked for replies per content sync run.
-- `plugin_mastodon_collect_known_entry_context_targets()` — line 8384 — Collect known synchronized entry threads for optional rotating reply-context refreshes while respecting the synchronization start-date window.
-- `plugin_mastodon_sync_remote_to_local()` — line 8457 — Synchronize remote Mastodon content into FlatPress with the durable start-date lower bound, scheduled-run window, and optional known-thread reply rotation.
-- `plugin_mastodon_sync_local_to_remote()` — line 8524 — Synchronize local FlatPress content to Mastodon, including remote-sourced entry comment export, scheduled-run window filtering, dirty-queue processing, media-plan reuse of stored `media_ids`, and version-aware in-place alt-text updates.
-- `plugin_mastodon_run_deletion_sync()` — line 8847 — Reconcile mapped deletions between FlatPress and Mastodon in a separate follow-up request, limiting scheduled remote existence lookups to the active window while cursoring large mapping sets.
+- `plugin_mastodon_build_entry_status_text()` — line 8557 — Build the status body used when exporting a FlatPress entry.
+- `plugin_mastodon_build_comment_status_text()` — line 8625 — Build the status body used when exporting a FlatPress comment.
+- `plugin_mastodon_import_remote_entry()` — line 8663 — Import a remote Mastodon status into FlatPress as an entry.
+- `plugin_mastodon_import_remote_comment()` — line 8924 — Import a remote Mastodon reply into FlatPress as a comment while respecting comment tombstones, including early tombstones for locally deleted exported comments.
+- `plugin_mastodon_import_remote_context_descendants()` — line 9013 — Import remote Mastodon replies from a fetched thread context while blocking tombstoned parent/child replies.
+- `plugin_mastodon_old_thread_context_rotation_limit()` — line 9114 — Return the maximum number of known synchronized threads checked for replies per content sync run.
+- `plugin_mastodon_collect_known_entry_context_targets()` — line 9130 — Collect known synchronized entry threads for optional rotating reply-context refreshes while respecting the synchronization start-date window.
+- `plugin_mastodon_sync_remote_to_local()` — line 9203 — Synchronize remote Mastodon content into FlatPress with the durable start-date lower bound, scheduled-run window, and optional known-thread reply rotation.
+- `plugin_mastodon_sync_local_to_remote()` — line 9270 — Synchronize local FlatPress content to Mastodon, including remote-sourced entry comment export, scheduled-run window filtering, dirty-queue processing, media-plan reuse of stored `media_ids`, and version-aware in-place alt-text updates.
+- `plugin_mastodon_run_deletion_sync()` — line 9501 — Reconcile mapped deletions between FlatPress and Mastodon in a separate follow-up request, limiting scheduled remote existence lookups to the active window while cursoring large mapping sets.
 
 ## Recommended reading order for new developers
 
@@ -490,27 +527,29 @@ A practical way to understand the plugin is:
 7. `plugin_mastodon_import_remote_entry()`
 8. `plugin_mastodon_import_remote_comment()`
 9. `plugin_mastodon_state_read()` / `plugin_mastodon_state_write()`
-10. `plugin_mastodon_get_options()`
-11. `plugin_mastodon_enabled_plugin_state()`
-12. `plugin_mastodon_extend_time_limit()`
-13. `plugin_mastodon_instance_configuration()`
-14. `plugin_mastodon_instance_url_reserved_length()` / `plugin_mastodon_status_text_length()` / `plugin_mastodon_limit_status_text()`
-15. `plugin_mastodon_http_request()`
-16. `plugin_mastodon_collect_local_entry_media()`
-17. `plugin_mastodon_upload_media_items()` / `plugin_mastodon_wait_for_media_attachment()`
+10. `plugin_mastodon_scheduler_state_read()` / `plugin_mastodon_scheduler_state_write()`
+11. `plugin_mastodon_get_options()`
+12. `plugin_mastodon_enabled_plugin_state()`
+13. `plugin_mastodon_extend_time_limit()`
+14. `plugin_mastodon_instance_configuration()`
+15. `plugin_mastodon_instance_url_reserved_length()` / `plugin_mastodon_status_text_length()` / `plugin_mastodon_limit_status_text()`
+16. `plugin_mastodon_http_request()`
+17. `plugin_mastodon_collect_local_entry_media()`
+18. `plugin_mastodon_upload_media_items()` / `plugin_mastodon_wait_for_media_attachment()`
 
 ## Current feature areas reflected in the function set
 
 The current plugin version includes dedicated function groups for:
 
 - Mastodon identity metadata in the HTML head
-- runtime cache and optional APCu-backed shared cache
+- request-local runtime cache, optional APCu-backed small-value/cache guards, and core APCu file hotcache usage for compact scheduler summaries
 - reuse of the early FlatPress configuration (`EARLY_FP_CONFIG`) with APCu/runtime fallbacks
 - centralized FlatPress plugin-state detection for companion-plugin diagnostics
-- FlatPress-native file I/O wrappers for plugin state, logs, and downloaded media
+- FlatPress-native file I/O wrappers for plugin state, APCu-capable scheduler summary reads, rotated append-only logs, and downloaded media
+- request-time scheduler due checks that avoid loading the full `state.json` mappings when no sync is due and can benefit from the core file/APCu hotcache for `scheduler-state.json`
 - encrypted storage of sensitive configuration values
 - sync start date filtering plus a configurable 7/14/30-day automatic window for scheduled runs
-- persistent dirty queues that still synchronize changed older mapped entries and comments outside the scheduled window
+- Core-hook-fed persistent dirty queues that still synchronize changed older mapped entries and comments outside the scheduled window
 - optional rotating reply checks for known synchronized Mastodon threads
 - status language export derived from the FlatPress locale configuration
 - optional remote overwrite of existing local content
@@ -545,263 +584,281 @@ When changing the plugin, these clusters usually need to stay in sync:
 A change in one of these areas often requires corresponding updates in the simulation script.
 
 ## Alphabetical appendix
-- `main()` — line 8999 — Keep the admin panel lifecycle compatible with FlatPress without extra processing.
-- `onsubmit()` — line 9003 — Process configuration saves, OAuth actions, including app registration and authorization-code exchange, and the manual synchronization trigger.
-- `plugin_mastodon_absolute_url()` — line 3826 — Convert a URL or path into an absolute URL when possible.
-- `plugin_mastodon_admin_assign()` — line 9244 — Assign plugin data to Smarty for the admin panel.
-- `plugin_mastodon_apcu_cache_key()` — line 1011 — Build the namespaced APCu key used by this plugin.
-- `plugin_mastodon_apcu_delete()` — line 1053 — Delete a value from APCu using the FlatPress namespace key builder.
-- `plugin_mastodon_apcu_enabled()` — line 1002 — Check whether shared APCu caching is available for the plugin.
-- `plugin_mastodon_apcu_fetch()` — line 1025 — Fetch a value from APCu through the FlatPress namespace helper.
-- `plugin_mastodon_apcu_store()` — line 1040 — Store a value in APCu through the FlatPress namespace helper.
-- `plugin_mastodon_state_fallback_key()` — line 1065 — Return the APCu key used for the short-lived last-known-good state fallback.
-- `plugin_mastodon_state_fallback_store()` — line 1074 — Store a normalized runtime state in APCu for a 5-minute emergency fallback window.
-- `plugin_mastodon_state_fallback_read()` — line 1086 — Fetch the short-lived last-known-good state fallback from APCu.
-- `plugin_mastodon_sync_guard_kind()` — line 1104 — Normalize the cooldown guard kind.
-- `plugin_mastodon_sync_guard_apcu_key()` — line 1114 — Return the APCu key used for one sync cooldown guard.
-- `plugin_mastodon_sync_guard_entry_active()` — line 1124 — Check whether one cooldown guard entry is still active.
-- `plugin_mastodon_sync_guard_apcu_store()` — line 1135 — Store one cooldown guard in APCu.
-- `plugin_mastodon_sync_guard_file_read()` — line 1148 — Read and prune the file-backed cooldown guard.
-- `plugin_mastodon_sync_guard_file_write()` — line 1175 — Write the file-backed cooldown guard.
-- `plugin_mastodon_sync_guard_active()` — line 1196 — Check whether a recent scheduled content/deletion pass is still cooling down.
-- `plugin_mastodon_sync_guard_mark()` — line 1221 — Mark a 5-minute cooldown guard for a scheduled sync/deletion pass.
-- `plugin_mastodon_sync_guard_clear()` — line 1242 — Clear one sync cooldown guard.
-- `plugin_mastodon_rate_limit_default_budgets()` — line 1257 — Return conservative per-run Mastodon API budgets.
-- `plugin_mastodon_rate_limit_window_budgets()` — line 1281 — Return persistent cross-run Mastodon API window budgets.
-- `plugin_mastodon_rate_limit_window_config()` — line 1308 — Return the persistent window key, budget, TTL, and block reason for one request kind.
-- `plugin_mastodon_rate_limit_window_entry()` — line 1328 — Normalize one persistent rate-limit window entry and drop expired values.
-- `plugin_mastodon_rate_limit_window_read()` — line 1348 — Read and prune the persistent cross-run rate-limit windows.
-- `plugin_mastodon_rate_limit_window_write()` — line 1380 — Persist cross-run rate-limit windows with FlatPress file permissions.
-- `plugin_mastodon_rate_limit_window_acquire()` — line 1405 — Reserve one media-upload/delete/account-status-page slot from the persistent cross-run window.
-- `plugin_mastodon_rate_limit_window_clear()` — line 1454 — Clear persistent rate-limit windows for tests or recovery tooling.
-- `plugin_mastodon_rate_limit_guard_start()` — line 1466 — Start the per-run Mastodon API rate-limit guard.
-- `plugin_mastodon_rate_limit_guard_stop()` — line 1492 — Stop the per-run Mastodon API rate-limit guard while keeping its summary inspectable.
-- `plugin_mastodon_rate_limit_guard_active()` — line 1503 — Check whether the per-run Mastodon API guard is active.
-- `plugin_mastodon_rate_limit_guard_summary()` — line 1511 — Return the current per-run rate-limit guard summary.
-- `plugin_mastodon_rate_limit_headers()` — line 1520 — Normalize response headers for rate-limit checks.
-- `plugin_mastodon_rate_limit_request_kind()` — line 1541 — Classify Mastodon API requests as general, media upload, status deletion, or account-status paging.
-- `plugin_mastodon_rate_limit_block()` — line 1566 — Mark the current run as blocked by a rate-limit budget, persistent window, or Mastodon response and log the stop reason with budget counters once per run.
-- `plugin_mastodon_rate_limit_acquire()` — line 1610 — Reserve per-run and persistent window budget before a Mastodon API request proceeds.
-- `plugin_mastodon_rate_limit_observe_response()` — line 1655 — Update the guard from `X-RateLimit-*` headers and `429` responses.
-- `plugin_mastodon_rate_limit_blocked_reason()` — line 1679 — Return the current rate-limit block reason.
-- `plugin_mastodon_rate_limit_blocked_response()` — line 1691 — Build the synthetic `429` response used for locally blocked requests.
-- `plugin_mastodon_rate_limit_state_error()` — line 1707 — Return the rate-limit reason that should be written to synchronization state.
-- `plugin_mastodon_bbcode_attr_escape()` — line 5203 — Escape a value for safe BBCode attribute usage.
-- `plugin_mastodon_bbcode_text_escape()` — line 5215 — Escape plain text embedded between BBCode tags.
-- `plugin_mastodon_bbcode_plugin_active()` — line 3980 — Determine whether the BBCode plugin is active for the current FlatPress request.
-- `plugin_mastodon_blog_base_url()` — line 3773 — Return the absolute base URL of the current FlatPress installation.
-- `plugin_mastodon_build_authorize_url()` — line 7596 — Build the OAuth authorization URL using the scopes that the registered app may safely request.
-- `plugin_mastodon_build_comment_status_text()` — line 7894 — Build the status body used when exporting a FlatPress comment.
-- `plugin_mastodon_build_entry_status_text()` — line 7826 — Build the status body used when exporting a FlatPress entry.
-- `plugin_mastodon_build_flatpress_tag_bbcode()` — line 4278 — Build Tag plugin BBCode from a list of remote Mastodon tags.
-- `plugin_mastodon_build_imported_media_bbcode()` — line 6123 — Build FlatPress BBCode for imported remote media attachments, including AudioVideo optional description endtag text.
-- `plugin_mastodon_cleanup_imported_text()` — line 4536 — Clean imported text before saving it to FlatPress.
-- `plugin_mastodon_cleanup_uploaded_media()` — line 6755 — Best-effort cleanup for uploaded Mastodon media that never reached a final status request.
-- `plugin_mastodon_collect_entry_files()` — line 7090 — Collect entry files recursively from the FlatPress content tree.
-- `plugin_mastodon_collect_known_entry_context_targets()` — line 8384 — Collect known synchronized entry threads that should have their Mastodon reply context refreshed while respecting the synchronization start-date window.
-- `plugin_mastodon_collect_local_entry_media()` — line 5594 — Collect local images, galleries, AudioVideo media, optional AudioVideo endtag descriptions, and video poster thumbnails referenced by an entry.
-- `plugin_mastodon_comment_hash()` — line 5040 — Build a change-detection hash for a FlatPress comment.
-- `plugin_mastodon_comment_parent_fields()` — line 3584 — Return the comment fields that may contain a parent reference.
-- `plugin_mastodon_companion_plugins_status()` — line 4046 — Return the status of companion FlatPress plugins used for the full Mastodon feature set.
-- `plugin_mastodon_compare_local_entries_for_export()` — line 7143 — Compare local FlatPress entries for Mastodon export order.
-- `plugin_mastodon_configured_status_language()` — line 2168 — Read the configured FlatPress locale and return the Mastodon language code.
-- `plugin_mastodon_create_status()` — line 7773 — Create a Mastodon status.
-- `plugin_mastodon_date_matches_content_window()` — line 2481 — Combine the durable sync-start lower bound with the scheduled-run recent-content window.
-- `plugin_mastodon_date_matches_sync_start()` — line 2446 — Determine whether a content date passes the configured sync start date.
-- `plugin_mastodon_datetime_date_key()` — line 2422 — Normalize a stored date/datetime string to the sync-start date-key format.
-- `plugin_mastodon_default_content_stats()` — line 484 — Return the default counters for the last content synchronization.
-- `plugin_mastodon_default_deletion_stats()` — line 501 — Return the default counters for the last deletion synchronization.
-- `plugin_mastodon_default_options()` — line 101 — Return the default plugin option values.
-- `plugin_mastodon_default_state()` — line 514 — Return the default runtime state structure, including the targeted deletion-follow-up scope marker and deletion progress cursors.
-- `plugin_mastodon_delete_media_attachment()` — line 6736 — Delete an uploaded Mastodon media attachment before it is attached to a final status.
-- `plugin_mastodon_delete_status()` — line 7747 — Delete a Mastodon status, including media when requested.
-- `plugin_mastodon_detect_local_comment_parent_id()` — line 3610 — Detect the local parent comment identifier from comment data.
-- `plugin_mastodon_dom_children_to_flatpress()` — line 4590 — Convert DOM child nodes into FlatPress BBCode text.
-- `plugin_mastodon_dom_node_to_flatpress()` — line 4608 — Convert a single DOM node into FlatPress BBCode text.
-- `plugin_mastodon_domains_match()` — line 4522 — Determine whether two host names belong to the same domain family.
-- `plugin_mastodon_emoticon_entity_to_unicode()` — line 4291 — Convert an emoticon HTML entity into a Unicode character.
-- `plugin_mastodon_emoticon_map()` — line 4304 — Return the FlatPress emoticon-to-Unicode lookup map.
-- `plugin_mastodon_emoticons_plugin_active()` — line 4031 — Determine whether the Emoticons plugin is active for the current FlatPress request.
-- `plugin_mastodon_enabled_plugin_state()` — line 3898 — Determine whether a FlatPress plugin is enabled in the centralized plugin configuration.
-- `plugin_mastodon_ensure_state_dir()` — line 2587 — Ensure that the plugin runtime directory exists.
-- `plugin_mastodon_entry_hash()` — line 5028 — Build a change-detection hash for a FlatPress entry.
-- `plugin_mastodon_entry_media_signature()` — line 5805 — Build a signature for media references contained in entry content.
-- `plugin_mastodon_exchange_code_for_token()` — line 7616 — Exchange an OAuth authorization code for an access token using the same negotiated scope string.
-- `plugin_mastodon_extend_time_limit()` — line 6322 — Refresh or raise the PHP execution time budget for long-running Mastodon work without lowering an existing higher or unlimited limit.
-- `plugin_mastodon_extract_flatpress_tags()` — line 4125 — Extract FlatPress Tag plugin labels from an entry body.
-- `plugin_mastodon_extract_url_token()` — line 3809 — Extract the URL token from a BBCode or attribute fragment.
-- `plugin_mastodon_fediverse_creator_value()` — line 2088 — Build the fediverse creator meta value.
-- `plugin_mastodon_fetch_account_statuses()` — line 7678 — Fetch statuses for the authenticated Mastodon account.
-- `plugin_mastodon_fetch_media_attachment()` — line 6726 — Fetch a single Mastodon media attachment by ID.
-- `plugin_mastodon_fetch_status()` — line 7736 — Fetch a single Mastodon status.
-- `plugin_mastodon_fetch_status_context()` — line 7725 — Fetch the conversation context for a Mastodon status.
-- `plugin_mastodon_file_prestat()` — line 1717 — Read a cheap file metadata snapshot for cache validation.
-- `plugin_mastodon_file_prestat_signature()` — line 1737 — Convert a file metadata snapshot into a stable cache signature.
-- `plugin_mastodon_flatpress_to_mastodon()` — line 4889 — Convert FlatPress content into Mastodon-ready plain text.
-- `plugin_mastodon_fp_config()` — line 730 — Return the FlatPress configuration, preferring the early-loaded core cache.
-- `plugin_mastodon_fp_config_value()` — line 766 — Read a nested FlatPress configuration value.
-- `plugin_mastodon_fp_timeoffset_seconds()` — line 782 — Return the configured FlatPress time offset in seconds for exact local admin-time conversion.
-- `plugin_mastodon_fp_timeoffset_label()` — line 802 — Format the configured FlatPress time offset as a UTC label for admin users.
-- `plugin_mastodon_sync_time_to_minutes()` — line 832 — Convert a normalized `HH:MM` sync-time value into minutes after midnight.
-- `plugin_mastodon_minutes_to_sync_time()` — line 843 — Convert minutes after midnight back into a normalized `HH:MM` sync-time value.
-- `plugin_mastodon_sync_time_utc_to_local()` — line 859 — Convert the stored UTC synchronization time to the FlatPress-local admin time.
-- `plugin_mastodon_sync_time_local_to_utc()` — line 870 — Convert the FlatPress-local admin synchronization time back to stored UTC.
-- `plugin_mastodon_format_admin_datetime()` — line 881 — Format stored UTC timestamps for the admin panel using FlatPress `timeoffset`, date format, and time format.
-- `plugin_mastodon_get_options()` — line 1748 — Load the saved plugin options and merge them with defaults.
-- `plugin_mastodon_guess_subject()` — line 3722 — Guess a subject line from imported plain text.
-- `plugin_mastodon_head()` — line 2106 — Print Mastodon profile metadata into the HTML head.
-- `plugin_mastodon_html_entity_decode()` — line 3764 — Decode HTML entities using the plugin defaults.
-- `plugin_mastodon_http_build_query()` — line 7306 — Build an application/x-www-form-urlencoded query string.
-- `plugin_mastodon_http_request()` — line 7362 — Perform an HTTP request using cURL or the stream fallback.
-- `plugin_mastodon_http_request_multipart()` — line 6593 — Perform a multipart HTTP request.
-- `plugin_mastodon_import_remote_comment()` — line 8183 — Import a remote Mastodon reply into FlatPress as a comment while respecting comment tombstones, including early tombstones for locally deleted exported comments.
-- `plugin_mastodon_import_remote_context_descendants()` — line 8267 — Import remote Mastodon replies from a fetched thread context while blocking tombstoned parent/child replies.
-- `plugin_mastodon_import_remote_entry()` — line 7932 — Import a remote Mastodon status into FlatPress as an entry.
-- `plugin_mastodon_instance_authority()` — line 2042 — Return the Mastodon instance authority used in fediverse creator metadata.
-- `plugin_mastodon_instance_character_limit()` — line 7663 — Return the status character limit of the configured instance.
-- `plugin_mastodon_instance_configuration()` — line 6432 — Load and cache the Mastodon instance configuration document.
-- `plugin_mastodon_instance_media_description_limit()` — line 6455 — Return the media description length limit of the configured instance.
-- `plugin_mastodon_instance_media_limit()` — line 6442 — Return the media attachment limit of the configured instance.
-- `plugin_mastodon_instance_url_reserved_length()` — line 6468 — Return the reserved Mastodon character budget used for each URL.
-- `plugin_mastodon_io_append_file()` — line 986 — Append to a file via the FlatPress I/O layer.
-- `plugin_mastodon_io_read_file()` — line 915 — Read a file through the FlatPress I/O layer when available.
-- `plugin_mastodon_io_read_file_uncached()` — line 928 — Read a file without FlatPress request-local caches.
-- `plugin_mastodon_file_permissions_mode()` — line 943 — Return the FlatPress `FILE_PERMISSIONS` mode used for plugin runtime files.
-- `plugin_mastodon_apply_file_permissions()` — line 952 — Apply FlatPress `FILE_PERMISSIONS` to a plugin runtime file.
-- `plugin_mastodon_io_write_file()` — line 965 — Write a file through the FlatPress I/O layer when available and enforce `FILE_PERMISSIONS` after successful writes.
-- `plugin_mastodon_is_public_host()` — line 4408 — Determine whether a host name resolves to a public endpoint.
-- `plugin_mastodon_lang_string()` — line 3868 — Return a localized plugin string or a provided fallback.
-- `plugin_mastodon_limit_status_text()` — line 6514 — Truncate status text using Mastodon URL-budget rules.
-- `plugin_mastodon_limit_text()` — line 5006 — Limit text to a maximum number of characters.
-- `plugin_mastodon_list_local_entries()` — line 7161 — List local FlatPress entry identifiers.
-- `plugin_mastodon_local_item_date_key()` — line 2376 — Determine the date key of a local FlatPress entry or comment.
-- `plugin_mastodon_local_item_matches_content_window()` — line 2515 — Determine whether a local FlatPress item is inside the active content synchronization window.
-- `plugin_mastodon_local_item_matches_sync_start()` — line 2503 — Determine whether a local FlatPress item should be synchronized.
-- `plugin_mastodon_local_item_timestamp()` — line 7117 — Resolve the best timestamp for a local FlatPress item.
-- `plugin_mastodon_log()` — line 2596 — Append a line to the plugin sync log.
-- `plugin_mastodon_mapping_matches_sync_start()` — line 2547 — Determine whether a stored synchronization mapping still belongs to the active sync-start window.
-- `plugin_mastodon_mastodon_api()` — line 7480 — Call the Mastodon API and return the raw HTTP response.
-- `plugin_mastodon_mastodon_hashtag_footer()` — line 4167 — Convert FlatPress tag labels into a Mastodon hashtag footer line.
-- `plugin_mastodon_mastodon_html_to_flatpress()` — line 4787 — Convert Mastodon HTML content into FlatPress BBCode.
-- `plugin_mastodon_mastodon_json()` — line 7529 — Call the Mastodon API and decode a JSON response.
-- `plugin_mastodon_maybe_sync()` — line 9239 — Run the scheduled synchronization when the current request is due.
-- `plugin_mastodon_media_copy_tree()` — line 5165 — Copy a directory tree used for media synchronization.
-- `plugin_mastodon_media_delete_tree()` — line 5138 — Delete a directory tree used for imported media.
-- `plugin_mastodon_media_download()` — line 6057 — Download a remote media asset.
-- `plugin_mastodon_media_guess_mime_type()` — line 5237 — Guess the MIME type of a local media file.
-- `plugin_mastodon_media_description_from_bbcode_content()` — line 5490 — Normalize optional AudioVideo BBCode content into a Mastodon media description.
-- `plugin_mastodon_media_parse_tag_attributes()` — line 5459 — Parse key/value attributes from a FlatPress media tag.
-- `plugin_mastodon_media_prepare_directory()` — line 5122 — Ensure that a media directory exists.
-- `plugin_mastodon_media_relative_to_absolute()` — line 5109 — Resolve a FlatPress media path to an absolute file path.
-- `plugin_mastodon_media_processing_attempts()` — line 6791 — Calculate media-type- and size-aware polling attempts for asynchronous Mastodon media processing.
-- `plugin_mastodon_media_transfer_timeout()` — line 6815 — Calculate media-type- and size-aware HTTP transfer timeouts for uploads.
-- `plugin_mastodon_normalize_comment_parent_id()` — line 3593 — Normalize a stored local comment parent identifier.
-- `plugin_mastodon_normalize_delete_sync_enabled()` — line 2344 — Normalize the toggle that enables or disables the follow-up deletion synchronization.
-- `plugin_mastodon_normalize_head_username()` — line 2003 — Normalize the configured Mastodon username for HTML head metadata.
-- `plugin_mastodon_normalize_import_synced_comments_as_entries()` — line 2290 — Normalize the toggle that allows importing already synchronized local comments as entries.
-- `plugin_mastodon_normalize_instance_url()` — line 1970 — Normalize the configured Mastodon instance URL.
-- `plugin_mastodon_normalize_old_thread_reply_check()` — line 2326 — Normalize the toggle that enables rotating context checks for known synchronized Mastodon threads.
-- `plugin_mastodon_normalize_scheduled_window_days()` — line 2231 — Normalize the configured 7/14/30-day automatic window for scheduled runs.
-- `plugin_mastodon_normalize_status_language()` — line 2146 — Normalize a FlatPress locale string to a Mastodon-compatible ISO 639-1 code.
-- `plugin_mastodon_normalize_sync_start_date()` — line 2205 — Normalize the configured sync start date.
-- `plugin_mastodon_normalize_sync_time()` — line 2188 — Normalize the configured daily sync time.
-- `plugin_mastodon_normalize_tag_list()` — line 4094 — Normalize a list of tag labels.
-- `plugin_mastodon_normalize_update_local_from_remote()` — line 2272 — Normalize the toggle that controls whether existing local content may be updated from remote Mastodon data.
-- `plugin_mastodon_oauth_legacy_scopes()` — line 542 — Return the legacy OAuth scope string used before scope discovery was added.
-- `plugin_mastodon_oauth_preferred_scopes()` — line 636 — Prefer the narrow `profile` scope on current instances and fall back to `read:accounts` on older ones.
-- `plugin_mastodon_oauth_profile_scopes()` — line 550 — Return the stricter OAuth scope string that uses `profile` for `verify_credentials`.
-- `plugin_mastodon_oauth_scope_supported()` — line 615 — Check whether the configured Mastodon instance advertises support for a specific OAuth scope.
-- `plugin_mastodon_oauth_scopes()` — line 653 — Return the OAuth scopes that the currently registered app may safely request.
-- `plugin_mastodon_oauth_server_metadata()` — line 559 — Discover and cache OAuth authorization-server metadata from `/.well-known/oauth-authorization-server`.
-- `plugin_mastodon_oauth_supported_scopes()` — line 578 — Parse the discoverable OAuth scopes supported by the configured Mastodon instance.
-- `plugin_mastodon_old_thread_context_rotation_limit()` — line 8368 — Return the maximum number of known synchronized threads checked for replies per content sync run.
-- `plugin_mastodon_parse_http_response_headers()` — line 7198 — Parse raw HTTP response headers.
-- `plugin_mastodon_parse_iso_datetime()` — line 3500 — Parse an ISO date/time string into FlatPress date format.
-- `plugin_mastodon_parse_iso_timestamp()` — line 3518 — Parse an ISO date/time value into a Unix timestamp.
-- `plugin_mastodon_photoswipe_plugin_active()` — line 3997 — Determine whether the PhotoSwipe plugin is active for the current FlatPress request.
-- `plugin_mastodon_plain_text_from_bbcode()` — line 4450 — Convert FlatPress BBCode into plain text for Mastodon export, removing complete AudioVideo player tags including optional description content.
-- `plugin_mastodon_profile_url()` — line 2072 — Build the public Mastodon profile URL used for the rel-me link.
-- `plugin_mastodon_public_comment_url()` — line 4772 — Return the public URL for a specific FlatPress comment.
-- `plugin_mastodon_public_comments_url()` — line 4744 — Return the public comments URL for a FlatPress entry.
-- `plugin_mastodon_public_entry_url()` — line 4717 — Return the public URL for a FlatPress entry.
-- `plugin_mastodon_public_url_for_mastodon()` — line 4431 — Return a Mastodon-safe public URL or an empty string.
-- `plugin_mastodon_register_app()` — line 7573 — Register the FlatPress application on the configured Mastodon instance with the preferred discoverable scope set.
-- `plugin_mastodon_remote_media_description()` — line 5928 — Resolve the best description for a remote attachment.
-- `plugin_mastodon_remote_media_source_url()` — line 5888 — Resolve the best downloadable source URL for a remote attachment.
-- `plugin_mastodon_remote_media_source_urls()` — line 5906 — Resolve direct-download fallback candidates for a remote attachment.
-- `plugin_mastodon_remote_status_date_key()` — line 2396 — Determine the date key of a remote Mastodon status.
-- `plugin_mastodon_remote_status_image_attachments()` — line 5879 — Extract image attachments from a remote Mastodon status.
-- `plugin_mastodon_remote_status_is_importable()` — line 3572 — Determine whether a remote Mastodon status may be imported.
-- `plugin_mastodon_remote_status_matches_content_window()` — line 2536 — Determine whether a remote Mastodon status is inside the active content synchronization window.
-- `plugin_mastodon_remote_status_matches_sync_start()` — line 2525 — Determine whether a remote Mastodon status should be synchronized.
-- `plugin_mastodon_remote_status_tags()` — line 4188 — Collect remote Mastodon tags from a status entity.
-- `plugin_mastodon_remote_status_timestamp()` — line 3540 — Resolve the best FlatPress-adjusted timestamp for a remote Mastodon status.
-- `plugin_mastodon_remote_status_visibility()` — line 3559 — Return the normalized visibility of a remote Mastodon status.
-- `plugin_mastodon_replace_emoticon_shortcodes_with_unicode()` — line 4358 — Replace FlatPress emoticon shortcodes with Unicode glyphs.
-- `plugin_mastodon_replace_unicode_emoticons_with_shortcodes()` — line 4386 — Replace Unicode emoticons with FlatPress shortcodes.
-- `plugin_mastodon_resolve_comment_reply_target()` — line 3632 — Resolve the remote reply target for a local comment export.
-- `plugin_mastodon_list_local_comment_ids()` — line 3685 — Scan the FlatPress comment directory directly so local reply export is not blocked by stale comment-list caches.
-- `plugin_mastodon_response_error_message()` — line 7544 — Extract the most useful error message from an API response.
-- `plugin_mastodon_run_deletion_sync()` — line 8847 — Run the deferred deletion synchronization in a follow-up request after content sync completed, with scheduled-window-limited remote existence lookups and progress cursors.
-- `plugin_mastodon_run_sync()` — line 9159 — Run a full synchronization cycle.
-- `plugin_mastodon_runtime_cache_clear()` — line 715 — Clear one request-local plugin cache bucket or the complete cache.
-- `plugin_mastodon_runtime_cache_get()` — line 673 — Return a value from the request-local plugin cache.
-- `plugin_mastodon_runtime_cache_set()` — line 697 — Store a value in the request-local plugin cache.
-- `plugin_mastodon_safe_filename()` — line 5073 — Sanitize a file name for local storage.
-- `plugin_mastodon_safe_path_component()` — line 5058 — Sanitize a string so it can be used as a path component.
-- `plugin_mastodon_save_options()` — line 1807 — Persist plugin options.
-- `plugin_mastodon_scheduled_window_choices()` — line 2243 — Return the localized admin radio choices for the scheduled synchronization window.
-- `plugin_mastodon_scheduled_window_start_date()` — line 2464 — Return the FlatPress-local date key that starts the automatic scheduled sync window.
-- `plugin_mastodon_secret_decode()` — line 1939 — Decode a previously stored secret value.
-- `plugin_mastodon_secret_encode()` — line 1916 — Encode a secret value before storing it in the configuration.
-- `plugin_mastodon_secret_key()` — line 1899 — Build the encryption key used for stored secrets.
-- `plugin_mastodon_should_import_synced_comments_as_entries()` — line 2299 — Check whether a remote Mastodon status that is already mapped to a local FlatPress comment may also be imported as an entry.
-- `plugin_mastodon_should_check_old_thread_replies()` — line 2335 — Check whether known synchronized Mastodon threads should be checked for replies in rotating batches.
-- `plugin_mastodon_should_run_deletion_sync()` — line 2353 — Check whether the follow-up deletion synchronization is enabled.
-- `plugin_mastodon_should_update_local_from_remote()` — line 2281 — Check whether remote Mastodon updates may overwrite already existing local FlatPress content.
-- `plugin_mastodon_state_comment_key()` — line 2747 — Build the compound state key used for comment mappings.
-- `plugin_mastodon_state_get_comment_meta()` — line 3071 — Return mapping metadata for a local comment.
-- `plugin_mastodon_state_has_dirty_comment()` — line 2965 — Check whether a comment is queued for synchronization outside the scheduled window.
-- `plugin_mastodon_state_has_dirty_entry()` — line 2915 — Check whether an entry is queued for synchronization outside the scheduled window.
-- `plugin_mastodon_state_set_comment_tombstone()` — line 3085 — Store a tombstone that blocks stale re-imports of one deleted remote comment.
-- `plugin_mastodon_state_has_comment_tombstone()` — line 3105 — Check whether one remote Mastodon comment status was tombstoned locally.
-- `plugin_mastodon_protect_locally_deleted_exported_comments()` — line 3116 — Tombstone locally deleted exported FlatPress comment mappings before the next content sync can stale-reimport them from Mastodon thread context.
-- `plugin_mastodon_reattach_local_comment_to_entry_status()` — line 3162 — Remove a local imported reply parent link and reattach the surviving reply to the synchronized entry status after its remote parent reply disappeared.
-- `plugin_mastodon_state_remove_pending_comment_remote_recheck()` — line 3222 — Remove one pending descendant recheck marker.
-- `plugin_mastodon_state_get_pending_comment_remote_recheck()` — line 3236 — Return one pending descendant recheck marker.
-- `plugin_mastodon_state_set_pending_comment_remote_recheck()` — line 3251 — Mark one local comment for follow-up verification after an ancestor disappeared remotely.
-- `plugin_mastodon_state_set_deletions_pending()` — line 3277 — Persist whether another deletion follow-up request is pending, which scope it should run, and when it may start.
-- `plugin_mastodon_deletion_sync_due()` — line 3291 — Check whether the pending deletion synchronization may start after its persisted not-before timestamp.
-- `plugin_mastodon_state_has_comment_recheck_scope()` — line 3319 — Check whether the next deletion follow-up request should run only the targeted descendant recheck scope.
-- `plugin_mastodon_build_comment_remote_child_index()` — line 3328 — Build a direct-child index for mapped remote reply trees.
-- `plugin_mastodon_queue_comment_descendant_remote_rechecks()` — line 3356 — Queue only the direct mapped local children of one deleted remote comment for additional verification passes.
-- `plugin_mastodon_process_pending_comment_remote_rechecks()` — line 3395 — Process pending descendant rechecks breadth-first so deeper reply chains can converge within the same targeted follow-up request.
-- `plugin_mastodon_state_get_entry_meta()` — line 2976 — Return mapping metadata for a local entry.
-- `plugin_mastodon_normalize_deletions_pending_scope()` — line 2685 — Normalize the targeted deletion-follow-up scope marker.
-- `plugin_mastodon_state_normalize()` — line 2698 — Normalize a runtime state array and fill in missing keys.
-- `plugin_mastodon_state_read()` — line 2606 — Load the persisted runtime state from disk and fall back to the short-lived APCu state if the file is temporarily missing, empty, or invalid.
-- `plugin_mastodon_state_remove_dirty_comment()` — line 2951 — Remove a comment from the dirty queue.
-- `plugin_mastodon_state_remove_dirty_entry()` — line 2902 — Remove an entry from the dirty queue.
-- `plugin_mastodon_state_remove_comment_mapping()` — line 2857 — Remove the mapping between a local comment and a remote status.
-- `plugin_mastodon_state_remove_entry_mapping()` — line 2835 — Remove the mapping between a local entry and a remote status.
-- `plugin_mastodon_state_set_comment_mapping()` — line 2800 — Store the mapping between a local comment and a remote status.
-- `plugin_mastodon_state_set_dirty_comment()` — line 2928 — Add an older changed comment to the persistent dirty queue.
-- `plugin_mastodon_state_set_dirty_entry()` — line 2882 — Add an older changed entry to the persistent dirty queue.
-- `plugin_mastodon_state_set_entry_mapping()` — line 2762 — Store the mapping between a local entry and a remote status.
-- `plugin_mastodon_state_write()` — line 2660 — Persist the runtime state to disk and always refresh the short-lived APCu last-known-good state when possible.
-- `plugin_mastodon_status_missing_response()` — line 7760 — Check whether an API response means that the referenced Mastodon status no longer exists.
-- `plugin_mastodon_status_text_length()` — line 6482 — Calculate the Mastodon-visible status length with instance URL budgeting.
-- `plugin_mastodon_stream_context_request()` — line 7228 — Perform an HTTP request through a stream context fallback.
-- `plugin_mastodon_strip_flatpress_tag_bbcode()` — line 4150 — Remove Tag plugin BBCode blocks from entry content.
-- `plugin_mastodon_strip_trailing_mastodon_hashtag_footer()` — line 4215 — Remove a trailing Mastodon hashtag footer from imported plain text.
-- `plugin_mastodon_subject_line_is_noise()` — line 4494 — Determine whether an extracted line should be ignored as a subject.
-- `plugin_mastodon_sync_due()` — line 9137 — Determine whether the scheduled synchronization is currently due.
-- `plugin_mastodon_sync_local_to_remote()` — line 8524 — Synchronize local FlatPress content to Mastodon.
-- `plugin_mastodon_sync_remote_to_local()` — line 8457 — Synchronize remote Mastodon content into FlatPress.
-- `plugin_mastodon_tag_plugin_active()` — line 3963 — Determine whether the Tag plugin is active for the current FlatPress request.
-- `plugin_mastodon_timestamp_date_key()` — line 2362 — Convert a FlatPress-adjusted timestamp into a stable date key.
-- `plugin_mastodon_update_status()` — line 7800 — Update an existing Mastodon status.
-- `plugin_mastodon_upload_media_items()` — line 6884 — Upload local media items to Mastodon and collect the created media IDs.
-- `plugin_mastodon_verify_credentials()` — line 7646 — Verify the currently configured access token.
-- `plugin_mastodon_wait_for_media_attachment()` — line 6835 — Poll an asynchronously processed Mastodon media attachment until it is ready or times out.
-- `setup()` — line 8994 — Register the Mastodon admin panel template and assign plugin data to Smarty.
+- `main()` — line 10134 — Keep the admin panel lifecycle compatible with FlatPress without extra processing.
+- `onsubmit()` — line 10138 — Process configuration saves, OAuth actions, including app registration and authorization-code exchange, and the manual synchronization trigger.
+- `plugin_mastodon_absolute_url()` — line 4443 — Convert a URL or path into an absolute URL when possible.
+- `plugin_mastodon_admin_assign()` — line 10081 — Assign plugin data to Smarty for the admin panel.
+- `plugin_mastodon_apcu_cache_key()` — line 1125 — Build the namespaced APCu key used by this plugin.
+- `plugin_mastodon_apcu_delete()` — line 1167 — Delete a value from APCu using FlatPress `apcu_delete_key()` when available.
+- `plugin_mastodon_apcu_enabled()` — line 1116 — Check whether shared APCu caching is available for the plugin.
+- `plugin_mastodon_apcu_fetch()` — line 1139 — Fetch a value from APCu through the FlatPress namespace helper.
+- `plugin_mastodon_apcu_store()` — line 1154 — Store a value in APCu through the FlatPress namespace helper.
+- `plugin_mastodon_state_fallback_key()` — line 1186 — Return the legacy APCu key that used to hold a full last-known-good state fallback.
+- `plugin_mastodon_state_fallback_store()` — line 1195 — Remove the legacy full-state APCu fallback instead of storing large mapping arrays.
+- `plugin_mastodon_state_fallback_read()` — line 1204 — Return an empty full-state fallback and delete the legacy APCu entry when APCu is available.
+- `plugin_mastodon_sync_guard_kind()` — line 1214 — Normalize the cooldown guard kind.
+- `plugin_mastodon_sync_guard_apcu_key()` — line 1224 — Return the APCu key used for one sync cooldown guard.
+- `plugin_mastodon_sync_guard_entry_active()` — line 1234 — Check whether one cooldown guard entry is still active.
+- `plugin_mastodon_sync_guard_apcu_store()` — line 1245 — Store one cooldown guard in APCu.
+- `plugin_mastodon_sync_guard_file_read()` — line 1258 — Read and prune the file-backed cooldown guard.
+- `plugin_mastodon_sync_guard_file_write()` — line 1285 — Write the file-backed cooldown guard.
+- `plugin_mastodon_sync_guard_active()` — line 1306 — Check whether a recent scheduled content/deletion pass is still cooling down.
+- `plugin_mastodon_sync_guard_mark()` — line 1331 — Mark a 5-minute cooldown guard for a scheduled sync/deletion pass.
+- `plugin_mastodon_sync_guard_clear()` — line 1352 — Clear one sync cooldown guard.
+- `plugin_mastodon_rate_limit_default_budgets()` — line 1367 — Return conservative per-run Mastodon API budgets.
+- `plugin_mastodon_rate_limit_window_budgets()` — line 1391 — Return persistent cross-run Mastodon API window budgets.
+- `plugin_mastodon_rate_limit_window_config()` — line 1418 — Return the persistent window key, budget, TTL, and block reason for one request kind.
+- `plugin_mastodon_rate_limit_window_entry()` — line 1438 — Normalize one persistent rate-limit window entry and drop expired values.
+- `plugin_mastodon_rate_limit_window_read()` — line 1458 — Read and prune the persistent cross-run rate-limit windows.
+- `plugin_mastodon_rate_limit_window_write()` — line 1490 — Persist cross-run rate-limit windows with FlatPress file permissions.
+- `plugin_mastodon_rate_limit_window_acquire()` — line 1515 — Reserve one media-upload/delete/account-status-page slot from the persistent cross-run window.
+- `plugin_mastodon_rate_limit_window_clear()` — line 1564 — Clear persistent rate-limit windows for tests or recovery tooling.
+- `plugin_mastodon_rate_limit_guard_start()` — line 1576 — Start the per-run Mastodon API rate-limit guard.
+- `plugin_mastodon_rate_limit_guard_stop()` — line 1602 — Stop the per-run Mastodon API rate-limit guard while keeping its summary inspectable.
+- `plugin_mastodon_rate_limit_guard_active()` — line 1613 — Check whether the per-run Mastodon API guard is active.
+- `plugin_mastodon_rate_limit_guard_summary()` — line 1621 — Return the current per-run rate-limit guard summary.
+- `plugin_mastodon_rate_limit_headers()` — line 1630 — Normalize response headers for rate-limit checks.
+- `plugin_mastodon_rate_limit_request_kind()` — line 1651 — Classify Mastodon API requests as general, media upload, status deletion, or account-status paging.
+- `plugin_mastodon_rate_limit_block()` — line 1676 — Mark the current run as blocked by a rate-limit budget, persistent window, or Mastodon response and log the stop reason with budget counters once per run.
+- `plugin_mastodon_rate_limit_acquire()` — line 1720 — Reserve per-run and persistent window budget before a Mastodon API request proceeds.
+- `plugin_mastodon_rate_limit_observe_response()` — line 1765 — Update the guard from `X-RateLimit-*` headers and `429` responses.
+- `plugin_mastodon_rate_limit_blocked_reason()` — line 1789 — Return the current rate-limit block reason.
+- `plugin_mastodon_rate_limit_blocked_response()` — line 1801 — Build the synthetic `429` response used for locally blocked requests.
+- `plugin_mastodon_rate_limit_state_error()` — line 1817 — Return the rate-limit reason that should be written to synchronization state.
+- `plugin_mastodon_bbcode_attr_escape()` — line 5820 — Escape a value for safe BBCode attribute usage.
+- `plugin_mastodon_bbcode_text_escape()` — line 5832 — Escape plain text embedded between BBCode tags.
+- `plugin_mastodon_bbcode_plugin_active()` — line 4597 — Determine whether the BBCode plugin is active for the current FlatPress request.
+- `plugin_mastodon_blog_base_url()` — line 4390 — Return the absolute base URL of the current FlatPress installation.
+- `plugin_mastodon_build_authorize_url()` — line 8327 — Build the OAuth authorization URL using the scopes that the registered app may safely request.
+- `plugin_mastodon_build_comment_status_text()` — line 8625 — Build the status body used when exporting a FlatPress comment.
+- `plugin_mastodon_build_entry_status_text()` — line 8557 — Build the status body used when exporting a FlatPress entry.
+- `plugin_mastodon_build_flatpress_tag_bbcode()` — line 4895 — Build Tag plugin BBCode from a list of remote Mastodon tags.
+- `plugin_mastodon_build_imported_media_bbcode()` — line 6740 — Build FlatPress BBCode for imported remote media attachments, including AudioVideo optional description endtag text.
+- `plugin_mastodon_cleanup_imported_text()` — line 5153 — Clean imported text before saving it to FlatPress.
+- `plugin_mastodon_cleanup_uploaded_media()` — line 7372 — Best-effort cleanup for uploaded Mastodon media that never reached a final status request.
+- `plugin_mastodon_collect_entry_files()` — line 7707 — Collect entry files recursively from the FlatPress content tree.
+- `plugin_mastodon_collect_known_entry_context_targets()` — line 9130 — Collect known synchronized entry threads that should have their Mastodon reply context refreshed while respecting the synchronization start-date window.
+- `plugin_mastodon_collect_local_entry_media()` — line 6211 — Collect local images, galleries, AudioVideo media, optional AudioVideo endtag descriptions, and video poster thumbnails referenced by an entry.
+- `plugin_mastodon_comment_hash()` — line 5657 — Build a change-detection hash for a FlatPress comment.
+- `plugin_mastodon_comment_parent_fields()` — line 4201 — Return the comment fields that may contain a parent reference.
+- `plugin_mastodon_companion_plugins_status()` — line 4663 — Return the status of companion FlatPress plugins used for the full Mastodon feature set.
+- `plugin_mastodon_compare_local_entries_for_export()` — line 7763 — Compare local FlatPress entries for Mastodon export order.
+- `plugin_mastodon_configured_status_language()` — line 2278 — Read the configured FlatPress locale and return the Mastodon language code.
+- `plugin_mastodon_create_status()` — line 8504 — Create a Mastodon status.
+- `plugin_mastodon_date_matches_content_window()` — line 2594 — Combine the durable sync-start lower bound with the scheduled-run recent-content window.
+- `plugin_mastodon_date_matches_sync_start()` — line 2559 — Determine whether a content date passes the configured sync start date.
+- `plugin_mastodon_datetime_date_key()` — line 2535 — Normalize a stored date/datetime string to the sync-start date-key format.
+- `plugin_mastodon_default_content_stats()` — line 503 — Return the default counters for the last content synchronization.
+- `plugin_mastodon_default_deletion_stats()` — line 520 — Return the default counters for the last deletion synchronization.
+- `plugin_mastodon_default_options()` — line 120 — Return the default plugin option values.
+- `plugin_mastodon_default_state()` — line 533 — Return the default runtime state structure, including the targeted deletion-follow-up scope marker and deletion progress cursors.
+- `plugin_mastodon_delete_media_attachment()` — line 7353 — Delete an uploaded Mastodon media attachment before it is attached to a final status.
+- `plugin_mastodon_delete_status()` — line 8478 — Delete a Mastodon status, including media when requested.
+- `plugin_mastodon_detect_local_comment_parent_id()` — line 4227 — Detect the local parent comment identifier from comment data.
+- `plugin_mastodon_dom_children_to_flatpress()` — line 5207 — Convert DOM child nodes into FlatPress BBCode text.
+- `plugin_mastodon_dom_node_to_flatpress()` — line 5225 — Convert a single DOM node into FlatPress BBCode text.
+- `plugin_mastodon_domains_match()` — line 5139 — Determine whether two host names belong to the same domain family.
+- `plugin_mastodon_emoticon_entity_to_unicode()` — line 4908 — Convert an emoticon HTML entity into a Unicode character.
+- `plugin_mastodon_emoticon_map()` — line 4921 — Return the FlatPress emoticon-to-Unicode lookup map.
+- `plugin_mastodon_emoticons_plugin_active()` — line 4648 — Determine whether the Emoticons plugin is active for the current FlatPress request.
+- `plugin_mastodon_enabled_plugin_state()` — line 4515 — Determine whether a FlatPress plugin is enabled in the centralized plugin configuration.
+- `plugin_mastodon_ensure_state_dir()` — line 2788 — Ensure that the plugin runtime directory exists.
+- `plugin_mastodon_entry_hash()` — line 5645 — Build a change-detection hash for a FlatPress entry.
+- `plugin_mastodon_entry_media_signature()` — line 6422 — Build a signature for media references contained in entry content.
+- `plugin_mastodon_exchange_code_for_token()` — line 8347 — Exchange an OAuth authorization code for an access token using the same negotiated scope string.
+- `plugin_mastodon_extension_from_mime_type()` — line 5955 — Resolve a safe file extension from a MIME type.
+- `plugin_mastodon_extend_time_limit()` — line 6939 — Refresh or raise the PHP execution time budget for long-running Mastodon work without lowering an existing higher or unlimited limit.
+- `plugin_mastodon_extract_flatpress_tags()` — line 4742 — Extract FlatPress Tag plugin labels from an entry body.
+- `plugin_mastodon_extract_url_token()` — line 4426 — Extract the URL token from a BBCode or attribute fragment.
+- `plugin_mastodon_fediverse_creator_value()` — line 2198 — Build the fediverse creator meta value.
+- `plugin_mastodon_fetch_account_statuses()` — line 8409 — Fetch statuses for the authenticated Mastodon account.
+- `plugin_mastodon_fetch_media_attachment()` — line 7343 — Fetch a single Mastodon media attachment by ID.
+- `plugin_mastodon_fetch_status()` — line 8467 — Fetch a single Mastodon status.
+- `plugin_mastodon_fetch_status_context()` — line 8456 — Fetch the conversation context for a Mastodon status.
+- `plugin_mastodon_file_prestat()` — line 1827 — Read a cheap file metadata snapshot for cache validation.
+- `plugin_mastodon_file_prestat_signature()` — line 1847 — Convert a file metadata snapshot into a stable cache signature.
+- `plugin_mastodon_flatpress_to_mastodon()` — line 5506 — Convert FlatPress content into Mastodon-ready plain text.
+- `plugin_mastodon_fp_config()` — line 751 — Return the FlatPress configuration, preferring the early-loaded core cache.
+- `plugin_mastodon_fp_config_value()` — line 787 — Read a nested FlatPress configuration value.
+- `plugin_mastodon_fp_timeoffset_seconds()` — line 803 — Return the configured FlatPress time offset in seconds for exact local admin-time conversion.
+- `plugin_mastodon_fp_timeoffset_label()` — line 823 — Format the configured FlatPress time offset as a UTC label for admin users.
+- `plugin_mastodon_sync_time_to_minutes()` — line 853 — Convert a normalized `HH:MM` sync-time value into minutes after midnight.
+- `plugin_mastodon_minutes_to_sync_time()` — line 864 — Convert minutes after midnight back into a normalized `HH:MM` sync-time value.
+- `plugin_mastodon_sync_time_utc_to_local()` — line 880 — Convert the stored UTC synchronization time to the FlatPress-local admin time.
+- `plugin_mastodon_sync_time_local_to_utc()` — line 891 — Convert the FlatPress-local admin synchronization time back to stored UTC.
+- `plugin_mastodon_format_admin_datetime()` — line 902 — Format stored UTC timestamps for the admin panel using FlatPress `timeoffset`, date format, and time format.
+- `plugin_mastodon_get_options()` — line 1858 — Load the saved plugin options and merge them with defaults.
+- `plugin_mastodon_guess_subject()` — line 4339 — Guess a subject line from imported plain text.
+- `plugin_mastodon_head()` — line 2216 — Print Mastodon profile metadata into the HTML head.
+- `plugin_mastodon_html_entity_decode()` — line 4381 — Decode HTML entities using the plugin defaults.
+- `plugin_mastodon_http_build_query()` — line 8037 — Build an application/x-www-form-urlencoded query string.
+- `plugin_mastodon_http_request()` — line 8093 — Perform an HTTP request using cURL or the stream fallback.
+- `plugin_mastodon_http_request_multipart()` — line 7210 — Perform a multipart HTTP request.
+- `plugin_mastodon_import_remote_comment()` — line 8924 — Import a remote Mastodon reply into FlatPress as a comment while respecting comment tombstones, including early tombstones for locally deleted exported comments.
+- `plugin_mastodon_import_remote_context_descendants()` — line 9013 — Import remote Mastodon replies from a fetched thread context while blocking tombstoned parent/child replies.
+- `plugin_mastodon_import_remote_entry()` — line 8663 — Import a remote Mastodon status into FlatPress as an entry.
+- `plugin_mastodon_instance_authority()` — line 2152 — Return the Mastodon instance authority used in fediverse creator metadata.
+- `plugin_mastodon_instance_character_limit()` — line 8394 — Return the status character limit of the configured instance.
+- `plugin_mastodon_instance_configuration()` — line 7049 — Load and cache the Mastodon instance configuration document.
+- `plugin_mastodon_instance_media_description_limit()` — line 7072 — Return the media description length limit of the configured instance.
+- `plugin_mastodon_instance_media_limit()` — line 7059 — Return the media attachment limit of the configured instance.
+- `plugin_mastodon_instance_url_reserved_length()` — line 7085 — Return the reserved Mastodon character budget used for each URL.
+- `plugin_mastodon_io_append_file()` — line 1013 — Append to a file with `FILE_APPEND | LOCK_EX`, without re-reading/re-writing the complete log payload.
+- `plugin_mastodon_io_read_file()` — line 936 — Read a file through the FlatPress I/O layer when available, allowing the core APCu file hotcache for small files.
+- `plugin_mastodon_io_read_file_uncached()` — line 952 — Read a file without FlatPress request-local caches.
+- `plugin_mastodon_file_permissions_mode()` — line 970 — Return the FlatPress `FILE_PERMISSIONS` mode used for plugin runtime files.
+- `plugin_mastodon_admin_add_info_row()` — line 9962 — Add one admin diagnostics row when the value is available.
+- `plugin_mastodon_admin_boolean_label()` — line 9947 — Return a localized yes/no/unknown label for admin diagnostics.
+- `plugin_mastodon_apply_file_permissions()` — line 979 — Apply FlatPress `FILE_PERMISSIONS` to a plugin runtime file.
+- `plugin_mastodon_io_write_file()` — line 992 — Write a file through the FlatPress I/O layer when available and enforce `FILE_PERMISSIONS` after successful writes.
+- `plugin_mastodon_is_public_host()` — line 5025 — Determine whether a host name resolves to a public endpoint.
+- `plugin_mastodon_lang_string()` — line 4485 — Return a localized plugin string or a provided fallback.
+- `plugin_mastodon_limit_status_text()` — line 7131 — Truncate status text using Mastodon URL-budget rules.
+- `plugin_mastodon_limit_text()` — line 5623 — Limit text to a maximum number of characters.
+- `plugin_mastodon_list_local_entries()` — line 7891 — List local FlatPress entry identifiers.
+- `plugin_mastodon_local_item_date_key()` — line 2486 — Determine the date key of a local FlatPress entry or comment.
+- `plugin_mastodon_local_item_matches_content_window()` — line 2628 — Determine whether a local FlatPress item is inside the active content synchronization window.
+- `plugin_mastodon_local_item_matches_sync_start()` — line 2616 — Determine whether a local FlatPress item should be synchronized.
+- `plugin_mastodon_local_item_timestamp()` — line 7734 — Resolve the best timestamp for a local FlatPress item.
+- `plugin_mastodon_log()` — line 2797 — Append a line to the rotated append-only plugin sync log.
+- `plugin_mastodon_log_flush_skip_summaries()` — line 2842 — Flush aggregated skip counters as concise summary lines.
+- `plugin_mastodon_log_max_bytes()` — line 1053 — Return the sync.log rotation size limit.
+- `plugin_mastodon_log_rotate_files()` — line 1064 — Return the number of retained rotated sync logs.
+- `plugin_mastodon_log_skip()` — line 2812 — Aggregate high-volume skip messages by reason until the current sync phase ends.
+- `plugin_mastodon_mapping_matches_sync_start()` — line 2660 — Determine whether a stored synchronization mapping still belongs to the active sync-start window.
+- `plugin_mastodon_mastodon_api()` — line 8211 — Call the Mastodon API and return the raw HTTP response.
+- `plugin_mastodon_mastodon_hashtag_footer()` — line 4784 — Convert FlatPress tag labels into a Mastodon hashtag footer line.
+- `plugin_mastodon_mastodon_html_to_flatpress()` — line 5404 — Convert Mastodon HTML content into FlatPress BBCode.
+- `plugin_mastodon_mastodon_json()` — line 8260 — Call the Mastodon API and decode a JSON response.
+- `plugin_mastodon_maybe_sync()` — line 9915 — Run the scheduled synchronization when the current request is due.
+- `plugin_mastodon_media_copy_tree()` — line 5782 — Copy a directory tree used for media synchronization.
+- `plugin_mastodon_media_delete_tree()` — line 5755 — Delete a directory tree used for imported media.
+- `plugin_mastodon_media_download()` — line 6674 — Download a remote media asset.
+- `plugin_mastodon_media_guess_mime_type()` — line 5854 — Guess the MIME type of a local media file.
+- `plugin_mastodon_media_description_from_bbcode_content()` — line 6107 — Normalize optional AudioVideo BBCode content into a Mastodon media description.
+- `plugin_mastodon_media_parse_tag_attributes()` — line 6076 — Parse key/value attributes from a FlatPress media tag.
+- `plugin_mastodon_media_prepare_directory()` — line 5739 — Ensure that a media directory exists.
+- `plugin_mastodon_media_relative_to_absolute()` — line 5726 — Resolve a FlatPress media path to an absolute file path.
+- `plugin_mastodon_media_processing_attempts()` — line 7408 — Calculate media-type- and size-aware polling attempts for asynchronous Mastodon media processing.
+- `plugin_mastodon_media_transfer_timeout()` — line 7432 — Calculate media-type- and size-aware HTTP transfer timeouts for uploads.
+- `plugin_mastodon_media_type_from_mime()` — line 5921 — Classify a MIME type or extension as image, video, or audio.
+- `plugin_mastodon_normalize_comment_parent_id()` — line 4210 — Normalize a stored local comment parent identifier.
+- `plugin_mastodon_normalize_delete_sync_enabled()` — line 2454 — Normalize the toggle that enables or disables the follow-up deletion synchronization.
+- `plugin_mastodon_normalize_head_username()` — line 2113 — Normalize the configured Mastodon username for HTML head metadata.
+- `plugin_mastodon_normalize_media_relative_path()` — line 5703 — Normalize a FlatPress media path and reject unsafe paths.
+- `plugin_mastodon_normalize_import_synced_comments_as_entries()` — line 2400 — Normalize the toggle that allows importing already synchronized local comments as entries.
+- `plugin_mastodon_normalize_instance_url()` — line 2080 — Normalize the configured Mastodon instance URL.
+- `plugin_mastodon_normalize_old_thread_reply_check()` — line 2436 — Normalize the toggle that enables rotating context checks for known synchronized Mastodon threads.
+- `plugin_mastodon_normalize_scheduled_window_days()` — line 2341 — Normalize the configured 7/14/30-day automatic window for scheduled runs.
+- `plugin_mastodon_normalize_status_language()` — line 2256 — Normalize a FlatPress locale string to a Mastodon-compatible ISO 639-1 code.
+- `plugin_mastodon_normalize_sync_start_date()` — line 2315 — Normalize the configured sync start date.
+- `plugin_mastodon_normalize_sync_time()` — line 2298 — Normalize the configured daily sync time.
+- `plugin_mastodon_normalize_tag_list()` — line 4711 — Normalize a list of tag labels.
+- `plugin_mastodon_normalize_update_local_from_remote()` — line 2382 — Normalize the toggle that controls whether existing local content may be updated from remote Mastodon data.
+- `plugin_mastodon_oauth_legacy_scopes()` — line 563 — Return the legacy OAuth scope string used before scope discovery was added.
+- `plugin_mastodon_oauth_preferred_scopes()` — line 657 — Prefer the narrow `profile` scope on current instances and fall back to `read:accounts` on older ones.
+- `plugin_mastodon_oauth_profile_scopes()` — line 571 — Return the stricter OAuth scope string that uses `profile` for `verify_credentials`.
+- `plugin_mastodon_oauth_scope_supported()` — line 636 — Check whether the configured Mastodon instance advertises support for a specific OAuth scope.
+- `plugin_mastodon_oauth_scopes()` — line 674 — Return the OAuth scopes that the currently registered app may safely request.
+- `plugin_mastodon_oauth_server_metadata()` — line 580 — Discover and cache OAuth authorization-server metadata from `/.well-known/oauth-authorization-server`.
+- `plugin_mastodon_oauth_supported_scopes()` — line 599 — Parse the discoverable OAuth scopes supported by the configured Mastodon instance.
+- `plugin_mastodon_old_thread_context_rotation_limit()` — line 9114 — Return the maximum number of known synchronized threads checked for replies per content sync run.
+- `plugin_mastodon_parse_http_response_headers()` — line 7929 — Parse raw HTTP response headers.
+- `plugin_mastodon_parse_iso_datetime()` — line 4117 — Parse an ISO date/time string into FlatPress date format.
+- `plugin_mastodon_parse_iso_timestamp()` — line 4135 — Parse an ISO date/time value into a Unix timestamp.
+- `plugin_mastodon_photoswipe_plugin_active()` — line 4614 — Determine whether the PhotoSwipe plugin is active for the current FlatPress request.
+- `plugin_mastodon_plain_text_from_bbcode()` — line 5067 — Convert FlatPress BBCode into plain text for Mastodon export, removing complete AudioVideo player tags including optional description content.
+- `plugin_mastodon_profile_url()` — line 2182 — Build the public Mastodon profile URL used for the rel-me link.
+- `plugin_mastodon_public_comment_url()` — line 5389 — Return the public URL for a specific FlatPress comment.
+- `plugin_mastodon_public_comments_url()` — line 5361 — Return the public comments URL for a FlatPress entry.
+- `plugin_mastodon_public_entry_url()` — line 5334 — Return the public URL for a FlatPress entry.
+- `plugin_mastodon_public_url_for_mastodon()` — line 5048 — Return a Mastodon-safe public URL or an empty string.
+- `plugin_mastodon_register_app()` — line 8304 — Register the FlatPress application on the configured Mastodon instance with the preferred discoverable scope set.
+- `plugin_mastodon_remote_media_description()` — line 6545 — Resolve the best description for a remote attachment.
+- `plugin_mastodon_remote_media_source_url()` — line 6505 — Resolve the best downloadable source URL for a remote attachment.
+- `plugin_mastodon_remote_media_source_urls()` — line 6523 — Resolve direct-download fallback candidates for a remote attachment.
+- `plugin_mastodon_remote_status_date_key()` — line 2509 — Determine the date key of a remote Mastodon status.
+- `plugin_mastodon_remote_status_image_attachments()` — line 6496 — Extract image attachments from a remote Mastodon status.
+- `plugin_mastodon_remote_status_is_importable()` — line 4189 — Determine whether a remote Mastodon status may be imported.
+- `plugin_mastodon_remote_status_matches_content_window()` — line 2649 — Determine whether a remote Mastodon status is inside the active content synchronization window.
+- `plugin_mastodon_remote_status_matches_sync_start()` — line 2638 — Determine whether a remote Mastodon status should be synchronized.
+- `plugin_mastodon_remote_status_tags()` — line 4805 — Collect remote Mastodon tags from a status entity.
+- `plugin_mastodon_remote_status_timestamp()` — line 4157 — Resolve the best FlatPress-adjusted timestamp for a remote Mastodon status.
+- `plugin_mastodon_remote_status_visibility()` — line 4176 — Return the normalized visibility of a remote Mastodon status.
+- `plugin_mastodon_replace_emoticon_shortcodes_with_unicode()` — line 4975 — Replace FlatPress emoticon shortcodes with Unicode glyphs.
+- `plugin_mastodon_replace_unicode_emoticons_with_shortcodes()` — line 5003 — Replace Unicode emoticons with FlatPress shortcodes.
+- `plugin_mastodon_resolve_comment_reply_target()` — line 4249 — Resolve the remote reply target for a local comment export.
+- `plugin_mastodon_list_local_comment_ids()` — line 4302 — Scan the FlatPress comment directory directly so local reply export is not blocked by stale comment-list caches.
+- `plugin_mastodon_response_error_message()` — line 8275 — Extract the most useful error message from an API response.
+- `plugin_mastodon_run_deletion_sync()` — line 9501 — Run the deferred deletion synchronization in a follow-up request after content sync completed, with scheduled-window-limited remote existence lookups and progress cursors.
+- `plugin_mastodon_run_sync()` — line 9832 — Run a full synchronization cycle.
+- `plugin_mastodon_runtime_cache_clear()` — line 736 — Clear one request-local plugin cache bucket or the complete cache.
+- `plugin_mastodon_runtime_cache_get()` — line 694 — Return a value from the request-local plugin cache.
+- `plugin_mastodon_runtime_cache_set()` — line 718 — Store a value in the request-local plugin cache.
+- `plugin_mastodon_safe_filename()` — line 5690 — Sanitize a file name for local storage.
+- `plugin_mastodon_safe_path_component()` — line 5675 — Sanitize a string so it can be used as a path component.
+- `plugin_mastodon_save_options()` — line 1917 — Persist plugin options.
+- `plugin_mastodon_scheduled_window_choices()` — line 2353 — Return the localized admin radio choices for the scheduled synchronization window.
+- `plugin_mastodon_scheduled_window_start_date()` — line 2577 — Return the FlatPress-local date key that starts the automatic scheduled sync window.
+- `plugin_mastodon_secret_decode()` — line 2049 — Decode a previously stored secret value.
+- `plugin_mastodon_secret_encode()` — line 2026 — Encode a secret value before storing it in the configuration.
+- `plugin_mastodon_secret_key()` — line 2009 — Build the encryption key used for stored secrets.
+- `plugin_mastodon_should_import_synced_comments_as_entries()` — line 2409 — Check whether a remote Mastodon status that is already mapped to a local FlatPress comment may also be imported as an entry.
+- `plugin_mastodon_should_check_old_thread_replies()` — line 2445 — Check whether known synchronized Mastodon threads should be checked for replies in rotating batches.
+- `plugin_mastodon_should_run_deletion_sync()` — line 2463 — Check whether the follow-up deletion synchronization is enabled.
+- `plugin_mastodon_should_update_local_from_remote()` — line 2391 — Check whether remote Mastodon updates may overwrite already existing local FlatPress content.
+- `plugin_mastodon_state_comment_key()` — line 3152 — Build the compound state key used for comment mappings.
+- `plugin_mastodon_state_get_comment_meta()` — line 3683 — Return mapping metadata for a local comment.
+- `plugin_mastodon_state_has_dirty_comment()` — line 3370 — Check whether a comment is queued for synchronization outside the scheduled window.
+- `plugin_mastodon_state_has_dirty_entry()` — line 3320 — Check whether an entry is queued for synchronization outside the scheduled window.
+- `plugin_mastodon_state_set_comment_tombstone()` — line 3697 — Store a tombstone that blocks stale re-imports of one deleted remote comment.
+- `plugin_mastodon_state_has_comment_tombstone()` — line 3717 — Check whether one remote Mastodon comment status was tombstoned locally.
+- `plugin_mastodon_protect_locally_deleted_exported_comments()` — line 3728 — Tombstone locally deleted exported FlatPress comment mappings before the next content sync can stale-reimport them from Mastodon thread context.
+- `plugin_mastodon_reattach_local_comment_to_entry_status()` — line 3774 — Remove a local imported reply parent link and reattach the surviving reply to the synchronized entry status after its remote parent reply disappeared.
+- `plugin_mastodon_state_remove_pending_comment_remote_recheck()` — line 3834 — Remove one pending descendant recheck marker.
+- `plugin_mastodon_state_get_pending_comment_remote_recheck()` — line 3848 — Return one pending descendant recheck marker.
+- `plugin_mastodon_state_set_pending_comment_remote_recheck()` — line 3863 — Mark one local comment for follow-up verification after an ancestor disappeared remotely.
+- `plugin_mastodon_state_set_deletions_pending()` — line 3889 — Persist whether another deletion follow-up request is pending, which scope it should run, and when it may start.
+- `plugin_mastodon_deletion_sync_due()` — line 3903 — Check whether the pending deletion synchronization may start after its persisted not-before timestamp.
+- `plugin_mastodon_state_has_comment_recheck_scope()` — line 3931 — Check whether the next deletion follow-up request should run only the targeted descendant recheck scope.
+- `plugin_mastodon_build_comment_remote_child_index()` — line 3940 — Build a direct-child index for mapped remote reply trees.
+- `plugin_mastodon_queue_comment_descendant_remote_rechecks()` — line 3968 — Queue only the direct mapped local children of one deleted remote comment for additional verification passes.
+- `plugin_mastodon_process_pending_comment_remote_rechecks()` — line 4007 — Process pending descendant rechecks breadth-first so deeper reply chains can converge within the same targeted follow-up request.
+- `plugin_mastodon_state_entry_media_attachment_signature()` — line 3661 — Return the stored attachment-signature for one entry mapping.
+- `plugin_mastodon_state_entry_media_description_signature()` — line 3671 — Return the stored description-signature for one entry mapping.
+- `plugin_mastodon_state_entry_remote_media()` — line 3631 — Return stored remote media descriptors for one entry mapping.
+- `plugin_mastodon_state_get_entry_meta()` — line 3588 — Return mapping metadata for a local entry.
+- `plugin_mastodon_normalize_deletions_pending_scope()` — line 3088 — Normalize the targeted deletion-follow-up scope marker.
+- `plugin_mastodon_state_normalize()` — line 3101 — Normalize a runtime state array and fill in missing keys.
+- `plugin_mastodon_scheduler_source_signature()` — line 2931 — Return the current stat-based signature of the full state file.
+- `plugin_mastodon_scheduler_state_default()` — line 2910 — Return an empty scheduler state derived from the full default state.
+- `plugin_mastodon_scheduler_state_from_state()` — line 2978 — Build the lightweight scheduler summary from a full runtime state.
+- `plugin_mastodon_scheduler_state_normalize()` — line 2940 — Normalize a scheduler summary without touching full mapping arrays.
+- `plugin_mastodon_scheduler_state_read()` — line 3022 — Load the lightweight scheduler summary and rebuild it conservatively when stale.
+- `plugin_mastodon_scheduler_state_write()` — line 2998 — Persist the lightweight scheduler state.
+- `plugin_mastodon_state_read()` — line 2872 — Load the persisted runtime state from disk without storing or reading a full-state APCu fallback.
+- `plugin_mastodon_state_remove_dirty_comment()` — line 3356 — Remove a comment from the dirty queue.
+- `plugin_mastodon_state_remove_dirty_entry()` — line 3307 — Remove an entry from the dirty queue.
+- `plugin_mastodon_state_remove_comment_mapping()` — line 3262 — Remove the mapping between a local comment and a remote status.
+- `plugin_mastodon_state_remove_entry_mapping()` — line 3240 — Remove the mapping between a local entry and a remote status.
+- `plugin_mastodon_state_set_comment_mapping()` — line 3205 — Store the mapping between a local comment and a remote status.
+- `plugin_mastodon_state_set_dirty_comment()` — line 3333 — Add an older changed comment to the persistent dirty queue.
+- `plugin_mastodon_state_set_dirty_entry()` — line 3287 — Add an older changed entry to the persistent dirty queue.
+- `plugin_mastodon_state_set_entry_mapping()` — line 3167 — Store the mapping between a local entry and a remote status.
+- `plugin_mastodon_state_write()` — line 3063 — Persist the runtime state to disk and refresh the compact scheduler summary after successful writes, without caching the full state in APCu.
+- `plugin_mastodon_status_missing_response()` — line 8491 — Check whether an API response means that the referenced Mastodon status no longer exists.
+- `plugin_mastodon_status_text_length()` — line 7099 — Calculate the Mastodon-visible status length with instance URL budgeting.
+- `plugin_mastodon_stream_context_request()` — line 7959 — Perform an HTTP request through a stream context fallback.
+- `plugin_mastodon_strip_flatpress_tag_bbcode()` — line 4767 — Remove Tag plugin BBCode blocks from entry content.
+- `plugin_mastodon_strip_trailing_mastodon_hashtag_footer()` — line 4832 — Remove a trailing Mastodon hashtag footer from imported plain text.
+- `plugin_mastodon_subject_line_is_noise()` — line 5111 — Determine whether an extracted line should be ignored as a subject.
+- `plugin_mastodon_sync_due()` — line 9802 — Determine whether the scheduled synchronization is currently due.
+- `plugin_mastodon_sync_local_to_remote()` — line 9270 — Synchronize local FlatPress content to Mastodon.
+- `plugin_mastodon_sync_remote_to_local()` — line 9203 — Synchronize remote Mastodon content into FlatPress.
+- `plugin_mastodon_tag_plugin_active()` — line 4580 — Determine whether the Tag plugin is active for the current FlatPress request.
+- `plugin_mastodon_timestamp_date_key()` — line 2472 — Convert a FlatPress-adjusted timestamp into a stable date key.
+- `plugin_mastodon_update_status()` — line 8531 — Update an existing Mastodon status.
+- `plugin_mastodon_upload_media_items()` — line 7501 — Upload local media items to Mastodon and collect the created media IDs.
+- `plugin_mastodon_verify_credentials()` — line 8377 — Verify the currently configured access token.
+- `plugin_mastodon_wait_for_media_attachment()` — line 7452 — Poll an asynchronously processed Mastodon media attachment until it is ready or times out.
+- `setup()` — line 10129 — Register the Mastodon admin panel template and assign plugin data to Smarty.

--- a/fp-plugins/mastodon/plugin.mastodon.php
+++ b/fp-plugins/mastodon/plugin.mastodon.php
@@ -3,7 +3,7 @@
  * Plugin Name: Mastodon
  * Plugin URI: https://www.flatpress.org
  * Description: Synchronizes FlatPress entries and comments with Mastodon. <a href="./fp-plugins/mastodon/doc_mastodon.txt" title="Instructions" target="_blank">[Instructions]</a>
- * Version: 2.3.0
+ * Version: 2.4.1
  * Author: FlatPress
  * Author URI: https://www.flatpress.org
  */
@@ -25,6 +25,16 @@ if (!defined('PLUGIN_MASTODON_STATE_FILE')) {
 	 */
 	define('PLUGIN_MASTODON_STATE_FILE', PLUGIN_MASTODON_STATE_DIR . 'state.json');
 }
+if (!defined('PLUGIN_MASTODON_SCHEDULER_STATE_FILE')) {
+	/**
+	 * Small request-time scheduler summary derived from state.json.
+	 *
+	 * This file intentionally contains only due-check and admin summary fields
+	 * so regular frontend requests do not have to load the full synchronization
+	 * mappings from state.json when no sync is due.
+	 */
+	define('PLUGIN_MASTODON_SCHEDULER_STATE_FILE', PLUGIN_MASTODON_STATE_DIR . 'scheduler-state.json');
+}
 if (!defined('PLUGIN_MASTODON_LOCK_FILE')) {
 	define('PLUGIN_MASTODON_LOCK_FILE', PLUGIN_MASTODON_STATE_DIR . 'sync.lock');
 }
@@ -36,6 +46,15 @@ if (!defined('PLUGIN_MASTODON_RATE_LIMIT_WINDOW_FILE')) {
 }
 if (!defined('PLUGIN_MASTODON_LOG_FILE')) {
 	define('PLUGIN_MASTODON_LOG_FILE', PLUGIN_MASTODON_STATE_DIR . 'sync.log');
+}
+if (!defined('PLUGIN_MASTODON_LOG_MAX_BYTES')) {
+	/**
+	 * Rotate sync.log before appending when it reaches roughly one MiB.
+	 */
+	define('PLUGIN_MASTODON_LOG_MAX_BYTES', 1048576);
+}
+if (!defined('PLUGIN_MASTODON_LOG_ROTATE_FILES')) {
+	define('PLUGIN_MASTODON_LOG_ROTATE_FILES', 3);
 }
 if (!defined('PLUGIN_MASTODON_APP_NAME')) {
 	define('PLUGIN_MASTODON_APP_NAME', 'FlatPress Mastodon');
@@ -732,7 +751,7 @@ function plugin_mastodon_runtime_cache_clear($bucket = '') {
 function plugin_mastodon_fp_config() {
 	$cached = plugin_mastodon_runtime_cache_get('core', 'fp_config', $hit);
 	if ($hit && is_array($cached)) {
-		return plugin_mastodon_state_normalize($cached);
+		return $cached;
 	}
 
 	$config = array();
@@ -915,6 +934,9 @@ function plugin_mastodon_format_admin_datetime($value) {
  * @return string|false
  */
 function plugin_mastodon_io_read_file($file, $prestat = null) {
+	if (isset($GLOBALS ['plugin_mastodon_test_file_reads']) && is_array($GLOBALS ['plugin_mastodon_test_file_reads'])) {
+		$GLOBALS ['plugin_mastodon_test_file_reads'] [] = (string) $file;
+	}
 	if (function_exists('io_load_file')) {
 		return io_load_file($file, $prestat);
 	}
@@ -928,6 +950,9 @@ function plugin_mastodon_io_read_file($file, $prestat = null) {
  * @return string|false
  */
 function plugin_mastodon_io_read_file_uncached($file, $assumeExists = false) {
+	if (isset($GLOBALS ['plugin_mastodon_test_uncached_file_reads']) && is_array($GLOBALS ['plugin_mastodon_test_uncached_file_reads'])) {
+		$GLOBALS ['plugin_mastodon_test_uncached_file_reads'] [] = (string) $file;
+	}
 	if (function_exists('io_load_file_uncached')) {
 		return io_load_file_uncached($file, (bool) $assumeExists);
 	}
@@ -980,21 +1005,108 @@ function plugin_mastodon_io_write_file($file, $payload) {
 }
 
 /**
- * Append to a file via the FlatPress I/O layer.
+ * Append to a file without re-reading and rewriting the complete payload.
  * @param string $file
  * @param string $payload
  * @return bool
  */
 function plugin_mastodon_io_append_file($file, $payload) {
-	$existing = '';
-	$prestat = plugin_mastodon_file_prestat($file);
-	if (!empty($prestat ['exists'])) {
-		$loaded = plugin_mastodon_io_read_file($file, $prestat);
-		if (is_string($loaded)) {
-			$existing = $loaded;
+	$payload = (string) $payload;
+	$dir = dirname((string) $file);
+	if (function_exists('fs_mkdir')) {
+		if (!fs_mkdir($dir)) {
+			return false;
+		}
+	} elseif (!is_dir($dir) && !@mkdir($dir, 0777, true)) {
+		return false;
+	}
+
+	$lockFile = (string) $file . '.lock';
+	$lockHandle = @fopen($lockFile, 'c+');
+	if ($lockHandle) {
+		plugin_mastodon_apply_file_permissions($lockFile);
+		if (@flock($lockHandle, LOCK_EX)) {
+			plugin_mastodon_io_rotate_file_if_needed($file, strlen($payload));
+			$written = @file_put_contents($file, $payload, FILE_APPEND | LOCK_EX);
+			if ($written !== false) {
+				plugin_mastodon_apply_file_permissions($file);
+			}
+			@flock($lockHandle, LOCK_UN);
+			@fclose($lockHandle);
+			return $written !== false;
+		}
+		@fclose($lockHandle);
+	}
+
+	plugin_mastodon_io_rotate_file_if_needed($file, strlen($payload));
+	$written = @file_put_contents($file, $payload, FILE_APPEND | LOCK_EX);
+	if ($written !== false) {
+		plugin_mastodon_apply_file_permissions($file);
+	}
+	return $written !== false;
+}
+
+/**
+ * Return the maximum sync.log size before rotation.
+ * @return int
+ */
+function plugin_mastodon_log_max_bytes() {
+	if (isset($GLOBALS ['plugin_mastodon_test_log_max_bytes']) && is_numeric($GLOBALS ['plugin_mastodon_test_log_max_bytes'])) {
+		return max(0, (int) $GLOBALS ['plugin_mastodon_test_log_max_bytes']);
+	}
+	return max(0, (int) PLUGIN_MASTODON_LOG_MAX_BYTES);
+}
+
+/**
+ * Return the number of retained sync.log rotation files.
+ * @return int
+ */
+function plugin_mastodon_log_rotate_files() {
+	if (isset($GLOBALS ['plugin_mastodon_test_log_rotate_files']) && is_numeric($GLOBALS ['plugin_mastodon_test_log_rotate_files'])) {
+		return max(0, (int) $GLOBALS ['plugin_mastodon_test_log_rotate_files']);
+	}
+	return max(0, (int) PLUGIN_MASTODON_LOG_ROTATE_FILES);
+}
+
+/**
+ * Rotate an append-only log file when the next append would exceed the size cap.
+ * @param string $file
+ * @param int $appendBytes
+ * @return void
+ */
+function plugin_mastodon_io_rotate_file_if_needed($file, $appendBytes) {
+	$maxBytes = plugin_mastodon_log_max_bytes();
+	if ($maxBytes <= 0) {
+		return;
+	}
+	clearstatcache(true, $file);
+	$currentSize = @is_file($file) ? (int) @filesize($file) : 0;
+	if ($currentSize <= 0 || ($currentSize + max(0, (int) $appendBytes)) <= $maxBytes) {
+		return;
+	}
+
+	$rotateFiles = plugin_mastodon_log_rotate_files();
+	if ($rotateFiles <= 0) {
+		@unlink($file);
+		return;
+	}
+
+	$oldest = $file . '.' . $rotateFiles;
+	if (@is_file($oldest)) {
+		@unlink($oldest);
+	}
+	for ($index = $rotateFiles - 1; $index >= 1; $index--) {
+		$source = $file . '.' . $index;
+		$target = $file . '.' . ($index + 1);
+		if (@is_file($source)) {
+			@rename($source, $target);
+			plugin_mastodon_apply_file_permissions($target);
 		}
 	}
-	return plugin_mastodon_io_write_file($file, $existing . (string) $payload);
+	if (@is_file($file)) {
+		@rename($file, $file . '.1');
+		plugin_mastodon_apply_file_permissions($file . '.1');
+	}
 }
 
 /**
@@ -1053,7 +1165,14 @@ function plugin_mastodon_apcu_store($suffix, $value, $ttl) {
  * @return void
  */
 function plugin_mastodon_apcu_delete($suffix) {
-	if (!plugin_mastodon_apcu_enabled() || !function_exists('apcu_delete')) {
+	if (!plugin_mastodon_apcu_enabled()) {
+		return;
+	}
+	if (function_exists('apcu_delete_key')) {
+		@apcu_delete_key('mastodon:' . (string) $suffix);
+		return;
+	}
+	if (!function_exists('apcu_delete')) {
 		return;
 	}
 	$cacheKey = plugin_mastodon_apcu_cache_key($suffix);
@@ -1061,7 +1180,7 @@ function plugin_mastodon_apcu_delete($suffix) {
 }
 
 /**
- * Return the APCu key used for the short-lived last-known-good state fallback.
+ * Return the legacy APCu key that used to hold a full last-known-good state fallback.
  * @return string
  */
 function plugin_mastodon_state_fallback_key() {
@@ -1069,33 +1188,22 @@ function plugin_mastodon_state_fallback_key() {
 }
 
 /**
- * Store a normalized runtime state in APCu for a short emergency fallback window.
+ * Remove the legacy full-state APCu fallback instead of storing large mapping arrays.
  * @param array<string, mixed> $state
  * @return bool
  */
 function plugin_mastodon_state_fallback_store($state) {
-	$state = plugin_mastodon_state_normalize(is_array($state) ? $state : array());
-	return plugin_mastodon_apcu_store(plugin_mastodon_state_fallback_key(), array(
-		'stored_at' => time(),
-		'state' => $state
-	), PLUGIN_MASTODON_STATE_FALLBACK_TTL);
+	plugin_mastodon_apcu_delete(plugin_mastodon_state_fallback_key());
+	return false;
 }
 
 /**
- * Fetch the short-lived last-known-good state fallback from APCu.
+ * Full-state APCu fallback is intentionally disabled to avoid multi-MiB APCu entries.
  * @return array<string, mixed>
  */
 function plugin_mastodon_state_fallback_read() {
-	$hit = false;
-	$value = plugin_mastodon_apcu_fetch(plugin_mastodon_state_fallback_key(), $hit);
-	if (!$hit || !is_array($value) || !isset($value ['state']) || !is_array($value ['state'])) {
-		return array();
-	}
-	if (isset($value ['stored_at']) && ((int) $value ['stored_at']) > 0 && ((int) $value ['stored_at']) + PLUGIN_MASTODON_STATE_FALLBACK_TTL < time()) {
-		plugin_mastodon_apcu_delete(plugin_mastodon_state_fallback_key());
-		return array();
-	}
-	return plugin_mastodon_state_normalize($value ['state']);
+	plugin_mastodon_apcu_delete(plugin_mastodon_state_fallback_key());
+	return array();
 }
 
 /**
@@ -2383,6 +2491,9 @@ function plugin_mastodon_local_item_date_key($item, $fallbackId = '') {
 	$fallbackId = trim((string) $fallbackId);
 	if ($fallbackId !== '' && function_exists('date_from_id')) {
 		$fallbackTimestamp = date_from_id($fallbackId);
+		if (is_array($fallbackTimestamp) && isset($fallbackTimestamp ['time'])) {
+			$fallbackTimestamp = $fallbackTimestamp ['time'];
+		}
 		if (is_numeric($fallbackTimestamp)) {
 			return plugin_mastodon_timestamp_date_key((int) $fallbackTimestamp);
 		}
@@ -2686,7 +2797,72 @@ function plugin_mastodon_ensure_state_dir() {
 function plugin_mastodon_log($message) {
 	plugin_mastodon_ensure_state_dir();
 	$line = '[' . gmdate('Y-m-d H:i:s') . ' UTC] ' . trim((string) $message) . PHP_EOL;
-		plugin_mastodon_io_append_file(PLUGIN_MASTODON_LOG_FILE, $line);
+	plugin_mastodon_io_append_file(PLUGIN_MASTODON_LOG_FILE, $line);
+}
+
+/**
+ * Aggregate high-volume skip messages until the current sync phase ends.
+ * @param string $bucket
+ * @param string $singular
+ * @param string $plural
+ * @param string $itemId
+ * @param string $reason
+ * @return void
+ */
+function plugin_mastodon_log_skip($bucket, $singular, $plural, $itemId, $reason) {
+	$key = (string) $bucket;
+	if ($key === '') {
+		plugin_mastodon_log('Skipping ' . (string) $singular . ' ' . (string) $itemId . ' ' . (string) $reason);
+		return;
+	}
+	if (!isset($GLOBALS ['plugin_mastodon_skip_log_summaries']) || !is_array($GLOBALS ['plugin_mastodon_skip_log_summaries'])) {
+		$GLOBALS ['plugin_mastodon_skip_log_summaries'] = array();
+	}
+	if (!isset($GLOBALS ['plugin_mastodon_skip_log_summaries'] [$key]) || !is_array($GLOBALS ['plugin_mastodon_skip_log_summaries'] [$key])) {
+		$GLOBALS ['plugin_mastodon_skip_log_summaries'] [$key] = array(
+			'count' => 0,
+			'singular' => (string) $singular,
+			'plural' => (string) $plural,
+			'first' => '',
+			'last' => '',
+			'reason' => trim((string) $reason)
+		);
+	}
+	$GLOBALS ['plugin_mastodon_skip_log_summaries'] [$key] ['count'] = (int) $GLOBALS ['plugin_mastodon_skip_log_summaries'] [$key] ['count'] + 1;
+	if ((string) $GLOBALS ['plugin_mastodon_skip_log_summaries'] [$key] ['first'] === '') {
+		$GLOBALS ['plugin_mastodon_skip_log_summaries'] [$key] ['first'] = (string) $itemId;
+	}
+	$GLOBALS ['plugin_mastodon_skip_log_summaries'] [$key] ['last'] = (string) $itemId;
+}
+
+/**
+ * Flush aggregated skip log messages.
+ * @return void
+ */
+function plugin_mastodon_log_flush_skip_summaries() {
+	if (!isset($GLOBALS ['plugin_mastodon_skip_log_summaries']) || !is_array($GLOBALS ['plugin_mastodon_skip_log_summaries'])) {
+		return;
+	}
+	$summaries = $GLOBALS ['plugin_mastodon_skip_log_summaries'];
+	$GLOBALS ['plugin_mastodon_skip_log_summaries'] = array();
+	foreach ($summaries as $summary) {
+		if (!is_array($summary)) {
+			continue;
+		}
+		$count = isset($summary ['count']) ? (int) $summary ['count'] : 0;
+		if ($count <= 0) {
+			continue;
+		}
+		$label = $count === 1 ? (string) $summary ['singular'] : (string) $summary ['plural'];
+		$reason = trim(isset($summary ['reason']) ? (string) $summary ['reason'] : '');
+		$first = isset($summary ['first']) ? (string) $summary ['first'] : '';
+		$last = isset($summary ['last']) ? (string) $summary ['last'] : '';
+		$range = '';
+		if ($first !== '') {
+			$range = $first === $last ? ' (item: ' . $first . ')' : ' (first: ' . $first . ', last: ' . $last . ')';
+		}
+		plugin_mastodon_log('Skipped ' . $count . ' ' . $label . ($reason !== '' ? ' ' . $reason : '') . $range);
+	}
 }
 
 /**
@@ -2699,12 +2875,6 @@ function plugin_mastodon_state_read() {
 	$prestat = plugin_mastodon_file_prestat(PLUGIN_MASTODON_STATE_FILE);
 	if (empty($prestat ['exists'])) {
 		plugin_mastodon_runtime_cache_clear('state');
-		$fallbackState = plugin_mastodon_state_fallback_read();
-		if ($fallbackState !== array()) {
-			plugin_mastodon_runtime_cache_set('state', '__signature__', 'apcu-fallback');
-			plugin_mastodon_runtime_cache_set('state', 'apcu-fallback', $fallbackState);
-			return $fallbackState;
-		}
 		return $defaults;
 	}
 
@@ -2721,25 +2891,168 @@ function plugin_mastodon_state_read() {
 
 	$json = plugin_mastodon_io_read_file_uncached(PLUGIN_MASTODON_STATE_FILE, !empty($prestat ['exists']));
 	if (!is_string($json) || trim($json) === '') {
-		$fallbackState = plugin_mastodon_state_fallback_read();
-		if ($fallbackState !== array()) {
-			return $fallbackState;
-		}
 		return $defaults;
 	}
 	$data = json_decode($json, true);
 	if (!is_array($data)) {
-		$fallbackState = plugin_mastodon_state_fallback_read();
-		if ($fallbackState !== array()) {
-			return $fallbackState;
-		}
 		return $defaults;
 	}
 	$state = plugin_mastodon_state_normalize($data);
 	plugin_mastodon_runtime_cache_set('state', '__signature__', $signature);
 	plugin_mastodon_runtime_cache_set('state', $signature, $state);
-	plugin_mastodon_state_fallback_store($state);
 	return $state;
+}
+
+/**
+ * Return an empty scheduler state derived from the full default state.
+ * @return array<string, mixed>
+ */
+function plugin_mastodon_scheduler_state_default() {
+	$defaults = plugin_mastodon_default_state();
+	return array(
+		'version' => (int) $defaults ['version'],
+		'last_run' => '',
+		'last_deletion_run' => '',
+		'deletions_pending' => 0,
+		'deletions_pending_scope' => $defaults ['deletions_pending_scope'],
+		'deletions_not_before' => '',
+		'last_error' => '',
+		'content_stats' => $defaults ['content_stats'],
+		'deletion_stats' => $defaults ['deletion_stats'],
+		'source_state_signature' => '',
+		'updated_at' => ''
+	);
+}
+
+/**
+ * Return the current stat-based signature of the full state file.
+ * @return string
+ */
+function plugin_mastodon_scheduler_source_signature() {
+	return plugin_mastodon_file_prestat_signature(plugin_mastodon_file_prestat(PLUGIN_MASTODON_STATE_FILE));
+}
+
+/**
+ * Normalize a scheduler summary without touching full mapping arrays.
+ * @param array<string, mixed> $state
+ * @return array<string, mixed>
+ */
+function plugin_mastodon_scheduler_state_normalize($state) {
+	$defaults = plugin_mastodon_scheduler_state_default();
+	$input = is_array($state) ? $state : array();
+	$normalized = array_merge($defaults, $input);
+	$normalized ['version'] = (int) (isset($normalized ['version']) ? $normalized ['version'] : $defaults ['version']);
+	$normalized ['last_run'] = isset($normalized ['last_run']) ? (string) $normalized ['last_run'] : '';
+	$normalized ['last_deletion_run'] = isset($normalized ['last_deletion_run']) ? (string) $normalized ['last_deletion_run'] : '';
+	$normalized ['deletions_pending'] = !empty($normalized ['deletions_pending']) ? 1 : 0;
+	$normalized ['deletions_pending_scope'] = plugin_mastodon_normalize_deletions_pending_scope(isset($normalized ['deletions_pending_scope']) ? $normalized ['deletions_pending_scope'] : $defaults ['deletions_pending_scope']);
+	$normalized ['deletions_not_before'] = plugin_mastodon_parse_iso_datetime(isset($normalized ['deletions_not_before']) ? (string) $normalized ['deletions_not_before'] : '');
+	$normalized ['last_error'] = isset($normalized ['last_error']) ? (string) $normalized ['last_error'] : '';
+	$normalized ['source_state_signature'] = isset($normalized ['source_state_signature']) ? (string) $normalized ['source_state_signature'] : '';
+	$normalized ['updated_at'] = isset($normalized ['updated_at']) ? (string) $normalized ['updated_at'] : '';
+
+	$contentStats = isset($input ['content_stats']) && is_array($input ['content_stats']) ? $input ['content_stats'] : array();
+	$normalized ['content_stats'] = $defaults ['content_stats'];
+	foreach (array_keys($defaults ['content_stats']) as $key) {
+		if (isset($contentStats [$key])) {
+			$normalized ['content_stats'] [$key] = (int) $contentStats [$key];
+		}
+	}
+
+	$deletionStats = isset($input ['deletion_stats']) && is_array($input ['deletion_stats']) ? $input ['deletion_stats'] : array();
+	$normalized ['deletion_stats'] = $defaults ['deletion_stats'];
+	foreach (array_keys($defaults ['deletion_stats']) as $key) {
+		if (isset($deletionStats [$key])) {
+			$normalized ['deletion_stats'] [$key] = (int) $deletionStats [$key];
+		}
+	}
+
+	return $normalized;
+}
+
+/**
+ * Build the lightweight scheduler summary from a full runtime state.
+ * @param array<string, mixed> $state
+ * @return array<string, mixed>
+ */
+function plugin_mastodon_scheduler_state_from_state($state) {
+	$state = plugin_mastodon_state_normalize(is_array($state) ? $state : array());
+	return plugin_mastodon_scheduler_state_normalize(array(
+		'version' => $state ['version'],
+		'last_run' => $state ['last_run'],
+		'last_deletion_run' => $state ['last_deletion_run'],
+		'deletions_pending' => $state ['deletions_pending'],
+		'deletions_pending_scope' => $state ['deletions_pending_scope'],
+		'deletions_not_before' => $state ['deletions_not_before'],
+		'last_error' => $state ['last_error'],
+		'content_stats' => $state ['content_stats'],
+		'deletion_stats' => $state ['deletion_stats']
+	));
+}
+
+/**
+ * Persist the lightweight scheduler state. Failure only disables the request-time optimization.
+ * @param array<string, mixed> $state
+ * @return bool
+ */
+function plugin_mastodon_scheduler_state_write($state) {
+	plugin_mastodon_ensure_state_dir();
+	$schedulerState = plugin_mastodon_scheduler_state_normalize(is_array($state) ? $state : array());
+	$schedulerState ['source_state_signature'] = plugin_mastodon_scheduler_source_signature();
+	$schedulerState ['updated_at'] = date('Y-m-d H:i:s');
+	$json = json_encode($schedulerState, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+	if (!is_string($json)) {
+		return false;
+	}
+	$written = plugin_mastodon_io_write_file(PLUGIN_MASTODON_SCHEDULER_STATE_FILE, $json . PHP_EOL);
+	plugin_mastodon_runtime_cache_clear('scheduler_state');
+	if ($written) {
+		$prestat = plugin_mastodon_file_prestat(PLUGIN_MASTODON_SCHEDULER_STATE_FILE);
+		$signature = plugin_mastodon_file_prestat_signature($prestat) . '|' . $schedulerState ['source_state_signature'];
+		plugin_mastodon_runtime_cache_set('scheduler_state', '__signature__', $signature);
+		plugin_mastodon_runtime_cache_set('scheduler_state', $signature, $schedulerState);
+	}
+	return $written;
+}
+
+/**
+ * Load the lightweight scheduler summary and rebuild it conservatively when stale.
+ * @return array<string, mixed>
+ */
+function plugin_mastodon_scheduler_state_read() {
+	plugin_mastodon_ensure_state_dir();
+	$sourceSignature = plugin_mastodon_scheduler_source_signature();
+	$prestat = plugin_mastodon_file_prestat(PLUGIN_MASTODON_SCHEDULER_STATE_FILE);
+	if (!empty($prestat ['exists'])) {
+		$signature = plugin_mastodon_file_prestat_signature($prestat) . '|' . $sourceSignature;
+		$cached = plugin_mastodon_runtime_cache_get('scheduler_state', $signature, $hit);
+		if ($hit && is_array($cached)) {
+			return plugin_mastodon_scheduler_state_normalize($cached);
+		}
+
+		$legacySignature = plugin_mastodon_runtime_cache_get('scheduler_state', '__signature__', $legacyHit);
+		if ($legacyHit && $legacySignature !== $signature) {
+			plugin_mastodon_runtime_cache_clear('scheduler_state');
+		}
+
+		$json = plugin_mastodon_io_read_file(PLUGIN_MASTODON_SCHEDULER_STATE_FILE, $prestat);
+		if (is_string($json) && trim($json) !== '') {
+			$data = json_decode($json, true);
+			if (is_array($data)) {
+				$schedulerState = plugin_mastodon_scheduler_state_normalize($data);
+				if ($schedulerState ['source_state_signature'] === $sourceSignature) {
+					plugin_mastodon_runtime_cache_set('scheduler_state', '__signature__', $signature);
+					plugin_mastodon_runtime_cache_set('scheduler_state', $signature, $schedulerState);
+					return $schedulerState;
+				}
+			}
+		}
+	}
+
+	$state = plugin_mastodon_state_read();
+	$schedulerState = plugin_mastodon_scheduler_state_from_state($state);
+	plugin_mastodon_scheduler_state_write($schedulerState);
+	return $schedulerState;
 }
 
 /**
@@ -2757,12 +3070,12 @@ function plugin_mastodon_state_write($state) {
 	$payload = $json . PHP_EOL;
 	$written = plugin_mastodon_io_write_file(PLUGIN_MASTODON_STATE_FILE, $payload);
 	plugin_mastodon_runtime_cache_clear('state');
-	plugin_mastodon_state_fallback_store($state);
 	if ($written) {
 		$prestat = plugin_mastodon_file_prestat(PLUGIN_MASTODON_STATE_FILE);
 		$signature = plugin_mastodon_file_prestat_signature($prestat);
 		plugin_mastodon_runtime_cache_set('state', '__signature__', $signature);
 		plugin_mastodon_runtime_cache_set('state', $signature, $state);
+		plugin_mastodon_scheduler_state_write(plugin_mastodon_scheduler_state_from_state($state));
 	}
 	return $written;
 }
@@ -3057,6 +3370,213 @@ function plugin_mastodon_state_remove_dirty_comment(&$state, $entryId, $commentI
 function plugin_mastodon_state_has_dirty_comment($state, $entryId, $commentId) {
 	$key = plugin_mastodon_state_comment_key($entryId, $commentId);
 	return isset($state ['dirty_comments']) && is_array($state ['dirty_comments']) && isset($state ['dirty_comments'] [$key]);
+}
+
+/**
+ * Increase the local-write guard depth while the plugin mirrors remote Mastodon data into FlatPress.
+ * @return void
+ */
+function plugin_mastodon_local_write_guard_enter() {
+	if (!isset($GLOBALS ['plugin_mastodon_local_write_guard_depth']) || !is_numeric($GLOBALS ['plugin_mastodon_local_write_guard_depth'])) {
+		$GLOBALS ['plugin_mastodon_local_write_guard_depth'] = 0;
+	}
+	$GLOBALS ['plugin_mastodon_local_write_guard_depth'] = (int) $GLOBALS ['plugin_mastodon_local_write_guard_depth'] + 1;
+}
+
+/**
+ * Decrease the local-write guard depth after a plugin-owned FlatPress write.
+ * @return void
+ */
+function plugin_mastodon_local_write_guard_leave() {
+	if (!isset($GLOBALS ['plugin_mastodon_local_write_guard_depth']) || !is_numeric($GLOBALS ['plugin_mastodon_local_write_guard_depth'])) {
+		$GLOBALS ['plugin_mastodon_local_write_guard_depth'] = 0;
+		return;
+	}
+	$GLOBALS ['plugin_mastodon_local_write_guard_depth'] = max(0, (int) $GLOBALS ['plugin_mastodon_local_write_guard_depth'] - 1);
+}
+
+/**
+ * Return whether FlatPress write hooks are currently triggered by Mastodon remote mirroring.
+ * @return bool
+ */
+function plugin_mastodon_local_write_guard_active() {
+	return isset($GLOBALS ['plugin_mastodon_local_write_guard_depth']) && (int) $GLOBALS ['plugin_mastodon_local_write_guard_depth'] > 0;
+}
+
+/**
+ * Check whether dirty tracking should persist state for a local FlatPress write hook.
+ * @return array<string, string>
+ */
+function plugin_mastodon_dirty_tracking_options() {
+	if (plugin_mastodon_local_write_guard_active()) {
+		return array();
+	}
+	$options = plugin_mastodon_get_options();
+	if ($options ['instance_url'] === '' || $options ['access_token'] === '') {
+		return array();
+	}
+	return $options;
+}
+
+/**
+ * Mark a local FlatPress entry write as dirty for a later Mastodon sync.
+ * @param string $entryId
+ * @param array<string, mixed> $entry
+ * @param array<string, mixed> $oldEntry
+ * @param bool $isUpdate
+ * @return void
+ */
+function plugin_mastodon_on_entry_saved($entryId, $entry, $oldEntry = array(), $isUpdate = false) {
+	$options = plugin_mastodon_dirty_tracking_options();
+	if ($options === array()) {
+		return;
+	}
+	$entryId = trim((string) $entryId);
+	$entry = is_array($entry) ? $entry : array();
+	if ($entryId === '' || $entry === array()) {
+		return;
+	}
+	if (isset($entry ['categories']) && is_array($entry ['categories']) && in_array('draft', $entry ['categories'], true)) {
+		return;
+	}
+	$state = plugin_mastodon_state_read();
+	$meta = plugin_mastodon_state_get_entry_meta($state, $entryId);
+	if (!empty($meta ['source']) && strtolower((string) $meta ['source']) === 'remote') {
+		return;
+	}
+	if (!plugin_mastodon_local_item_matches_sync_start($options, $entry, $entryId)) {
+		plugin_mastodon_state_remove_dirty_entry($state, $entryId);
+		plugin_mastodon_state_write($state);
+		return;
+	}
+	$entryHash = plugin_mastodon_entry_hash($entry);
+	$hasRemoteMapping = !empty($meta ['remote_id']);
+	$hashChanged = empty($meta ['hash']) || (string) $meta ['hash'] !== $entryHash;
+	$insideActiveWindow = plugin_mastodon_local_item_matches_content_window($options, $entry, $entryId, false);
+	if ($hasRemoteMapping && $hashChanged) {
+		plugin_mastodon_state_set_dirty_entry($state, $entryId, $entryHash);
+		plugin_mastodon_state_write($state);
+		return;
+	}
+	if (!$hasRemoteMapping && !$insideActiveWindow) {
+		plugin_mastodon_state_remove_dirty_entry($state, $entryId);
+		plugin_mastodon_state_write($state);
+		return;
+	}
+	if ($insideActiveWindow) {
+		plugin_mastodon_state_remove_dirty_entry($state, $entryId);
+		plugin_mastodon_state_write($state);
+	}
+}
+
+/**
+ * Mark a local FlatPress entry deletion for the Mastodon deletion sync.
+ * @param string $entryId
+ * @param array<string, mixed> $oldEntry
+ * @return void
+ */
+function plugin_mastodon_on_entry_deleted($entryId, $oldEntry = array()) {
+	$options = plugin_mastodon_dirty_tracking_options();
+	if ($options === array()) {
+		return;
+	}
+	$entryId = trim((string) $entryId);
+	if ($entryId === '') {
+		return;
+	}
+	$state = plugin_mastodon_state_read();
+	$meta = plugin_mastodon_state_get_entry_meta($state, $entryId);
+	plugin_mastodon_state_remove_dirty_entry($state, $entryId);
+	if (!empty($meta ['remote_id'])) {
+		plugin_mastodon_state_set_deletions_pending($state, true, 'full', '');
+		plugin_mastodon_state_write($state);
+	}
+}
+
+/**
+ * Mark a local FlatPress comment write as dirty for a later Mastodon sync.
+ * @param string $entryId
+ * @param string $commentId
+ * @param array<string, mixed> $comment
+ * @param array<string, mixed> $oldComment
+ * @param bool $isUpdate
+ * @return void
+ */
+function plugin_mastodon_on_comment_saved($entryId, $commentId, $comment = array(), $oldComment = array(), $isUpdate = false) {
+	$options = plugin_mastodon_dirty_tracking_options();
+	if ($options === array()) {
+		return;
+	}
+	$entryId = trim((string) $entryId);
+	$commentId = trim((string) $commentId);
+	$comment = is_array($comment) ? $comment : array();
+	if ($entryId === '' || $commentId === '' || $comment === array()) {
+		return;
+	}
+	if (!plugin_mastodon_local_item_matches_sync_start($options, $comment, $commentId)) {
+		$state = plugin_mastodon_state_read();
+		plugin_mastodon_state_remove_dirty_comment($state, $entryId, $commentId);
+		plugin_mastodon_state_write($state);
+		return;
+	}
+	$entry = entry_parse($entryId);
+	if (!$entry || !is_array($entry)) {
+		return;
+	}
+	$state = plugin_mastodon_state_read();
+	$commentMeta = plugin_mastodon_state_get_comment_meta($state, $entryId, $commentId);
+	if (!empty($commentMeta ['source']) && strtolower((string) $commentMeta ['source']) === 'remote') {
+		return;
+	}
+	$entryMeta = plugin_mastodon_state_get_entry_meta($state, $entryId);
+	$commentHash = plugin_mastodon_comment_hash($comment);
+	$hasCommentRemoteMapping = !empty($commentMeta ['remote_id']);
+	$commentHashChanged = empty($commentMeta ['hash']) || (string) $commentMeta ['hash'] !== $commentHash;
+	$insideActiveWindow = plugin_mastodon_local_item_matches_content_window($options, $comment, $commentId, false);
+	if ($hasCommentRemoteMapping && $commentHashChanged) {
+		plugin_mastodon_state_set_dirty_comment($state, $entryId, $commentId, $commentHash);
+		plugin_mastodon_state_write($state);
+		return;
+	}
+	if (!$hasCommentRemoteMapping && $insideActiveWindow) {
+		if (empty($entryMeta ['remote_id']) && empty($entryMeta ['source']) && plugin_mastodon_local_item_matches_sync_start($options, $entry, $entryId)) {
+			plugin_mastodon_state_set_dirty_entry($state, $entryId, plugin_mastodon_entry_hash($entry));
+		}
+		plugin_mastodon_state_remove_dirty_comment($state, $entryId, $commentId);
+		plugin_mastodon_state_write($state);
+		return;
+	}
+	if (!$hasCommentRemoteMapping) {
+		plugin_mastodon_state_remove_dirty_comment($state, $entryId, $commentId);
+		plugin_mastodon_state_write($state);
+		return;
+	}
+}
+
+/**
+ * Mark a local FlatPress comment deletion for the Mastodon deletion sync.
+ * @param string $entryId
+ * @param string $commentId
+ * @param array<string, mixed> $oldComment
+ * @return void
+ */
+function plugin_mastodon_on_comment_deleted($entryId, $commentId, $oldComment = array()) {
+	$options = plugin_mastodon_dirty_tracking_options();
+	if ($options === array()) {
+		return;
+	}
+	$entryId = trim((string) $entryId);
+	$commentId = trim((string) $commentId);
+	if ($entryId === '' || $commentId === '') {
+		return;
+	}
+	$state = plugin_mastodon_state_read();
+	$meta = plugin_mastodon_state_get_comment_meta($state, $entryId, $commentId);
+	plugin_mastodon_state_remove_dirty_comment($state, $entryId, $commentId);
+	if (!empty($meta ['remote_id'])) {
+		plugin_mastodon_state_set_deletions_pending($state, true, 'full', '');
+		plugin_mastodon_state_write($state);
+	}
 }
 
 /**
@@ -3541,7 +4061,12 @@ function plugin_mastodon_process_pending_comment_remote_rechecks($options, &$sta
 		if (plugin_mastodon_status_missing_response($remote)) {
 			$queuedChildren = plugin_mastodon_queue_comment_descendant_remote_rechecks($state, $childIndex, $remoteId);
 			if (comment_exists($entryId, $commentId)) {
-				comment_delete($entryId, $commentId);
+				plugin_mastodon_local_write_guard_enter();
+				try {
+					comment_delete($entryId, $commentId);
+				} finally {
+					plugin_mastodon_local_write_guard_leave();
+				}
 			}
 			plugin_mastodon_state_set_comment_tombstone($state, $remoteId, $entryId, $commentId, 'pending_remote_missing_local_deleted');
 			plugin_mastodon_state_remove_comment_mapping($state, $entryId, $commentId);
@@ -5171,11 +5696,6 @@ function plugin_mastodon_safe_filename($filename) {
 }
 
 /**
- * Resolve a FlatPress media path to an absolute file path.
- * @param string $relativePath
- * @return string
- */
-/**
  * Normalize a FlatPress media path relative to fp-content.
  * @param string $relativePath
  * @return string
@@ -5198,6 +5718,11 @@ function plugin_mastodon_normalize_media_relative_path($relativePath) {
 	return $relativePath;
 }
 
+/**
+ * Resolve a FlatPress media path to an absolute file path.
+ * @param string $relativePath
+ * @return string
+ */
 function plugin_mastodon_media_relative_to_absolute($relativePath) {
 	$relativePath = plugin_mastodon_normalize_media_relative_path($relativePath);
 	if ($relativePath === '') {
@@ -7214,6 +7739,9 @@ function plugin_mastodon_local_item_timestamp($item, $fallbackId = '') {
 	$fallbackId = trim((string) $fallbackId);
 	if ($fallbackId !== '' && function_exists('date_from_id')) {
 		$fallbackTimestamp = date_from_id($fallbackId);
+		if (is_array($fallbackTimestamp) && isset($fallbackTimestamp ['time'])) {
+			$fallbackTimestamp = $fallbackTimestamp ['time'];
+		}
 		if (is_numeric($fallbackTimestamp)) {
 			return (int) $fallbackTimestamp;
 		}
@@ -7247,6 +7775,116 @@ function plugin_mastodon_compare_local_entries_for_export($left, $right) {
 }
 
 /**
+ * Increment a simulation-only local-entry parse counter when enabled.
+ * @param string $entryId
+ * @return void
+ */
+function plugin_mastodon_test_note_local_entry_parse($entryId) {
+	if (!isset($GLOBALS ['plugin_mastodon_test_local_entry_parse_count'])) {
+		return;
+	}
+	$GLOBALS ['plugin_mastodon_test_local_entry_parse_count'] = (int) $GLOBALS ['plugin_mastodon_test_local_entry_parse_count'] + 1;
+}
+
+/**
+ * Return entry identifiers that are explicitly queued by dirty entry/comment hooks.
+ * @param array<string, mixed> $state
+ * @return array<string, bool>
+ */
+function plugin_mastodon_dirty_entry_id_lookup($state) {
+	$lookup = array();
+	if (isset($state ['dirty_entries']) && is_array($state ['dirty_entries'])) {
+		foreach (array_keys($state ['dirty_entries']) as $entryId) {
+			$entryId = trim((string) $entryId);
+			if ($entryId !== '') {
+				$lookup [$entryId] = true;
+			}
+		}
+	}
+	if (isset($state ['dirty_comments']) && is_array($state ['dirty_comments'])) {
+		foreach ($state ['dirty_comments'] as $dirtyComment) {
+			if (is_array($dirtyComment) && !empty($dirtyComment ['entry_id'])) {
+				$entryId = trim((string) $dirtyComment ['entry_id']);
+				if ($entryId !== '') {
+					$lookup [$entryId] = true;
+				}
+			}
+		}
+	}
+	return $lookup;
+}
+
+/**
+ * Determine whether a local entry file should be parsed during a scheduled local-to-remote pass.
+ * @param array<string, string> $options
+ * @param array<string, bool> $dirtyEntryLookup
+ * @param string $entryId
+ * @param bool $force
+ * @return bool
+ */
+function plugin_mastodon_should_parse_local_entry_for_sync($options, $dirtyEntryLookup, $entryId, $force) {
+	$entryId = trim((string) $entryId);
+	if ($entryId === '') {
+		return false;
+	}
+	if ((bool) $force) {
+		return true;
+	}
+	if (isset($dirtyEntryLookup [$entryId])) {
+		return true;
+	}
+	return plugin_mastodon_date_matches_content_window($options, plugin_mastodon_local_item_date_key(array(), $entryId), false);
+}
+
+/**
+ * List local FlatPress entries for a local-to-remote synchronization pass.
+ *
+ * Manual full synchronizations keep the legacy repair behavior and scan every entry. Scheduled
+ * synchronizations parse only active-window entries plus entries queued by post-success dirty hooks.
+ *
+ * @param array<string, string> $options
+ * @param array<string, mixed> $state
+ * @param bool $force
+ * @return array<string, array<string, mixed>>
+ */
+function plugin_mastodon_list_local_entries_for_sync($options, $state, $force) {
+	$dirtyEntryLookup = plugin_mastodon_dirty_entry_id_lookup($state);
+	$files = array();
+	plugin_mastodon_collect_entry_files(CONTENT_DIR, $files);
+	sort($files, SORT_STRING);
+	$entryRecords = array();
+	foreach ($files as $file) {
+		$id = basename($file, EXT);
+		if (!plugin_mastodon_should_parse_local_entry_for_sync($options, $dirtyEntryLookup, $id, $force)) {
+			continue;
+		}
+		plugin_mastodon_test_note_local_entry_parse($id);
+		$entry = entry_parse($id);
+		if (!$entry || !is_array($entry)) {
+			continue;
+		}
+		if (isset($entry ['categories']) && is_array($entry ['categories']) && in_array('draft', $entry ['categories'], true)) {
+			continue;
+		}
+		$entryRecords [] = array(
+			'id' => $id,
+			'entry' => $entry,
+			'timestamp' => plugin_mastodon_local_item_timestamp($entry, $id)
+		);
+	}
+	usort($entryRecords, 'plugin_mastodon_compare_local_entries_for_export');
+	$entries = array();
+	foreach ($entryRecords as $entryRecord) {
+		$entryId = isset($entryRecord ['id']) ? (string) $entryRecord ['id'] : '';
+		if ($entryId === '') {
+			continue;
+		}
+		$entries [$entryId] = isset($entryRecord ['entry']) && is_array($entryRecord ['entry']) ? $entryRecord ['entry'] : array();
+	}
+	return $entries;
+}
+
+/**
  * List local FlatPress entries ordered for export.
  * @return array<string, array<string, mixed>>
  */
@@ -7257,6 +7895,7 @@ function plugin_mastodon_list_local_entries() {
 	$entryRecords = array();
 	foreach ($files as $file) {
 		$id = basename($file, EXT);
+		plugin_mastodon_test_note_local_entry_parse($id);
 		$entry = entry_parse($id);
 		if (!$entry || !is_array($entry)) {
 			continue;
@@ -8098,7 +8737,12 @@ function plugin_mastodon_import_remote_entry(&$options, &$state, $remoteStatus) 
 		if (is_array($existing) && !empty($existing ['date'])) {
 			$entry ['date'] = $existing ['date'];
 		}
-		$result = entry_save($entry, $localId);
+		plugin_mastodon_local_write_guard_enter();
+		try {
+			$result = entry_save($entry, $localId);
+		} finally {
+			plugin_mastodon_local_write_guard_leave();
+		}
 		if (is_string($result) && $result !== '') {
 			plugin_mastodon_state_set_entry_mapping($state, $result, $remoteId, 'remote', $hash, $url, $remoteUpdatedAt, plugin_mastodon_local_item_date_key($entry, $result), plugin_mastodon_remote_status_date_key($remoteStatus));
 			$state ['content_stats'] ['updated_entries']++;
@@ -8107,7 +8751,12 @@ function plugin_mastodon_import_remote_entry(&$options, &$state, $remoteStatus) 
 		return false;
 	}
 
-	$result = entry_save($entry, null);
+	plugin_mastodon_local_write_guard_enter();
+	try {
+		$result = entry_save($entry, null);
+	} finally {
+		plugin_mastodon_local_write_guard_leave();
+	}
 	if (is_string($result) && $result !== '') {
 		plugin_mastodon_state_set_entry_mapping($state, $result, $remoteId, 'remote', $hash, $url, $remoteUpdatedAt, plugin_mastodon_local_item_date_key($entry, $result), plugin_mastodon_remote_status_date_key($remoteStatus));
 		$state ['content_stats'] ['imported_entries']++;
@@ -8338,7 +8987,12 @@ function plugin_mastodon_import_remote_comment(&$options, &$state, $entryId, $re
 		}
 	}
 
-	$result = comment_save($entryId, $comment);
+	plugin_mastodon_local_write_guard_enter();
+	try {
+		$result = comment_save($entryId, $comment);
+	} finally {
+		plugin_mastodon_local_write_guard_leave();
+	}
 	if (is_string($result) && $result !== '') {
 		plugin_mastodon_state_set_comment_mapping($state, $entryId, $result, $remoteId, 'remote', $hash, isset($remoteComment ['url']) ? (string) $remoteComment ['url'] : '', $remoteUpdatedAt, $parentCommentId, $inReplyToRemoteId, plugin_mastodon_local_item_date_key($comment, $result), plugin_mastodon_remote_status_date_key($remoteComment));
 		$state ['content_stats'] ['imported_comments']++;
@@ -8398,7 +9052,7 @@ function plugin_mastodon_import_remote_context_descendants(&$options, &$state, $
 			if (!plugin_mastodon_remote_status_matches_sync_start($options, $descendant)) {
 				$blockedRemoteIds [$descendantId] = true;
 				$progress = true;
-				plugin_mastodon_log('Skipping remote reply ' . $descendantId . ' because it is older than the configured sync start date');
+				plugin_mastodon_log_skip('remote_reply_before_sync_start', 'remote reply', 'remote replies', $descendantId, 'because they are older than the configured sync start date');
 				continue;
 			}
 			$parentRemoteId = isset($descendant ['in_reply_to_id']) ? (string) $descendant ['in_reply_to_id'] : '';
@@ -8576,7 +9230,7 @@ function plugin_mastodon_sync_remote_to_local(&$options, &$state, $force = true)
 			continue;
 		}
 		if (!plugin_mastodon_remote_status_matches_content_window($options, $status, $force)) {
-			plugin_mastodon_log('Skipping remote status ' . $statusId . ' because it is outside the active synchronization date window');
+			plugin_mastodon_log_skip('remote_status_outside_content_window', 'remote status', 'remote statuses', $statusId, 'because they are outside the active synchronization date window');
 			continue;
 		}
 		$entryId = plugin_mastodon_import_remote_entry($options, $state, $status);
@@ -8618,7 +9272,7 @@ function plugin_mastodon_sync_local_to_remote(&$options, &$state, $force = true)
 	$force = (bool) $force;
 	$charLimit = plugin_mastodon_instance_character_limit($options);
 	$mediaLimit = plugin_mastodon_instance_media_limit($options);
-	$entries = plugin_mastodon_list_local_entries();
+	$entries = plugin_mastodon_list_local_entries_for_sync($options, $state, $force);
 	$hadFailure = false;
 	foreach ($entries as $entryId => $entry) {
 		plugin_mastodon_extend_time_limit(120);
@@ -8717,7 +9371,7 @@ function plugin_mastodon_sync_local_to_remote(&$options, &$state, $force = true)
 				}
 			}
 		} else {
-			plugin_mastodon_log('Skipping local entry ' . $entryId . ' because it is outside the active synchronization date window');
+			plugin_mastodon_log_skip('local_entry_outside_content_window', 'local entry', 'local entries', $entryId, 'because they are outside the active synchronization date window');
 		}
 
 		$entryMeta = plugin_mastodon_state_get_entry_meta($state, $entryId);
@@ -8741,7 +9395,7 @@ function plugin_mastodon_sync_local_to_remote(&$options, &$state, $force = true)
 				continue;
 			}
 			if (!plugin_mastodon_local_item_matches_sync_start($options, $comment, $commentId)) {
-				plugin_mastodon_log('Skipping local comment ' . $entryId . '/' . $commentId . ' because it is older than the configured sync start date');
+				plugin_mastodon_log_skip('local_comment_before_sync_start', 'local comment', 'local comments', $entryId . '/' . $commentId, 'because they are older than the configured sync start date');
 				continue;
 			}
 			$commentHash = plugin_mastodon_comment_hash($comment);
@@ -8753,7 +9407,7 @@ function plugin_mastodon_sync_local_to_remote(&$options, &$state, $force = true)
 					plugin_mastodon_log('Queued older changed local comment ' . $entryId . '/' . $commentId . ' for synchronization outside the scheduled window');
 				}
 				if (!$commentQueuedDirty) {
-					plugin_mastodon_log('Skipping local comment ' . $entryId . '/' . $commentId . ' because it is outside the active synchronization date window');
+					plugin_mastodon_log_skip('local_comment_outside_content_window', 'local comment', 'local comments', $entryId . '/' . $commentId, 'because they are outside the active synchronization date window');
 					continue;
 				}
 			}
@@ -8924,7 +9578,7 @@ function plugin_mastodon_run_deletion_sync($force) {
 				continue;
 			}
 			if (!plugin_mastodon_mapping_matches_sync_start($options, $meta, $localEntryId)) {
-				plugin_mastodon_log('Skipping deletion sync for entry ' . $localEntryId . ' because it is older than the configured sync start date');
+				plugin_mastodon_log_skip('deletion_entry_before_sync_start', 'deletion entry mapping', 'deletion entry mappings', $localEntryId, 'because they are older than the configured sync start date');
 				continue;
 			}
 			$remoteId = (string) $meta ['remote_id'];
@@ -8948,14 +9602,19 @@ function plugin_mastodon_run_deletion_sync($force) {
 			}
 
 			if (!plugin_mastodon_mapping_matches_deletion_lookup_window($options, $meta, $localEntryId, $force)) {
-				plugin_mastodon_log('Skipping remote deletion lookup for entry ' . $localEntryId . ' because it is outside the scheduled deletion lookup window');
+				plugin_mastodon_log_skip('deletion_entry_outside_lookup_window', 'remote deletion entry lookup', 'remote deletion entry lookups', $localEntryId, 'because they are outside the scheduled deletion lookup window');
 				continue;
 			}
 
 			$remote = plugin_mastodon_fetch_status($options, $remoteId);
 			if (plugin_mastodon_status_missing_response($remote)) {
 				if (entry_exists($localEntryId)) {
-					entry_delete($localEntryId);
+					plugin_mastodon_local_write_guard_enter();
+					try {
+						entry_delete($localEntryId);
+					} finally {
+						plugin_mastodon_local_write_guard_leave();
+					}
 				}
 				plugin_mastodon_state_remove_entry_mapping($state, $localEntryId);
 				$state ['deletion_stats'] ['deleted_local_entries']++;
@@ -9008,7 +9667,7 @@ function plugin_mastodon_run_deletion_sync($force) {
 					continue;
 				}
 				if (!plugin_mastodon_mapping_matches_sync_start($options, $commentMeta, $commentId)) {
-					plugin_mastodon_log('Skipping deletion sync for comment ' . $entryId . '/' . $commentId . ' because it is older than the configured sync start date');
+					plugin_mastodon_log_skip('deletion_comment_before_sync_start', 'deletion comment mapping', 'deletion comment mappings', $entryId . '/' . $commentId, 'because they are older than the configured sync start date');
 					plugin_mastodon_state_remove_pending_comment_remote_recheck($state, $entryId, $commentId);
 					continue;
 				}
@@ -9042,7 +9701,7 @@ function plugin_mastodon_run_deletion_sync($force) {
 				}
 
 				if (!plugin_mastodon_mapping_matches_deletion_lookup_window($options, $commentMeta, $commentId, $force)) {
-					plugin_mastodon_log('Skipping remote deletion lookup for comment ' . $entryId . '/' . $commentId . ' because it is outside the scheduled deletion lookup window');
+					plugin_mastodon_log_skip('deletion_comment_outside_lookup_window', 'remote deletion comment lookup', 'remote deletion comment lookups', $entryId . '/' . $commentId, 'because they are outside the scheduled deletion lookup window');
 					continue;
 				}
 
@@ -9050,7 +9709,12 @@ function plugin_mastodon_run_deletion_sync($force) {
 				if (plugin_mastodon_status_missing_response($remote)) {
 					$queuedDescendants = plugin_mastodon_queue_comment_descendant_remote_rechecks($state, $childIndex, $remoteId);
 					if (comment_exists($entryId, $commentId)) {
-						comment_delete($entryId, $commentId);
+						plugin_mastodon_local_write_guard_enter();
+						try {
+							comment_delete($entryId, $commentId);
+						} finally {
+							plugin_mastodon_local_write_guard_leave();
+						}
 					}
 					plugin_mastodon_state_set_comment_tombstone($state, $remoteId, $entryId, $commentId, 'remote_missing_local_deleted');
 					plugin_mastodon_state_remove_pending_comment_remote_recheck($state, $entryId, $commentId);
@@ -9080,6 +9744,8 @@ function plugin_mastodon_run_deletion_sync($force) {
 	} else {
 		plugin_mastodon_log('Deletion synchronization is running in targeted descendant recheck mode');
 	}
+
+	plugin_mastodon_log_flush_skip_summaries();
 
 	$pendingCommentRechecksRemaining = plugin_mastodon_process_pending_comment_remote_rechecks($options, $state, $childIndex, $hadFailure);
 	$rateLimitError = plugin_mastodon_rate_limit_state_error();
@@ -9116,7 +9782,6 @@ function plugin_mastodon_run_deletion_sync($force) {
 	$stateWriteOk = plugin_mastodon_state_write($state);
 	if (!$stateWriteOk && !$hadFailure) {
 		$state ['last_error'] = 'state_write_failed_after_deletion_sync';
-		plugin_mastodon_state_fallback_store($state);
 		plugin_mastodon_log('Deletion synchronization completed but state.json could not be persisted');
 	}
 	@flock($lockHandle, LOCK_UN);
@@ -9125,7 +9790,6 @@ function plugin_mastodon_run_deletion_sync($force) {
 
 	return array('ok' => (!$hadFailure && $stateWriteOk), 'state' => $state, 'message' => $state ['last_error'] === '' ? 'ok' : $state ['last_error']);
 }
-
 
 /**
  * Determine whether the scheduled synchronization is currently due.
@@ -9219,6 +9883,8 @@ function plugin_mastodon_run_sync($force, $fullWindow = null) {
 		$okLocal = plugin_mastodon_sync_local_to_remote($options, $state, $fullWindow);
 	}
 
+	plugin_mastodon_log_flush_skip_summaries();
+
 	if ($okRemote && $okLocal) {
 		$completionTimestamp = time();
 		$state ['last_run'] = date('Y-m-d H:i:s', $completionTimestamp);
@@ -9233,7 +9899,6 @@ function plugin_mastodon_run_sync($force, $fullWindow = null) {
 	$stateWriteOk = plugin_mastodon_state_write($state);
 	if (!$stateWriteOk && $okRemote && $okLocal) {
 		$state ['last_error'] = 'state_write_failed_after_sync';
-		plugin_mastodon_state_fallback_store($state);
 		plugin_mastodon_log('Synchronization completed but state.json could not be persisted');
 	}
 	@flock($lockHandle, LOCK_UN);
@@ -9256,10 +9921,10 @@ function plugin_mastodon_maybe_sync() {
 	}
 
 	$options = plugin_mastodon_get_options();
-	$state = plugin_mastodon_state_read();
 	if ($options ['instance_url'] === '' || $options ['access_token'] === '') {
 		return;
 	}
+	$state = plugin_mastodon_scheduler_state_read();
 	if (plugin_mastodon_sync_due($options, $state, time())) {
 		plugin_mastodon_run_sync(false);
 		return;
@@ -9269,6 +9934,10 @@ function plugin_mastodon_maybe_sync() {
 	}
 }
 add_action('init', 'plugin_mastodon_maybe_sync', 20);
+add_action('entry_saved', 'plugin_mastodon_on_entry_saved', 10, 4);
+add_action('entry_deleted', 'plugin_mastodon_on_entry_deleted', 10, 2);
+add_action('comment_saved', 'plugin_mastodon_on_comment_saved', 10, 5);
+add_action('comment_deleted', 'plugin_mastodon_on_comment_deleted', 10, 3);
 
 /**
  * Return a localized yes/no/unknown label for admin diagnostics.
@@ -9411,7 +10080,7 @@ function plugin_mastodon_admin_instance_info_rows($options) {
  */
 function plugin_mastodon_admin_assign(&$smarty) {
 	$options = plugin_mastodon_get_options();
-	$state = plugin_mastodon_state_read();
+	$state = plugin_mastodon_scheduler_state_read();
 	$authorizeUrl = plugin_mastodon_build_authorize_url($options);
 	if ($authorizeUrl === '' && !empty($options ['last_authorize_url'])) {
 		$authorizeUrl = $options ['last_authorize_url'];


### PR DESCRIPTION
The stat file is no longer loaded with every request. Instead, we only load scheduler-state, which requires less response time when there is a lot of content. The stat file is now only loaded when a full admin synchronization and deletion run is initiated, or if scheduler-state is missing or has been corrupted.

The FlatPress core has received new hooks:
```
entry_saved
entry_deleted
comment_saved
comment_deleted
```
The hooks only run after successful saving/deletion. These hooks are necessary to ensure that the CMS response time remains short, even when dealing with large volumes of posts and comments.

The two files, `core.entry.php` and `core.comment.php`, must be included in the plugin package for FP 1.5.1; preferably with the directory structure intact.