### PR TITLE
Fix 4-byte UTF-8 encoding | fixed #925

### DIFF
--- a/fp-includes/core/core.wp-formatting.php
+++ b/fp-includes/core/core.wp-formatting.php
@@ -244,16 +244,20 @@ function utf8_uri_encode($utf8_string) {
 			$unicode .= chr($value);
 		} else {
 			if (count($values) == 0) {
-				$num_octets = ($value < 224) ? 2 : 3;
+				if ($value < 224) {
+					$num_octets = 2;
+				} elseif ($value < 240) {
+					$num_octets = 3;
+				} else {
+					$num_octets = 4;
+				}
 			}
 
 			$values [] = $value;
 
 			if (count($values) == $num_octets) {
-				if ($num_octets == 3) {
-					$unicode .= '%' . dechex($values [0]) . '%' . dechex($values [1]) . '%' . dechex($values [2]);
-				} else {
-					$unicode .= '%' . dechex($values [0]) . '%' . dechex($values [1]);
+				for ($j = 0; $j < $num_octets; $j++) {
+					$unicode .= '%' . dechex($values [$j]);
 				}
 
 				$values = array();


### PR DESCRIPTION
- Fix 4-byte UTF-8 encoding in `utf8_uri_encode()` to prevent emoji-based PrettyURLs from generating invalid slugs.
- fixed #925